### PR TITLE
Git sparse checkout

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,10 +1,12 @@
 Release 0.0.6 (under development)
 ===================================
 
-* Make import command available for svn projects with externals
-* Improve documentation
-* Fix #73: Don't fail if svn or git is not installed
-* Fix #74: Don't default to SVN for non-ssh url
+* Make import command available for svn projects with externals.
+* Improve documentation.
+* Fix #73: Don't fail if svn or git is not installed.
+* Fix #74: Don't default to SVN for non-ssh url.
+* Add ``vcs:`` field to manifest.
+* Make ``src:`` partial checkouts available for git.
 
 Release 0.0.5 (released 2021-01-05)
 ===================================

--- a/dfetch.yaml
+++ b/dfetch.yaml
@@ -20,3 +20,8 @@ manifest:
     revision: '3948'
     vcs: svn                                                      # (optionally) explicitly state vcs type
     repo-path: cpputest/cpputest                                  # Use external git directly
+
+  - name: cpputest-src
+    dst: ../Tests/cpputest-src
+    repo-path: cpputest/cpputest.git                              # Use external git directly
+    src: src

--- a/dfetch.yaml
+++ b/dfetch.yaml
@@ -6,6 +6,9 @@ manifest:
     url-base: https://github.com/                                  # Allow git modules
     default: true                                                 # Set it as default
 
+  - name: github-com-google
+    url-base: https://github.com/google
+
   projects:
 
   - name: cpputest
@@ -25,3 +28,9 @@ manifest:
     dst: ../Tests/cpputest-src
     repo-path: cpputest/cpputest.git                              # Use external git directly
     src: src
+
+  - name: tests/googletest
+    revision: dcc92d0ab6c4ce022162a23566d44f673251eee4
+    remote: github-com-google
+    dst: ../Tests/googletest
+    repo-path: googletest.git

--- a/dfetch/project/git.py
+++ b/dfetch/project/git.py
@@ -121,7 +121,12 @@ class GitRepo(VCS):
 
     def _fetch_impl(self) -> None:
         """Get the revision of the remote and place it at the local path."""
-        rev_or_branch_or_tag = self.revision or self.branch or self.DEFAULT_BRANCH
+        if self.revision:
+            logger.warning(
+                "  Currently revision is ignored for git, use branch (or tags instead)"
+            )
+
+        branch_or_tag = self.branch or self.DEFAULT_BRANCH
 
         pathlib.Path(self.local_path).mkdir(parents=True, exist_ok=True)
 
@@ -135,7 +140,7 @@ class GitRepo(VCS):
                 with open(".git/info/sparse-checkout", "a") as sparse_checkout_file:
                     sparse_checkout_file.write("/" + self._project.source)
 
-            run_on_cmdline(logger, f"git fetch origin {rev_or_branch_or_tag}")
+            run_on_cmdline(logger, f"git fetch --depth 1 origin {branch_or_tag}")
             run_on_cmdline(logger, "git reset --hard FETCH_HEAD")
 
             if self._project.source:

--- a/dfetch/project/git.py
+++ b/dfetch/project/git.py
@@ -121,9 +121,10 @@ class GitRepo(VCS):
 
     def _fetch_impl(self) -> None:
         """Get the revision of the remote and place it at the local path."""
-        if self.revision:
+        if self._project.revision:
             logger.warning(
-                "  Currently revision is ignored for git, use branch (or tags instead)"
+                "  Currently explicit revision in manifest is ignored for git,"
+                " use branch (or tags instead)"
             )
 
         branch_or_tag = self.branch or self.DEFAULT_BRANCH


### PR DESCRIPTION
Makes it possible to only checkout a part of a git repository using the `src` keyword in the manifest.

Solves #21 