### PR TITLE
Don't mandate remotes ection in manifest (Fixes #102)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,7 @@ Release 0.0.8 (under development)
 =================================
 
 * Fix wrong version check (#101)
+* Don't mandate remote section in manifest (#102)
 
 Release 0.0.7 (released 2021-02-13)
 ===================================

--- a/dfetch/manifest/manifest.py
+++ b/dfetch/manifest/manifest.py
@@ -54,20 +54,24 @@ class Manifest:
         """Create the manifest."""
         self.__version: str = manifest.get("version", self.CURRENT_VERSION)
 
-        self._remotes, default_remotes = self._determine_remotes(manifest["remotes"])
+        self._remotes, default_remotes = self._determine_remotes(
+            manifest.get("remotes", [])
+        )
 
         if not default_remotes:
             default_remotes = list(self._remotes.values())[0:1]
+
+        default_remote = None if not default_remotes else default_remotes[0]
 
         self._projects: Dict[str, ProjectEntry] = {}
         for project in manifest["projects"]:
             if isinstance(project, dict):
                 last_project = self._projects[project["name"]] = ProjectEntry.from_yaml(
-                    project, default_remotes[0]
+                    project, default_remote
                 )
             elif isinstance(project, ProjectEntry):
                 last_project = self._projects[project.name] = ProjectEntry.copy(
-                    project, default_remotes[0]
+                    project, default_remote
                 )
             else:
                 raise RuntimeError(f"{project} has unknown type")

--- a/dfetch/manifest/remote.py
+++ b/dfetch/manifest/remote.py
@@ -1,7 +1,9 @@
 """Remotes are the external repository where the code should be retrieved from.
 
+The ``remotes:`` section is not mandatory.
 If only one remote is added this is assumed to be the default.
 If multiple remotes are listed ``default:`` can be explicitly specified.
+If multiple remotes are marked as default, the first marked as default is chosen.
 
 .. code-block:: yaml
 

--- a/dfetch/resources/schema.yaml
+++ b/dfetch/resources/schema.yaml
@@ -7,6 +7,7 @@ mapping:
     mapping:
       "version": { type: number, required: True}
       "remotes":
+          required: False
           type: seq
           sequence:
              - type: map
@@ -15,6 +16,7 @@ mapping:
                    "url-base": { type: str, required: True}
                    "default": { type: bool }
       "projects":
+          required: True
           type: seq
           sequence:
              - type: map

--- a/features/check-git-repo.feature
+++ b/features/check-git-repo.feature
@@ -90,10 +90,6 @@ Feature: Checking dependencies from a git repository
             manifest:
               version: '0.0'
 
-              remotes:
-                - name: something
-                  url-base: unused
-
               projects:
                 - name: ext/test-repo-tag
                   url: https://github.com/dfetch-org/test-repo
@@ -105,10 +101,6 @@ Feature: Checking dependencies from a git repository
             """
             manifest:
               version: '0.0'
-
-              remotes:
-                - name: something
-                  url-base: unused
 
               projects:
                 - name: ext/test-repo-tag

--- a/features/fetch-git-repo.feature
+++ b/features/fetch-git-repo.feature
@@ -36,15 +36,12 @@ Feature: Fetching dependencies from a git repository
             | ext/test-rev-and-branch    |
             | ext/test-repo-tag-v1       |
 
+    @wip
     Scenario: Tag is updated in manifest
         Given the manifest 'dfetch.yaml'
             """
             manifest:
               version: '0.0'
-
-              remotes:
-                - name: something
-                  url-base: unused
 
               projects:
                 - name: ext/test-repo-tag
@@ -57,10 +54,6 @@ Feature: Fetching dependencies from a git repository
             """
             manifest:
               version: '0.0'
-
-              remotes:
-                - name: something
-                  url-base: unused
 
               projects:
                 - name: ext/test-repo-tag

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -32,6 +32,16 @@ manifest:
      url-base: "http://www.myremote.com/"
 """
 
+
+MANIFEST_NO_REMOTES = u"""
+manifest:
+   version: 0
+
+   projects:
+   - name: my-project
+     url: "http://www.somewhere.com"
+"""
+
 DICTIONARY_MANIFEST = {
     "version": 0,
     "remotes": [{"name": "my-remote", "url-base": "http://www.myremote.com/"}],
@@ -56,6 +66,17 @@ def test_no_projects() -> None:
 
     with pytest.raises(KeyError):
         manifest = given_manifest_from_text(MANIFEST_NO_PROJECTS)
+
+
+def test_no_remotes() -> None:
+    """Test that manifest without remotes can be read."""
+
+    manifest = given_manifest_from_text(MANIFEST_NO_REMOTES)
+
+    assert len(manifest.projects) == 1
+    assert manifest.projects[0].name == "my-project"
+    assert manifest.projects[0].remote_url == "http://www.somewhere.com"
+    assert len(manifest._remotes) == 0
 
 
 def test_construct_from_dict() -> None:


### PR DESCRIPTION
As described in #102 `remotes:` section is currently mandated. This is useless for single project manifests.

This PR:
- Adds unit tests
- Updates feature tests
- Updates schema
- Doesn't require `remotes:` section in manifest anymore.