### PR TITLE
Assume not svn/git repo when not in path

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Install dfetch
         run: pip install .
 
+      - run: dfetch environment
       - run: dfetch validate
       - run: dfetch check
       - run: dfetch update

--- a/create_venv.py
+++ b/create_venv.py
@@ -4,7 +4,6 @@
 import argparse
 import subprocess  # nosec
 import venv
-
 from typing import Any
 
 

--- a/dfetch/__main__.py
+++ b/dfetch/__main__.py
@@ -9,8 +9,8 @@ import sys
 
 import dfetch.commands.check
 import dfetch.commands.environment
-import dfetch.commands.init
 import dfetch.commands.import_
+import dfetch.commands.init
 import dfetch.commands.update
 import dfetch.commands.validate
 import dfetch.log

--- a/dfetch/__main__.py
+++ b/dfetch/__main__.py
@@ -7,8 +7,6 @@ Created on 28/04/2020
 import argparse
 import sys
 
-from colorama import Fore
-
 import dfetch.commands.check
 import dfetch.commands.environment
 import dfetch.commands.init
@@ -17,7 +15,6 @@ import dfetch.commands.update
 import dfetch.commands.validate
 import dfetch.log
 import dfetch.util.cmdline
-from dfetch import __version__
 
 logger = dfetch.log.setup_root(__name__)
 
@@ -48,7 +45,7 @@ def _help(args: argparse.Namespace) -> None:
 
 def main() -> None:
     """Start dfetch."""
-    logger.info(f"{Fore.BLUE}Dfetch ({__version__})")
+    logger.print_title()
     args = create_parser().parse_args()
 
     if args.verbose:

--- a/dfetch/commands/check.py
+++ b/dfetch/commands/check.py
@@ -5,7 +5,6 @@ revision on that branch. If there are new versions available this will be shown.
 """
 
 import argparse
-import logging
 import os
 
 import dfetch.commands.command
@@ -13,8 +12,9 @@ import dfetch.manifest.manifest
 import dfetch.manifest.validate
 import dfetch.project
 import dfetch.util
+from dfetch.log import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class Check(dfetch.commands.command.Command):

--- a/dfetch/commands/environment.py
+++ b/dfetch/commands/environment.py
@@ -4,9 +4,10 @@ import argparse
 import logging
 
 import dfetch.commands.command
+from dfetch.log import get_logger
 from dfetch.project import SUPPORTED_PROJECT_TYPES
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class Environment(dfetch.commands.command.Command):

--- a/dfetch/commands/environment.py
+++ b/dfetch/commands/environment.py
@@ -1,7 +1,7 @@
 """*Dfetch* can generate output about its working environment."""
 
 import argparse
-import logging
+import platform
 
 import dfetch.commands.command
 from dfetch.log import get_logger
@@ -23,5 +23,6 @@ class Environment(dfetch.commands.command.Command):
 
     def __call__(self, _: argparse.Namespace) -> None:
         """Perform listing the environment."""
+        logger.print_info_line("platform", f"{platform.system()} {platform.release()}")
         for vcs in SUPPORTED_PROJECT_TYPES:
             vcs.list_tool_info()

--- a/dfetch/commands/import_.py
+++ b/dfetch/commands/import_.py
@@ -28,7 +28,6 @@ Migrating from SVN externals
 """
 
 import argparse
-import logging
 import os
 import re
 from itertools import combinations
@@ -36,13 +35,14 @@ from typing import List, Sequence, Set, Tuple
 
 import dfetch.commands.command
 from dfetch import DEFAULT_MANIFEST_NAME
+from dfetch.log import get_logger
 from dfetch.manifest.manifest import Manifest
 from dfetch.manifest.project import ProjectEntry
 from dfetch.manifest.remote import Remote
 from dfetch.project.git import GitRepo
 from dfetch.project.svn import SvnRepo
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class Import(dfetch.commands.command.Command):

--- a/dfetch/commands/import_.py
+++ b/dfetch/commands/import_.py
@@ -84,10 +84,10 @@ class Import(dfetch.commands.command.Command):
 
 def _import_projects() -> Sequence[ProjectEntry]:
     """Find out what type of VCS is used and import projects."""
-    if SvnRepo.check_path():
-        projects = _import_from_svn()
-    elif GitRepo.check_path():
+    if GitRepo.check_path():
         projects = _import_from_git()
+    elif SvnRepo.check_path():
+        projects = _import_from_svn()
     else:
         raise RuntimeError(
             "Only git or SVN projects can be imported.",

--- a/dfetch/commands/init.py
+++ b/dfetch/commands/init.py
@@ -4,15 +4,15 @@ It will be created in the current folder.
 """
 
 import argparse
-import logging
 import os
 import shutil
 
 import dfetch.commands.command
-from dfetch.resources import TEMPLATE_PATH
 from dfetch import DEFAULT_MANIFEST_NAME
+from dfetch.log import get_logger
+from dfetch.resources import TEMPLATE_PATH
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class Init(dfetch.commands.command.Command):

--- a/dfetch/commands/update.py
+++ b/dfetch/commands/update.py
@@ -5,7 +5,6 @@ It tries to determine what kind of vcs it is: git, svn or something else.
 """
 
 import argparse
-import logging
 import os
 
 import dfetch.commands.command
@@ -14,8 +13,9 @@ import dfetch.manifest.project
 import dfetch.manifest.validate
 import dfetch.project.git
 import dfetch.project.svn
+from dfetch.log import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class Update(dfetch.commands.command.Command):

--- a/dfetch/commands/validate.py
+++ b/dfetch/commands/validate.py
@@ -4,16 +4,14 @@ This will parse your :ref:`Manifest` and check if all fields can be parsed.
 """
 
 import argparse
-import logging
 import os
 
-from colorama import Fore
-
 import dfetch.commands.command
+from dfetch.log import get_logger
 from dfetch.manifest.manifest import find_manifest
 from dfetch.manifest.validate import validate
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class Validate(dfetch.commands.command.Command):
@@ -35,4 +33,4 @@ class Validate(dfetch.commands.command.Command):
         manifest_path = find_manifest()
         validate(manifest_path)
         manifest_path = os.path.relpath(manifest_path, os.getcwd())
-        logger.info(f"{manifest_path}: {Fore.GREEN}valid")
+        logger.print_info_line(manifest_path, "valid")

--- a/dfetch/log.py
+++ b/dfetch/log.py
@@ -1,13 +1,29 @@
 """Logging related items."""
 
 import logging
+from typing import cast
 
 import coloredlogs
+from colorama import Fore
+
+from dfetch import __version__
 
 
-def setup_root(name: str) -> logging.Logger:
+class DLogger(logging.Logger):
+    """Logging class extended with specific log items for dfetch."""
+
+    def print_info_line(self, name: str, info: str) -> None:
+        """Print a line of info."""
+        self.info(f"  {Fore.GREEN}{name:20s}:{Fore.BLUE} {info}")
+
+    def print_title(self) -> None:
+        """Print the DFetch tool title and version."""
+        self.info(f"{Fore.BLUE}Dfetch ({__version__})")
+
+
+def setup_root(name: str) -> DLogger:
     """Create the root logger."""
-    logger = logging.getLogger(name)
+    logger = get_logger(name)
 
     msg_format = "%(message)s"
 
@@ -33,6 +49,7 @@ def increase_verbosity() -> None:
     coloredlogs.increase_verbosity()
 
 
-def get_logger(name: str) -> logging.Logger:
+def get_logger(name: str) -> DLogger:
     """Get logger for a module."""
-    return logging.getLogger(name)
+    logging.setLoggerClass(DLogger)
+    return cast(DLogger, logging.getLogger(name))

--- a/dfetch/manifest/manifest.py
+++ b/dfetch/manifest/manifest.py
@@ -18,7 +18,6 @@ download and a section ``projects:`` that contains a list of projects to fetch.
            dst: external/mymodule/
 """
 import io
-import logging
 import os
 from typing import IO, Any, Dict, List, Sequence, Tuple, Union
 
@@ -26,12 +25,13 @@ import yaml
 from typing_extensions import TypedDict
 
 import dfetch.manifest.validate
+from dfetch import DEFAULT_MANIFEST_NAME
+from dfetch.log import get_logger
 from dfetch.manifest.project import ProjectEntry, ProjectEntryDict
 from dfetch.manifest.remote import Remote, RemoteDict
 from dfetch.util.util import find_file
-from dfetch import DEFAULT_MANIFEST_NAME
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class ManifestDict(TypedDict):

--- a/dfetch/project/git.py
+++ b/dfetch/project/git.py
@@ -90,7 +90,7 @@ class GitRepo(VCS):
             with in_directory(path):
                 run_on_cmdline(logger, "git status")
             return True
-        except SubprocessCommandError:
+        except (SubprocessCommandError, RuntimeError):
             return False
 
     @staticmethod

--- a/dfetch/project/svn.py
+++ b/dfetch/project/svn.py
@@ -108,7 +108,7 @@ class SvnRepo(VCS):
             with in_directory(path):
                 run_on_cmdline(logger, "svn info")
             return True
-        except SubprocessCommandError:
+        except (SubprocessCommandError, RuntimeError):
             return False
 
     @staticmethod

--- a/dfetch/project/vcs.py
+++ b/dfetch/project/vcs.py
@@ -3,10 +3,8 @@
 import os
 from abc import ABC, abstractmethod
 
-from colorama import Fore
-
-from dfetch.log import get_logger
 import dfetch.manifest.manifest
+from dfetch.log import get_logger
 from dfetch.project.metadata import Metadata
 from dfetch.util.util import safe_rm
 
@@ -92,11 +90,11 @@ class VCS(ABC):
         return True
 
     def _log_project(self, msg: str) -> None:
-        logger.info(f"  {Fore.GREEN}- {self._project.name:20s}:{Fore.BLUE} {msg}")
+        logger.print_info_line(self._project.name, msg)
 
     @staticmethod
     def _log_tool(name: str, msg: str) -> None:
-        logger.info(f"  {Fore.GREEN}- {name:20s}:{Fore.BLUE} {msg}")
+        logger.print_info_line(name, msg.strip())
 
     @property
     def local_path(self) -> str:

--- a/dfetch/util/cmdline.py
+++ b/dfetch/util/cmdline.py
@@ -3,7 +3,7 @@
 import logging
 import os
 import subprocess  # nosec
-from typing import Any, List, Union  # pylint: disable=unused-import
+from typing import Any, List, Optional, Union  # pylint: disable=unused-import
 
 
 class SubprocessCommandError(Exception):
@@ -13,9 +13,15 @@ class SubprocessCommandError(Exception):
     contains all the results for easier usage later on.
     """
 
-    def __init__(self, cmd: List[str], stdout: str, stderr: str, returncode: int):
+    def __init__(
+        self,
+        cmd: Optional[List[str]] = None,
+        stdout: str = "",
+        stderr: str = "",
+        returncode: int = 0,
+    ):
         """Error."""
-        cmd_str: str = " ".join(cmd)
+        cmd_str: str = " ".join(cmd or [])
         self._message = f"{cmd_str} returned {returncode}:{os.linesep}{stderr}"
         self.cmd = cmd_str
         self.stderr = stdout

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -18,6 +18,7 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import os
+
 from dfetch import __version__
 
 # -- General configuration ------------------------------------------------

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -1,0 +1,47 @@
+"""Test the cmdline."""
+# mypy: ignore-errors
+# flake8: noqa
+
+import os
+import subprocess
+from subprocess import CalledProcessError, CompletedProcess
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+from dfetch.util.cmdline import SubprocessCommandError, run_on_cmdline
+
+LS_CMD = "ls ."
+LS_OK_RESULT = CompletedProcess(
+    returncode=0, stdout="myfile".encode(), stderr="".encode(), args=LS_CMD
+)
+LS_NON_ZERO_RESULT = CalledProcessError(
+    returncode=1, output="myfile".encode(), stderr="".encode(), cmd=LS_CMD
+)
+LS_NOK_RESULT = CalledProcessError(
+    returncode=0, output="myfile".encode(), stderr="".encode(), cmd=LS_CMD
+)
+MISSING_CMD_RESULT = FileNotFoundError()
+
+
+@pytest.mark.parametrize(
+    "name, cmd, cmd_result, expectation",
+    [
+        ("cmd succeeds", LS_CMD, [LS_OK_RESULT], LS_OK_RESULT),
+        ("cmd non-zero return", LS_CMD, [LS_NON_ZERO_RESULT], SubprocessCommandError),
+        ("cmd raises", LS_CMD, [LS_NOK_RESULT], SubprocessCommandError),
+        ("cmd missing", LS_CMD, [MISSING_CMD_RESULT], RuntimeError),
+    ],
+)
+def test_run_on_cmdline(name, cmd, cmd_result, expectation):
+
+    with patch("dfetch.util.cmdline.subprocess.run") as subprocess_mock:
+
+        subprocess_mock.side_effect = cmd_result
+        logger_mock = MagicMock()
+
+        if isinstance(expectation, CompletedProcess):
+            assert expectation == run_on_cmdline(logger_mock, cmd)
+        else:
+            with pytest.raises(expectation):
+                run_on_cmdline(logger_mock, cmd)

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1,0 +1,28 @@
+"""Test the git."""
+# mypy: ignore-errors
+# flake8: noqa
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dfetch.project.git import GitRepo
+from dfetch.util.cmdline import SubprocessCommandError
+
+
+@pytest.mark.parametrize(
+    "name, cmd_result, expectation",
+    [
+        ("git repo", ["Yep!"], True),
+        ("not a git repo", [SubprocessCommandError("", "", "", -1)], False),
+        ("no git", [RuntimeError()], False),
+    ],
+)
+def test_check_path(name, cmd_result, expectation):
+
+    with patch("dfetch.project.git.run_on_cmdline") as run_on_cmdline_mock:
+
+        run_on_cmdline_mock.side_effect = cmd_result
+
+        assert GitRepo.check_path() == expectation

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -107,7 +107,9 @@ def test_svn_import(name, externals):
     with patch("dfetch.commands.import_.SvnRepo.check_path") as check_path:
         with patch("dfetch.commands.import_.SvnRepo.externals") as mocked_externals:
             with patch("dfetch.commands.import_.Manifest") as mocked_manifest:
-                with patch("dfetch.commands.import_.GitRepo.check_path") as check_path_git:
+                with patch(
+                    "dfetch.commands.import_.GitRepo.check_path"
+                ) as check_path_git:
 
                     check_path_git.return_value = False
                     check_path.return_value = True

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -107,22 +107,24 @@ def test_svn_import(name, externals):
     with patch("dfetch.commands.import_.SvnRepo.check_path") as check_path:
         with patch("dfetch.commands.import_.SvnRepo.externals") as mocked_externals:
             with patch("dfetch.commands.import_.Manifest") as mocked_manifest:
+                with patch("dfetch.commands.import_.GitRepo.check_path") as check_path_git:
 
-                check_path.return_value = True
-                mocked_externals.return_value = externals
+                    check_path_git.return_value = False
+                    check_path.return_value = True
+                    mocked_externals.return_value = externals
 
-                if len(externals) == 0:
-                    with pytest.raises(RuntimeError):
+                    if len(externals) == 0:
+                        with pytest.raises(RuntimeError):
+                            import_(argparse.Namespace)
+                    else:
                         import_(argparse.Namespace)
-                else:
-                    import_(argparse.Namespace)
 
-                    mocked_manifest.assert_called()
+                        mocked_manifest.assert_called()
 
-                    args = mocked_manifest.call_args_list[0][0][0]
+                        args = mocked_manifest.call_args_list[0][0][0]
 
-                    for project_entry in args["projects"]:
-                        assert project_entry.name in [ext.name for ext in externals]
+                        for project_entry in args["projects"]:
+                            assert project_entry.name in [ext.name for ext in externals]
 
-                    # Manifest should have been dumped
-                    mocked_manifest.return_value.dump.assert_called()
+                        # Manifest should have been dumped
+                        mocked_manifest.return_value.dump.assert_called()

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -8,8 +8,8 @@ from unittest.mock import mock_open, patch
 import pytest
 
 import dfetch.manifest.manifest
-from dfetch.manifest.manifest import Manifest, find_manifest
 from dfetch import DEFAULT_MANIFEST_NAME
+from dfetch.manifest.manifest import Manifest, find_manifest
 
 BASIC_MANIFEST = u"""
 manifest:

--- a/tests/test_svn.py
+++ b/tests/test_svn.py
@@ -7,7 +7,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from dfetch.project.svn import SvnRepo, External
+from dfetch.project.svn import External, SvnRepo
+from dfetch.util.cmdline import SubprocessCommandError
 
 REPO_ROOT = "repo-root"
 CWD = "C:\\mydir"
@@ -120,3 +121,20 @@ def test_externals(name, externals, expectations):
 
                 for actual, expected in zip(parsed_externals, expectations):
                     assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "name, cmd_result, expectation",
+    [
+        ("svn repo", ["Yep!"], True),
+        ("not a svn repo", [SubprocessCommandError("", "", "", -1)], False),
+        ("no svn", [RuntimeError()], False),
+    ],
+)
+def test_check_path(name, cmd_result, expectation):
+
+    with patch("dfetch.project.svn.run_on_cmdline") as run_on_cmdline_mock:
+
+        run_on_cmdline_mock.side_effect = cmd_result
+
+        assert SvnRepo.check_path() == expectation


### PR DESCRIPTION
Fixes #73 

If checking during import we are working in a git or svn repo, if either git or svn are not installed, don't stop