### PR TITLE
Feature/improve git svn detection

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,8 @@ Release 0.0.6 (under development)
 
 * Make import command available for svn projects with externals
 * Improve documentation
+* Fix #73: Don't fail if svn or git is not installed
+* Fix #74: Don't default to SVN for non-ssh url
 
 Release 0.0.5 (released 2021-01-05)
 ===================================

--- a/check_quality.bat
+++ b/check_quality.bat
@@ -14,10 +14,11 @@ if not exist %VENV_DIR% (
 call .\venv\Scripts\activate.bat
 
 CALL :sub_display isort
-isort dfetch
+isort --recursive dfetch
+isort --recursive tests
 
 CALL :sub_display black
-black dfetch
+black dfetch tests
 
 CALL :sub_display Pylint
 pylint dfetch --output-format=colorized

--- a/dfetch.yaml
+++ b/dfetch.yaml
@@ -18,4 +18,5 @@ manifest:
     remote: github
     branch: trunk
     revision: '3948'
+    vcs: svn                                                      # (optionally) explicitly state vcs type
     repo-path: cpputest/cpputest                                  # Use external git directly

--- a/dfetch/manifest/project.py
+++ b/dfetch/manifest/project.py
@@ -58,6 +58,35 @@ We can also list multiple projects.
            revision: bea84ba8f
            dst: external/myothermodule
 
+VCS type
+########
+*DFetch* does it best to find out what type of version control system (vcs) the remote url is,
+but sometimes both is possible. For example, GitHub provides an svn and git interface at
+the same url
+(`docs <https://docs.github.com/en/github/importing-your-projects-to-github/support-for-subversion-clients>`_).
+
+To provide you an option to explicitly state the vcs, with the ``vcs:`` key. In the below example
+the same project is fetched as SVN and as Git repository. *Dfetch* will default to the latest revision
+from trunk for svn and master from git.
+
+.. code-block:: yaml
+
+    manifest:
+        version: 0.0
+
+        remotes:
+        - name: github
+          url-base: https://github.com/
+
+        projects:
+        - name: cpputest
+          vcs: git
+          repo-path: cpputest/cpputest
+
+        - name: cpputestSVN
+          vcs: svn
+          repo-path: cpputest/cpputest
+
 """
 import copy
 from typing import Dict, Optional, Union
@@ -79,6 +108,7 @@ ProjectEntryDict = TypedDict(
         "repo": str,
         "branch": str,
         "repo-path": str,
+        "vcs": str,
         "default_remote": Optional[Remote],
     },
     total=False,
@@ -101,6 +131,7 @@ class ProjectEntry:  # pylint: disable=too-many-instance-attributes
         self._patch: str = kwargs.get("patch", "")  # noqa
         self._repo_path: str = kwargs.get("repo-path", "")
         self._branch: str = kwargs.get("branch", "")
+        self._vcs: str = kwargs.get("vcs", "")
 
     @classmethod
     def from_yaml(
@@ -182,6 +213,11 @@ class ProjectEntry:  # pylint: disable=too-many-instance-attributes
         """Get the revision that should be fetched."""
         return self._revision
 
+    @property
+    def vcs(self) -> str:
+        """Get the type of version control system."""
+        return self._vcs
+
     def __repr__(self) -> str:
         """Get a string representation of this project entry."""
         version = (
@@ -203,6 +239,7 @@ class ProjectEntry:  # pylint: disable=too-many-instance-attributes
             "patch": self._patch,
             "branch": self._branch,
             "repo-path": self._repo_path,
+            "vcs": self._vcs,
         }
 
         return {k: v for k, v in yamldata.items() if v}

--- a/dfetch/project/__init__.py
+++ b/dfetch/project/__init__.py
@@ -10,6 +10,10 @@ SUPPORTED_PROJECT_TYPES = [GitRepo, SvnRepo]
 def make(project_entry: dfetch.manifest.project.ProjectEntry) -> VCS:
     """Create a new VCS based on a project from the manifest."""
     for project_type in SUPPORTED_PROJECT_TYPES:
+        if project_type.NAME == project_entry.vcs:
+            return project_type(project_entry)
+
+    for project_type in SUPPORTED_PROJECT_TYPES:
         project = project_type(project_entry)
 
         if project.check():

--- a/dfetch/project/git.py
+++ b/dfetch/project/git.py
@@ -81,7 +81,14 @@ class GitRepo(VCS):
 
     def check(self) -> bool:
         """Check if is GIT."""
-        return self._project.remote_url.endswith(".git")
+        if self.remote.endswith(".git"):
+            return True
+
+        try:
+            run_on_cmdline(logger, f"git ls-remote --heads {self.remote}")
+            return True
+        except (SubprocessCommandError, RuntimeError):
+            return False
 
     @staticmethod
     def check_path(path: str = ".") -> bool:

--- a/dfetch/project/git.py
+++ b/dfetch/project/git.py
@@ -22,6 +22,7 @@ class GitRepo(VCS):
 
     METADATA_DIR = ".git"
     DEFAULT_BRANCH = "master"
+    NAME = "git"
 
     @staticmethod
     def submodules() -> List[Submodule]:

--- a/dfetch/project/svn.py
+++ b/dfetch/project/svn.py
@@ -24,6 +24,7 @@ class SvnRepo(VCS):
     """A svn repository."""
 
     DEFAULT_BRANCH = "trunk"
+    NAME = "svn"
 
     @staticmethod
     def externals() -> List[External]:

--- a/dfetch/project/svn.py
+++ b/dfetch/project/svn.py
@@ -98,7 +98,7 @@ class SvnRepo(VCS):
         try:
             run_on_cmdline(logger, f"svn info {self._project.remote_url}")
             return True
-        except SubprocessCommandError:
+        except (SubprocessCommandError, RuntimeError):
             return False
 
     @staticmethod

--- a/dfetch/project/vcs.py
+++ b/dfetch/project/vcs.py
@@ -18,6 +18,8 @@ class VCS(ABC):
     It can be updated.
     """
 
+    NAME = ""
+
     def __init__(self, project: dfetch.manifest.project.ProjectEntry) -> None:
         """Create the VCS."""
         self._project = project

--- a/dfetch/resources/schema.yaml
+++ b/dfetch/resources/schema.yaml
@@ -27,5 +27,6 @@ mapping:
                    "repo-path": { type: str }
                    "remote": { type: str }
                    "patch": { type: str }
+                   "vcs": { type: str, enum: ['git', 'svn'] }
                    "src":
                       type: any

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -32,10 +32,25 @@ def test_check_path(name, cmd_result, expectation):
 @pytest.mark.parametrize(
     "name, project, cmd_result, expectation",
     [
-        ("SSH url", ProjectEntry({'name': "sshProject", 'url':"some.git"}), [], True),
-        ("http url", ProjectEntry({'name': "httpProject", 'url':"some/bla"}), ["Yep!"], True),
-        ("Failed command", ProjectEntry({'name': "proj1", 'url':"some/bla"}), [SubprocessCommandError()], False),
-        ("No git", ProjectEntry({'name': "proj2", 'url':"some/bla"}), [RuntimeError()], False),
+        ("SSH url", ProjectEntry({"name": "sshProject", "url": "some.git"}), [], True),
+        (
+            "http url",
+            ProjectEntry({"name": "httpProject", "url": "some/bla"}),
+            ["Yep!"],
+            True,
+        ),
+        (
+            "Failed command",
+            ProjectEntry({"name": "proj1", "url": "some/bla"}),
+            [SubprocessCommandError()],
+            False,
+        ),
+        (
+            "No git",
+            ProjectEntry({"name": "proj2", "url": "some/bla"}),
+            [RuntimeError()],
+            False,
+        ),
     ],
 )
 def test_check(name, project, cmd_result, expectation):

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from dfetch.manifest.project import ProjectEntry
 from dfetch.project.git import GitRepo
 from dfetch.util.cmdline import SubprocessCommandError
 
@@ -15,7 +16,7 @@ from dfetch.util.cmdline import SubprocessCommandError
     "name, cmd_result, expectation",
     [
         ("git repo", ["Yep!"], True),
-        ("not a git repo", [SubprocessCommandError("", "", "", -1)], False),
+        ("not a git repo", [SubprocessCommandError()], False),
         ("no git", [RuntimeError()], False),
     ],
 )
@@ -26,3 +27,21 @@ def test_check_path(name, cmd_result, expectation):
         run_on_cmdline_mock.side_effect = cmd_result
 
         assert GitRepo.check_path() == expectation
+
+
+@pytest.mark.parametrize(
+    "name, project, cmd_result, expectation",
+    [
+        ("SSH url", ProjectEntry({'name': "sshProject", 'url':"some.git"}), [], True),
+        ("http url", ProjectEntry({'name': "httpProject", 'url':"some/bla"}), ["Yep!"], True),
+        ("Failed command", ProjectEntry({'name': "proj1", 'url':"some/bla"}), [SubprocessCommandError()], False),
+        ("No git", ProjectEntry({'name': "proj2", 'url':"some/bla"}), [RuntimeError()], False),
+    ],
+)
+def test_check(name, project, cmd_result, expectation):
+
+    with patch("dfetch.project.git.run_on_cmdline") as run_on_cmdline_mock:
+
+        run_on_cmdline_mock.side_effect = cmd_result
+
+        assert GitRepo(project).check() == expectation

--- a/tests/test_svn.py
+++ b/tests/test_svn.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from dfetch.manifest.project import ProjectEntry
 from dfetch.project.svn import External, SvnRepo
 from dfetch.util.cmdline import SubprocessCommandError
 
@@ -138,3 +139,30 @@ def test_check_path(name, cmd_result, expectation):
         run_on_cmdline_mock.side_effect = cmd_result
 
         assert SvnRepo.check_path() == expectation
+
+
+@pytest.mark.parametrize(
+    "name, project, cmd_result, expectation",
+    [
+        ("Ok url", ProjectEntry({"name": "proj1", "url": "some_url"}), ["Yep!"], True),
+        (
+            "Failed command",
+            ProjectEntry({"name": "proj2", "url": "some_url"}),
+            [SubprocessCommandError],
+            False,
+        ),
+        (
+            "No svn",
+            ProjectEntry({"name": "proj3", "url": "some_url"}),
+            [RuntimeError],
+            False,
+        ),
+    ],
+)
+def test_check(name, project, cmd_result, expectation):
+
+    with patch("dfetch.project.svn.run_on_cmdline") as run_on_cmdline_mock:
+
+        run_on_cmdline_mock.side_effect = cmd_result
+
+        assert SvnRepo(project).check() == expectation


### PR DESCRIPTION
Fixes #74

If git is non-ssh (doesn't end with `.ssh`), check with `git ls-remote` before assuming it is not a git repository