### PR TITLE
Feature/use manifests in projects

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,7 @@ Release 0.0.9 (under development)
 ===================================
 
 * Add copyright notices to documentation
+* Make it possible to check/update child-projects (#99)
 
 Release 0.0.8 (released 2021-02-14)
 ===================================

--- a/dfetch/commands/check.py
+++ b/dfetch/commands/check.py
@@ -42,5 +42,14 @@ class Check(dfetch.commands.command.Command):
                 with catch_runtime_exceptions(exceptions) as exceptions:
                     dfetch.project.make(project).check_for_update()
 
+                for (
+                    childmanifest,
+                    childpath,
+                ) in dfetch.manifest.manifest.get_childmanifests(project, skip=[path]):
+                    with in_directory(os.path.dirname(childpath)):
+                        for childproject in childmanifest.projects:
+                            with catch_runtime_exceptions(exceptions) as exceptions:
+                                dfetch.project.make(childproject).check_for_update()
+
         if exceptions:
             raise RuntimeError("\n".join(exceptions))

--- a/dfetch/commands/check.py
+++ b/dfetch/commands/check.py
@@ -5,6 +5,16 @@ the available version. If there are new versions available this will be shown.
 
 .. uml:: /static/uml/check.puml
 
+Child-manifests
+~~~~~~~~~~~~~~~
+
+It is possible that fetched projects have manifests of their own.
+After these projects are fetched (with ``dfetch update``), the manifests are fetched as well
+and will be checked. If you don't what this, you can prevent *Dfetch*
+checking child-manifests with ``--non-recursive``.
+
+.. note:: Any name or destination clashes are currently up to the user.
+
 """
 
 import argparse

--- a/dfetch/commands/check.py
+++ b/dfetch/commands/check.py
@@ -60,13 +60,13 @@ class Check(dfetch.commands.command.Command):
                     dfetch.project.make(project).check_for_update()
 
                 if not args.non_recursive:
-                    exceptions += Check.__check_child_manifests(project, path)
+                    exceptions += Check._check_child_manifests(project, path)
 
         if exceptions:
             raise RuntimeError("\n".join(exceptions))
 
     @staticmethod
-    def __check_child_manifests(project: ProjectEntry, path: str) -> List[str]:
+    def _check_child_manifests(project: ProjectEntry, path: str) -> List[str]:
         exceptions: List[str] = []
         for (
             childmanifest,

--- a/dfetch/commands/check.py
+++ b/dfetch/commands/check.py
@@ -9,13 +9,14 @@ the available version. If there are new versions available this will be shown.
 
 import argparse
 import os
+from typing import List
 
 import dfetch.commands.command
 import dfetch.manifest.manifest
 import dfetch.manifest.validate
 import dfetch.project
-import dfetch.util
 from dfetch.log import get_logger
+from dfetch.util.util import catch_runtime_exceptions, in_directory
 
 logger = get_logger(__name__)
 
@@ -35,13 +36,11 @@ class Check(dfetch.commands.command.Command):
         """Perform the check."""
         manifest, path = dfetch.manifest.manifest.get_manifest()
 
-        with dfetch.util.util.in_directory(os.path.dirname(path)):
-            exceptions = []
+        with in_directory(os.path.dirname(path)):
+            exceptions: List[str] = []
             for project in manifest.projects:
-                try:
+                with catch_runtime_exceptions(exceptions) as exceptions:
                     dfetch.project.make(project).check_for_update()
-                except RuntimeError as exc:
-                    exceptions += [str(exc)]
 
         if exceptions:
             raise RuntimeError("\n".join(exceptions))

--- a/dfetch/commands/check.py
+++ b/dfetch/commands/check.py
@@ -59,8 +59,9 @@ class Check(dfetch.commands.command.Command):
                 with catch_runtime_exceptions(exceptions) as exceptions:
                     dfetch.project.make(project).check_for_update()
 
-                if not args.non_recursive:
-                    exceptions += Check._check_child_manifests(project, path)
+                if not args.non_recursive and os.path.exists(project.destination):
+                    with in_directory(project.destination):
+                        exceptions += Check._check_child_manifests(project, path)
 
         if exceptions:
             raise RuntimeError("\n".join(exceptions))

--- a/dfetch/commands/update.py
+++ b/dfetch/commands/update.py
@@ -44,5 +44,15 @@ class Update(dfetch.commands.command.Command):
                 except RuntimeError as exc:
                     exceptions += [str(exc)]
 
+                for submanifest, subpath in dfetch.manifest.manifest.get_submanifests(
+                    project, skip=[path]
+                ):
+                    with dfetch.util.util.in_directory(os.path.dirname(subpath)):
+                        for subproject in submanifest.projects:
+                            try:
+                                dfetch.project.make(subproject).update()
+                            except RuntimeError as exc:
+                                exceptions += [str(exc)]
+
         if exceptions:
             raise RuntimeError("\n".join(exceptions))

--- a/dfetch/commands/update.py
+++ b/dfetch/commands/update.py
@@ -17,6 +17,7 @@ import dfetch.manifest.validate
 import dfetch.project.git
 import dfetch.project.svn
 from dfetch.log import get_logger
+from dfetch.manifest.project import ProjectEntry
 from dfetch.util.util import catch_runtime_exceptions, in_directory
 
 logger = get_logger(__name__)
@@ -50,16 +51,20 @@ class Update(dfetch.commands.command.Command):
                     dfetch.project.make(project).update()
 
                 if not args.non_recursive:
-                    for (
-                        childmanifest,
-                        childpath,
-                    ) in dfetch.manifest.manifest.get_childmanifests(
-                        project, skip=[path]
-                    ):
-                        with in_directory(os.path.dirname(childpath)):
-                            for childproject in childmanifest.projects:
-                                with catch_runtime_exceptions(exceptions) as exceptions:
-                                    dfetch.project.make(childproject).update()
+                    exceptions += Update.__update_child_manifests(project, path)
 
         if exceptions:
             raise RuntimeError("\n".join(exceptions))
+
+    @staticmethod
+    def __update_child_manifests(project: ProjectEntry, path: str) -> List[str]:
+        exceptions: List[str] = []
+        for (
+            childmanifest,
+            childpath,
+        ) in dfetch.manifest.manifest.get_childmanifests(project, skip=[path]):
+            with in_directory(os.path.dirname(childpath)):
+                for childproject in childmanifest.projects:
+                    with catch_runtime_exceptions(exceptions) as exceptions:
+                        dfetch.project.make(childproject).update()
+        return exceptions

--- a/dfetch/commands/update.py
+++ b/dfetch/commands/update.py
@@ -4,6 +4,18 @@ You can add Projects to your :ref:`Manifest` and update will fetch the version s
 It tries to determine what kind of vcs it is: git, svn or something else.
 
 .. uml:: /static/uml/update.puml
+
+Child-manifests
+~~~~~~~~~~~~~~~
+
+It is possible that projects have manifests of their own.
+After the projects of the main manifest are fetched,
+*Dfetch* will look for new manifests and update these as well following the same logic as above.
+If you don't what this, you can prevent *Dfetch*
+checking child-manifests with ``--non-recursive``.
+
+.. note:: Any name or destination clashes are currently up to the user.
+
 """
 
 import argparse

--- a/dfetch/commands/update.py
+++ b/dfetch/commands/update.py
@@ -29,7 +29,7 @@ class Update(dfetch.commands.command.Command):
     """
 
     @staticmethod
-    def create_menu(subparsers: "argparse._ChildParsersAction") -> None:
+    def create_menu(subparsers: "argparse._SubParsersAction") -> None:
         """Add the menu for the update action."""
         parser = dfetch.commands.command.Command.parser(subparsers, Update)
         parser.add_argument("--dry-run", "-n", action="store_true", help="Only check")

--- a/dfetch/commands/update.py
+++ b/dfetch/commands/update.py
@@ -29,7 +29,7 @@ class Update(dfetch.commands.command.Command):
     """
 
     @staticmethod
-    def create_menu(subparsers: "argparse._SubParsersAction") -> None:
+    def create_menu(subparsers: "argparse._ChildParsersAction") -> None:
         """Add the menu for the update action."""
         parser = dfetch.commands.command.Command.parser(subparsers, Update)
         parser.add_argument("--dry-run", "-n", action="store_true", help="Only check")
@@ -44,13 +44,14 @@ class Update(dfetch.commands.command.Command):
                 with catch_runtime_exceptions(exceptions) as exceptions:
                     dfetch.project.make(project).update()
 
-                for submanifest, subpath in dfetch.manifest.manifest.get_submanifests(
-                    project, skip=[path]
-                ):
-                    with in_directory(os.path.dirname(subpath)):
-                        for subproject in submanifest.projects:
+                for (
+                    childmanifest,
+                    childpath,
+                ) in dfetch.manifest.manifest.get_childmanifests(project, skip=[path]):
+                    with in_directory(os.path.dirname(childpath)):
+                        for childproject in childmanifest.projects:
                             with catch_runtime_exceptions(exceptions) as exceptions:
-                                dfetch.project.make(subproject).update()
+                                dfetch.project.make(childproject).update()
 
         if exceptions:
             raise RuntimeError("\n".join(exceptions))

--- a/dfetch/commands/update.py
+++ b/dfetch/commands/update.py
@@ -62,8 +62,9 @@ class Update(dfetch.commands.command.Command):
                 with catch_runtime_exceptions(exceptions) as exceptions:
                     dfetch.project.make(project).update()
 
-                if not args.non_recursive:
-                    exceptions += Update.__update_child_manifests(project, path)
+                if not args.non_recursive and os.path.exists(project.destination):
+                    with in_directory(project.destination):
+                        exceptions += Update.__update_child_manifests(project, path)
 
         if exceptions:
             raise RuntimeError("\n".join(exceptions))

--- a/dfetch/manifest/manifest.py
+++ b/dfetch/manifest/manifest.py
@@ -212,7 +212,7 @@ def find_manifest() -> str:
     if len(paths) == 0:
         raise RuntimeError("No manifests were found!")
     if len(paths) != 1:
-        raise RuntimeError("Multiple manifests found!")
+        logger.warning(f"Multiple manifests found, using {paths[0]}")
 
     return os.path.realpath(paths[0])
 

--- a/dfetch/manifest/manifest.py
+++ b/dfetch/manifest/manifest.py
@@ -233,14 +233,14 @@ def get_manifest() -> Tuple[Manifest, str]:
     )
 
 
-def get_submanifests(
+def get_childmanifests(
     parent: ProjectEntry, skip: Optional[List[str]] = None
 ) -> List[Tuple[Manifest, str]]:
     """Get manifest and its path."""
     skip = skip or []
     logger.debug("Looking for sub-manifests")
 
-    submanifests = []
+    childmanifests = []
     for path in find_file(DEFAULT_MANIFEST_NAME, "."):
         path = os.path.realpath(path)
         if path not in skip:
@@ -249,11 +249,11 @@ def get_submanifests(
                 pathlib.Path(path).relative_to(os.getcwd()).as_posix()
             ):
                 dfetch.manifest.validate.validate(path)
-            submanifest = dfetch.manifest.manifest.Manifest.from_file(path)
-            submanifest.set_parent(parent)
-            submanifests += [(submanifest, path)]
+            childmanifest = dfetch.manifest.manifest.Manifest.from_file(path)
+            childmanifest.set_parent(parent)
+            childmanifests += [(childmanifest, path)]
 
-    return submanifests
+    return childmanifests
 
 
 class ManifestDumper(yaml.SafeDumper):  # pylint: disable=too-many-ancestors

--- a/dfetch/manifest/manifest.py
+++ b/dfetch/manifest/manifest.py
@@ -19,6 +19,7 @@ download and a section ``projects:`` that contains a list of projects to fetch.
 """
 import io
 import os
+import pathlib
 from typing import IO, Any, Dict, List, Optional, Sequence, Tuple, Union
 
 import yaml
@@ -242,7 +243,9 @@ def get_submanifests(
         path = os.path.realpath(path)
         if path not in skip:
             logger.debug(f"Found sub-manifests {path}")
-            with prefix_runtime_exceptions(os.path.relpath(path, os.getcwd())):
+            with prefix_runtime_exceptions(
+                pathlib.Path(path).relative_to(os.getcwd()).as_posix()
+            ):
                 dfetch.manifest.validate.validate(path)
             submanifest = dfetch.manifest.manifest.Manifest.from_file(path)
             submanifest.set_parent(parent)

--- a/dfetch/manifest/manifest.py
+++ b/dfetch/manifest/manifest.py
@@ -212,7 +212,7 @@ def find_manifest() -> str:
     if len(paths) == 0:
         raise RuntimeError("No manifests were found!")
     if len(paths) != 1:
-        logger.warning(f"Multiple manifests found, using {paths[0]}")
+        raise RuntimeError("Multiple manifests found!")
 
     return os.path.realpath(paths[0])
 

--- a/dfetch/manifest/manifest.py
+++ b/dfetch/manifest/manifest.py
@@ -246,7 +246,7 @@ def get_childmanifests(
         if path not in skip:
             logger.debug(f"Found sub-manifests {path}")
             with prefix_runtime_exceptions(
-                pathlib.Path(path).relative_to(os.getcwd()).as_posix()
+                pathlib.Path(path).relative_to(os.path.dirname(os.getcwd())).as_posix()
             ):
                 dfetch.manifest.validate.validate(path)
             childmanifest = dfetch.manifest.manifest.Manifest.from_file(path)

--- a/dfetch/manifest/manifest.py
+++ b/dfetch/manifest/manifest.py
@@ -29,7 +29,7 @@ from dfetch import DEFAULT_MANIFEST_NAME
 from dfetch.log import get_logger
 from dfetch.manifest.project import ProjectEntry, ProjectEntryDict
 from dfetch.manifest.remote import Remote, RemoteDict
-from dfetch.util.util import find_file
+from dfetch.util.util import find_file, prefix_runtime_exceptions
 
 logger = get_logger(__name__)
 
@@ -242,8 +242,8 @@ def get_submanifests(
         path = os.path.realpath(path)
         if path not in skip:
             logger.debug(f"Found sub-manifests {path}")
-            # TODO: validate submanifests
-            # dfetch.manifest.validate.validate(path)
+            with prefix_runtime_exceptions(os.path.relpath(path, os.getcwd())):
+                dfetch.manifest.validate.validate(path)
             submanifest = dfetch.manifest.manifest.Manifest.from_file(path)
             submanifest.set_parent(parent)
             submanifests += [(submanifest, path)]

--- a/dfetch/manifest/manifest.py
+++ b/dfetch/manifest/manifest.py
@@ -213,7 +213,9 @@ def find_manifest() -> str:
     if len(paths) == 0:
         raise RuntimeError("No manifests were found!")
     if len(paths) != 1:
-        logger.warning(f"Multiple manifests found, using {paths[0]}")
+        logger.warning(
+            f"Multiple manifests found, using {pathlib.Path(paths[0]).as_posix()}"
+        )
 
     return os.path.realpath(paths[0])
 

--- a/dfetch/manifest/project.py
+++ b/dfetch/manifest/project.py
@@ -170,6 +170,7 @@ ProjectEntryDict = TypedDict(
         "repo-path": str,
         "vcs": str,
         "default_remote": Optional[Remote],
+        "parent": str,
     },
     total=False,
 )
@@ -193,6 +194,7 @@ class ProjectEntry:  # pylint: disable=too-many-instance-attributes
         self._branch: str = kwargs.get("branch", "")
         self._tag: str = kwargs.get("tag", "")
         self._vcs: str = kwargs.get("vcs", "")
+        self._parent: str = kwargs.get("parent", "")
 
     @classmethod
     def from_yaml(
@@ -233,6 +235,10 @@ class ProjectEntry:  # pylint: disable=too-many-instance-attributes
             self._repo_path = self._url.replace(remote.url, "").strip("/")
             self._url = ""
 
+    def set_parent(self, parent: str) -> None:
+        """Set the parent."""
+        self._parent = parent
+
     @property
     def remote_url(self) -> str:
         """Get the remote url of the project."""
@@ -251,7 +257,7 @@ class ProjectEntry:  # pylint: disable=too-many-instance-attributes
     @property
     def name(self) -> str:
         """Get the name of the project."""
-        return self._name
+        return self._name if not self._parent else self._parent + "/" + self._name
 
     @property
     def source(self) -> str:
@@ -306,6 +312,7 @@ class ProjectEntry:  # pylint: disable=too-many-instance-attributes
             "tag": self._tag,
             "repo-path": self._repo_path,
             "vcs": self._vcs,
+            "parent": self._parent,
         }
 
         return {k: v for k, v in yamldata.items() if v}

--- a/dfetch/manifest/validate.py
+++ b/dfetch/manifest/validate.py
@@ -5,14 +5,14 @@ import pykwalify
 from pykwalify.core import Core, SchemaError
 from yaml.scanner import ScannerError
 
-from dfetch.resources import SCHEMA_PATH
+import dfetch.resources
 
 
 def validate(path: str) -> None:
     """Validate the given manifest."""
     logging.getLogger(pykwalify.__name__).setLevel(logging.CRITICAL)
 
-    with SCHEMA_PATH as schema_path:
+    with dfetch.resources.schema_path() as schema_path:
         try:
             validator = Core(source_file=path, schema_files=[str(schema_path)])
         except ScannerError as err:

--- a/dfetch/resources/__init__.py
+++ b/dfetch/resources/__init__.py
@@ -1,8 +1,8 @@
 """Resources needed when dfetch is distributed."""
 
-import importlib.resources as pkg_resources
+import importlib.resources
 
 from dfetch import resources  # pylint: disable=import-self
 
-SCHEMA_PATH = pkg_resources.path(resources, "schema.yaml")
-TEMPLATE_PATH = pkg_resources.path(resources, "template.yaml")
+SCHEMA_PATH = importlib.resources.path(resources, "schema.yaml")
+TEMPLATE_PATH = importlib.resources.path(resources, "template.yaml")

--- a/dfetch/resources/__init__.py
+++ b/dfetch/resources/__init__.py
@@ -1,8 +1,15 @@
 """Resources needed when dfetch is distributed."""
 
 import importlib.resources
+from pathlib import Path
+from typing import ContextManager
 
 from dfetch import resources  # pylint: disable=import-self
 
-SCHEMA_PATH = importlib.resources.path(resources, "schema.yaml")
+
+def schema_path() -> ContextManager[Path]:
+    """Get path to schema."""
+    return importlib.resources.path(resources, "schema.yaml")
+
+
 TEMPLATE_PATH = importlib.resources.path(resources, "template.yaml")

--- a/dfetch/util/util.py
+++ b/dfetch/util/util.py
@@ -54,6 +54,17 @@ def catch_runtime_exceptions(
         exc_list += [str(exc)]
 
 
+@contextmanager
+def prefix_runtime_exceptions(
+    prefix: str,
+) -> Generator[None, None, None]:
+    """Prefix any runtime error with given string."""
+    try:
+        yield None
+    except RuntimeError as exc:
+        raise RuntimeError(f"{prefix}: {exc}") from exc
+
+
 def find_file(name: str, path: str = ".") -> List[str]:
     """Find all files with a specific name recursively in a directory."""
     return [

--- a/dfetch/util/util.py
+++ b/dfetch/util/util.py
@@ -42,6 +42,18 @@ def in_directory(path: str) -> Generator[str, None, None]:
     os.chdir(pwd)
 
 
+@contextmanager
+def catch_runtime_exceptions(
+    exc_list: Optional[List[str]] = None,
+) -> Generator[List[str], None, None]:
+    """Catch all runtime errors and add it to list of strings."""
+    exc_list = exc_list or []
+    try:
+        yield exc_list
+    except RuntimeError as exc:
+        exc_list += [str(exc)]
+
+
 def find_file(name: str, path: str = ".") -> List[str]:
     """Find all files with a specific name recursively in a directory."""
     return [

--- a/features/check-child-projects.feature
+++ b/features/check-child-projects.feature
@@ -1,0 +1,66 @@
+Feature: Check for updates in child projects
+
+    When a project has dependencies of its own, *Dfetch* should also fetch any dependencies in
+    a manifest of that project.
+
+    Scenario: Git projects are specified in the manifest
+        Given the manifest 'dfetch.yaml' in MyProject
+            """
+            manifest:
+                version: 0.0
+                projects:
+                    - name: SomeProject
+                      dst: ThirdParty/SomeProject
+                      url: some-remote-server/SomeProject.git
+                      tag: v1
+            """
+        And a git-repository "SomeProject.git" with the manifest:
+            """
+            manifest:
+                version: 0.0
+                projects:
+                    - name: SomeOtherProject
+                      dst: ../SomeOtherProject
+                      url: some-remote-server/SomeOtherProject.git
+                      tag: v1
+            """
+        And a git repository "SomeOtherProject.git"
+        When I run "dfetch check" in MyProject
+        Then the output shows
+            """
+            Dfetch (0.0.6)
+              SomeProject         : wanted (v1), available (v1)
+            """
+
+    Scenario: A check is performed, when child projects fetched
+        Given the manifest 'dfetch.yaml' in MyProject
+            """
+            manifest:
+                version: 0.0
+                projects:
+                    - name: SomeProject
+                      dst: ThirdParty/SomeProject
+                      url: some-remote-server/SomeProject.git
+                      tag: v1
+            """
+        And a git-repository "SomeProject.git" with the manifest:
+            """
+            manifest:
+                version: 0.0
+                projects:
+                    - name: SomeOtherProject
+                      dst: ../SomeOtherProject
+                      url: some-remote-server/SomeOtherProject.git
+                      tag: v1
+            """
+        And a git repository "SomeOtherProject.git"
+        And all projects are updated in MyProject
+        And a new tag "v2" is added to git-repository "SomeProject.git"
+        When I run "dfetch check" in MyProject
+        Then the output shows
+            """
+            Dfetch (0.0.6)
+            Multiple manifests found, using dfetch.yaml
+              SomeProject         : wanted & current (v1), available (v2)
+              SomeProject/SomeOtherProject: up-to-date (v1)
+            """

--- a/features/environment.py
+++ b/features/environment.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 import tempfile
 
 from behave import fixture, use_fixture
@@ -13,6 +12,9 @@ def tmpdir(context):
     context.orig_cwd = os.getcwd()
     context.tmpdir = tempfile.mkdtemp()
     os.chdir(context.tmpdir)
+    context.remotes_dir_path = os.path.abspath(
+        os.path.join(os.getcwd(), "some-remote-server")
+    )
     yield context.tmpdir
     # -- CLEANUP-FIXTURE PART:
     os.chdir(context.orig_cwd)
@@ -21,3 +23,7 @@ def tmpdir(context):
 
 def before_feature(context, feature):
     use_fixture(tmpdir, context)
+
+
+def before_all(context):
+    context.remotes_dir = "some-remote-server"

--- a/features/environment.py
+++ b/features/environment.py
@@ -21,7 +21,7 @@ def tmpdir(context):
     safe_rmtree(context.tmpdir)
 
 
-def before_feature(context, feature):
+def before_scenario(context, scenario):
     use_fixture(tmpdir, context)
 
 

--- a/features/steps/generic_steps.py
+++ b/features/steps/generic_steps.py
@@ -42,9 +42,14 @@ def list_dir(path):
     return result
 
 
+@given("all projects are updated in {path}")
 @given("all projects are updated")
-def step_impl(context):
-    context.execute_steps('When I run "dfetch update"')
+def step_impl(context, path=None):
+
+    if path:
+        context.execute_steps(f'When I run "dfetch update" in {path}')
+    else:
+        context.execute_steps('When I run "dfetch update"')
     assert not context.cmd_returncode, context.cmd_output
 
 

--- a/features/steps/generic_steps.py
+++ b/features/steps/generic_steps.py
@@ -11,18 +11,52 @@ ansi_escape = re.compile(r"\x1b(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
 dfetch_title = re.compile(r"Dfetch \(\d+.\d+.\d+\)")
 
 
+def generate_file(path, content):
+
+    with open(path, "w") as new_file:
+        for line in content.splitlines():
+            print(line, file=new_file)
+
+
+def list_dir(path):
+
+    # Get list of all nodes
+    nodes = [os.path.normpath(path).split(os.sep)]
+    for root, dirs, files in os.walk(path, followlinks=False):
+        root = os.path.relpath(root)
+        for name in dirs:
+            nodes += [os.path.normpath(os.path.join(root, name)).split(os.sep)]
+        for name in files:
+            nodes += [os.path.normpath(os.path.join(root, name)).split(os.sep)]
+
+    result = ""
+    prev_node = []
+    for node in list(sorted(nodes)) + [""]:
+        if prev_node:
+            end = ""
+            if "".join(node).startswith("".join(prev_node)):
+                end = "/"
+            result += "    " * (len(prev_node) - 1) + prev_node[-1] + end + os.linesep
+        prev_node = node
+
+    return result
+
+
 @given("all projects are updated")
 def step_impl(context):
     context.execute_steps('When I run "dfetch update"')
 
 
+@when('I run "{cmd}" in {path}')
 @when('I run "{cmd}"')
-def step_impl(context, cmd):
+def step_impl(context, cmd, path=None):
     """Call a command."""
     try:
         context.cmd_output = dfetch_title.sub(
             "",
-            subprocess.check_output(cmd.split(), stderr=subprocess.STDOUT, text=True),
+            subprocess.check_output(
+                cmd.split(), stderr=subprocess.STDOUT, text=True, cwd=path
+            ),
         )
         context.cmd_returncode = 0
     except subprocess.CalledProcessError as exc:
@@ -51,3 +85,13 @@ def step_impl(context):
     for project in context.table:
         assert os.path.exists(project["path"]), f"No project found at {project}"
         assert os.listdir(project["path"]), f"{project} is just an empty directory!"
+
+
+@then("'{path}' looks like")
+def step_impl(context, path):
+    expected_dir = context.text.strip()
+    actual_dir = list_dir(path).strip()
+
+    assert expected_dir == actual_dir, os.linesep.join(
+        ["", "Expected:", expected_dir, "", "Actual:", actual_dir]
+    )

--- a/features/steps/generic_steps.py
+++ b/features/steps/generic_steps.py
@@ -18,6 +18,13 @@ def generate_file(path, content):
             print(line, file=new_file)
 
 
+def extend_file(path, content):
+
+    with open(path, "a") as existing_file:
+        for line in content.splitlines():
+            print(line, file=existing_file)
+
+
 def list_dir(path):
 
     # Get list of all nodes

--- a/features/steps/generic_steps.py
+++ b/features/steps/generic_steps.py
@@ -45,6 +45,7 @@ def list_dir(path):
 @given("all projects are updated")
 def step_impl(context):
     context.execute_steps('When I run "dfetch update"')
+    assert not context.cmd_returncode, context.cmd_output
 
 
 @when('I run "{cmd}" in {path}')

--- a/features/steps/git_steps.py
+++ b/features/steps/git_steps.py
@@ -12,7 +12,7 @@ from features.steps.manifest_steps import generate_manifest
 
 
 def create_repo():
-    subprocess.call(["git", "init"])
+    subprocess.call(["git", "init", "--initial-branch=master"])
     subprocess.call(["git", "config", "user.email", "you@example.com"])
     subprocess.call(["git", "config", "user.name", "John Doe"])
 

--- a/features/steps/git_steps.py
+++ b/features/steps/git_steps.py
@@ -7,7 +7,7 @@ import subprocess
 from behave import given  # pylint: disable=no-name-in-module
 
 from dfetch.util.util import in_directory
-from features.steps.generic_steps import generate_file
+from features.steps.generic_steps import extend_file, generate_file
 from features.steps.manifest_steps import generate_manifest
 
 
@@ -20,6 +20,10 @@ def create_repo():
 def commit_all(msg):
     subprocess.call(["git", "add", "-A"])
     subprocess.call(["git", "commit", "-m", f'"{msg}"'])
+
+
+def tag(name: str):
+    subprocess.call(["git", "tag", "-a", name, "-m", f"'Some tag'"])
 
 
 @given("a git repo with the following submodules")
@@ -35,6 +39,15 @@ def step_impl(context):
         with in_directory(submodule["path"]):
             subprocess.call(["git", "checkout", submodule["revision"]])
     commit_all("Added submodules")
+
+
+@given('a new tag "{tagname}" is added to git-repository "{name}"')
+def step_impl(context, tagname, name):
+    remote_path = os.path.join(context.remotes_dir, name)
+    with in_directory(remote_path):
+        extend_file("README.md", f"New line for creating {tagname}")
+        commit_all("Extend readme")
+        tag(tagname)
 
 
 @given('a git-repository "{name}" with the manifest')
@@ -53,4 +66,4 @@ def step_impl(context, name):
             generate_manifest(context)
 
         commit_all("Initial commit")
-        subprocess.call(["git", "tag", "-a", "v1", "-m", "'Some tag'"])
+        tag("v1")

--- a/features/steps/git_steps.py
+++ b/features/steps/git_steps.py
@@ -1,10 +1,14 @@
 """Steps for features tests."""
 
+import os
+import pathlib
 import subprocess
 
 from behave import given  # pylint: disable=no-name-in-module
 
 from dfetch.util.util import in_directory
+from features.steps.generic_steps import generate_file
+from features.steps.manifest_steps import generate_manifest
 
 
 @given("a git repo with the following submodules")
@@ -21,3 +25,23 @@ def step_impl(context):
             subprocess.call(["git", "checkout", submodule["revision"]])
     subprocess.call(["git", "add", "-A"])
     subprocess.call(["git", "commit", "-m", '"Added submodules"'])
+
+
+@given('a git-repository "{name}" with the manifest')
+@given('a git repository "{name}"')
+def step_impl(context, name):
+
+    remote_path = os.path.join(context.remotes_dir, name)
+
+    pathlib.Path(remote_path).mkdir(parents=True, exist_ok=True)
+
+    with in_directory(remote_path):
+        subprocess.call(["git", "init"])
+
+        generate_file("README.md", f"Generated file for {name}")
+        if context.text:
+            generate_manifest(context)
+
+        subprocess.call(["git", "add", "-A"])
+        subprocess.call(["git", "commit", "-m", '"Initial commit"'])
+        subprocess.call(["git", "tag", "-a", "v1", "-m", "'Some tag'"])

--- a/features/steps/git_steps.py
+++ b/features/steps/git_steps.py
@@ -11,10 +11,21 @@ from features.steps.generic_steps import generate_file
 from features.steps.manifest_steps import generate_manifest
 
 
+def create_repo():
+    subprocess.call(["git", "init"])
+    subprocess.call(["git", "config", "user.email", "you@example.com"])
+    subprocess.call(["git", "config", "user.name", "John Doe"])
+
+
+def commit_all(msg):
+    subprocess.call(["git", "add", "-A"])
+    subprocess.call(["git", "commit", "-m", f'"{msg}"'])
+
+
 @given("a git repo with the following submodules")
 def step_impl(context):
 
-    subprocess.call(["git", "init"])
+    create_repo()
 
     for submodule in context.table:
         subprocess.call(
@@ -23,8 +34,7 @@ def step_impl(context):
 
         with in_directory(submodule["path"]):
             subprocess.call(["git", "checkout", submodule["revision"]])
-    subprocess.call(["git", "add", "-A"])
-    subprocess.call(["git", "commit", "-m", '"Added submodules"'])
+    commit_all("Added submodules")
 
 
 @given('a git-repository "{name}" with the manifest')
@@ -36,12 +46,11 @@ def step_impl(context, name):
     pathlib.Path(remote_path).mkdir(parents=True, exist_ok=True)
 
     with in_directory(remote_path):
-        subprocess.call(["git", "init"])
+        create_repo()
 
         generate_file("README.md", f"Generated file for {name}")
         if context.text:
             generate_manifest(context)
 
-        subprocess.call(["git", "add", "-A"])
-        subprocess.call(["git", "commit", "-m", '"Initial commit"'])
+        commit_all("Initial commit")
         subprocess.call(["git", "tag", "-a", "v1", "-m", "'Some tag'"])

--- a/features/steps/manifest_steps.py
+++ b/features/steps/manifest_steps.py
@@ -1,15 +1,32 @@
 """Steps for features tests."""
 
+import os
+import pathlib
 
-from behave import given, then  # pylint: disable=no-name-in-module
+from behave import given, then, when  # pylint: disable=no-name-in-module
+
+from features.steps.generic_steps import generate_file
 
 
+def generate_manifest(context, name="dfetch.yaml", path=None):
+
+    abs_server_path = "/".join(context.remotes_dir_path.split(os.sep))
+
+    manifest = context.text.replace(
+        "url: some-remote-server", f"url: {abs_server_path}"
+    )
+    generate_file(os.path.join(path or os.getcwd(), name), manifest)
+
+
+@given("the manifest '{name}' in {path}")
 @given("the manifest '{name}'")
 @when("the manifest '{name}' is changed to")
-def step_impl(context, name):
-    with open(name, "w") as manifest:
-        for line in context.text.splitlines():
-            print(line, file=manifest)
+def step_impl(context, name, path=None):
+
+    if path:
+        pathlib.Path(path).mkdir(parents=True, exist_ok=True)
+
+    generate_manifest(context, name, path)
 
 
 @then("it should generate the manifest '{name}'")

--- a/features/update-child-projects.feature
+++ b/features/update-child-projects.feature
@@ -1,4 +1,4 @@
-Feature: Use found manifest in project
+Feature: Update child-projects in projects
 
     When a project has dependencies of its own, *Dfetch* should also fetch any dependencies in
     a manifest of that project.

--- a/features/update-child-projects.feature
+++ b/features/update-child-projects.feature
@@ -9,40 +9,48 @@ Feature: Update child-projects in projects
             manifest:
                 version: 0.0
                 projects:
-                    - name: SomeProject
-                      dst: ThirdParty/SomeProject
-                      url: some-remote-server/SomeProject.git
+                    - name: SomeProjectWithChild
+                      dst: ThirdParty/SomeProjectWithChild
+                      url: some-remote-server/SomeProjectWithChild.git
+                      tag: v1
+                    - name: SomeProjectWithoutChild
+                      dst: ThirdParty/SomeProjectWithoutChild
+                      url: some-remote-server/SomeProjectWithoutChild.git
                       tag: v1
             """
-        And a git-repository "SomeProject.git" with the manifest:
+        And a git-repository "SomeProjectWithChild.git" with the manifest:
             """
             manifest:
                 version: 0.0
                 projects:
-                    - name: SomeOtherProject
-                      dst: ../SomeOtherProject
-                      url: some-remote-server/SomeOtherProject.git
+                    - name: SomeProjectWithoutChild2
+                      dst: ../SomeProjectWithoutChild2
+                      url: some-remote-server/SomeProjectWithoutChild.git
                       tag: v1
             """
-        And a git repository "SomeOtherProject.git"
+        And a git repository "SomeProjectWithoutChild.git"
         When I run "dfetch update" in MyProject
         Then the output shows
             """
             Dfetch (0.0.6)
-              SomeProject         : Fetched v1
-              SomeProject/SomeOtherProject: Fetched v1
+              SomeProjectWithChild: Fetched v1
+              SomeProjectWithChild/SomeProjectWithoutChild2: Fetched v1
+              SomeProjectWithoutChild: Fetched v1
             """
         And 'MyProject' looks like:
             """
             MyProject/
                 ThirdParty/
-                    SomeOtherProject/
-                        .dfetch_data.yaml
-                        README.md
-                    SomeProject/
+                    SomeProjectWithChild/
                         .dfetch_data.yaml
                         README.md
                         dfetch.yaml
+                    SomeProjectWithoutChild/
+                        .dfetch_data.yaml
+                        README.md
+                    SomeProjectWithoutChild2/
+                        .dfetch_data.yaml
+                        README.md
                 dfetch.yaml
             """
 
@@ -66,7 +74,7 @@ Feature: Update child-projects in projects
             """
             Dfetch (0.0.6)
               SomeProject         : Fetched v1
-            ThirdParty/SomeProject/dfetch.yaml: Schema validation failed:
+            SomeProject/dfetch.yaml: Schema validation failed:
              - Value 'very-invalid-manifest' is not a dict. Value path: ''.
             """
         And 'MyProject' looks like:

--- a/features/use-found-manifest-in-project.feature
+++ b/features/use-found-manifest-in-project.feature
@@ -103,26 +103,6 @@ Feature: Use found manifest in project
             """
         And a git repository "SomeOtherProject.git"
         And all projects are updated in MyProject
-        Then the output shows
-            """
-            Dfetch (0.0.6)
-              SomeProject         : Fetched v1
-              SomeProject/SomeOtherProject: Fetched v1
-            """
-        Then 'MyProject' looks like:
-            """
-            MyProject/
-                ThirdParty/
-                    SomeOtherProject/
-                        .dfetch_data.yaml
-                        README.md
-                    SomeProject/
-                        .dfetch_data.yaml
-                        README.md
-                        dfetch.yaml
-                dfetch.yaml
-            """
-
         When I run "dfetch update" in MyProject
         Then the output shows
             """

--- a/features/use-found-manifest-in-project.feature
+++ b/features/use-found-manifest-in-project.feature
@@ -103,7 +103,7 @@ Feature: Use found manifest in project
                       tag: v1
             """
         And a git repository "SomeOtherProject.git"
-        And all projects are updated
+        And all projects are updated in MyProject
         Then the output shows
             """
             Dfetch (0.0.6)

--- a/features/use-found-manifest-in-project.feature
+++ b/features/use-found-manifest-in-project.feature
@@ -46,7 +46,7 @@ Feature: Use found manifest in project
                 dfetch.yaml
             """
 
-    Scenario: A subproject has an invalid manifest
+    Scenario: A child-project has an invalid manifest
         Given the manifest 'dfetch.yaml' in MyProject
             """
             manifest:

--- a/features/use-found-manifest-in-project.feature
+++ b/features/use-found-manifest-in-project.feature
@@ -1,0 +1,48 @@
+@wip
+Feature: Use found manifest in project
+
+    When a project has dependencies of its own, *Dfetch* should also fetch any dependencies in
+    a manifest of that project.
+
+    Scenario: Git projects are specified in the manifest
+        Given the manifest 'dfetch.yaml' in MyProject
+            """
+            manifest:
+                version: 0.0
+                projects:
+                    - name: SomeProject
+                      dst: ThirdParty/SomeProject
+                      url: some-remote-server/SomeProject.git
+                      tag: v1
+            """
+        And a git-repository "SomeProject.git" with the manifest:
+            """
+            manifest:
+                version: 0.0
+                projects:
+                    - name: SomeOtherProject
+                      dst: ../SomeOtherProject
+                      url: some-remote-server/SomeOtherProject.git
+                      tag: v1
+            """
+        And a git repository "SomeOtherProject.git"
+        When I run "dfetch update" in MyProject
+        Then the output shows
+            """
+            Dfetch (0.0.6)
+              SomeProject         : Fetched v1
+              SomeProject/SomeOtherProject: Fetched v1
+            """
+        And 'MyProject' looks like:
+            """
+            MyProject/
+                ThirdParty/
+                    SomeOtherProject/
+                        .dfetch_data.yaml
+                        README.md
+                    SomeProject/
+                        .dfetch_data.yaml
+                        README.md
+                        dfetch.yaml
+                dfetch.yaml
+            """

--- a/features/use-found-manifest-in-project.feature
+++ b/features/use-found-manifest-in-project.feature
@@ -104,6 +104,26 @@ Feature: Use found manifest in project
             """
         And a git repository "SomeOtherProject.git"
         And all projects are updated
+        Then the output shows
+            """
+            Dfetch (0.0.6)
+              SomeProject         : Fetched v1
+              SomeProject/SomeOtherProject: Fetched v1
+            """
+        Then 'MyProject' looks like:
+            """
+            MyProject/
+                ThirdParty/
+                    SomeOtherProject/
+                        .dfetch_data.yaml
+                        README.md
+                    SomeProject/
+                        .dfetch_data.yaml
+                        README.md
+                        dfetch.yaml
+                dfetch.yaml
+            """
+
         When I run "dfetch update" in MyProject
         Then the output shows
             """

--- a/features/use-found-manifest-in-project.feature
+++ b/features/use-found-manifest-in-project.feature
@@ -1,4 +1,3 @@
-@wip
 Feature: Use found manifest in project
 
     When a project has dependencies of its own, *Dfetch* should also fetch any dependencies in
@@ -128,7 +127,7 @@ Feature: Use found manifest in project
         Then the output shows
             """
             Dfetch (0.0.6)
-            Multiple manifests found, using .\dfetch.yaml
+            Multiple manifests found, using dfetch.yaml
               SomeProject         : up-to-date (v1)
               SomeProject/SomeOtherProject: up-to-date (v1)
             """

--- a/features/use-found-manifest-in-project.feature
+++ b/features/use-found-manifest-in-project.feature
@@ -79,3 +79,48 @@ Feature: Use found manifest in project
                         dfetch.yaml
                 dfetch.yaml
             """
+
+    Scenario: A second update is performed
+        Given the manifest 'dfetch.yaml' in MyProject
+            """
+            manifest:
+                version: 0.0
+                projects:
+                    - name: SomeProject
+                      dst: ThirdParty/SomeProject
+                      url: some-remote-server/SomeProject.git
+                      tag: v1
+            """
+        And a git-repository "SomeProject.git" with the manifest:
+            """
+            manifest:
+                version: 0.0
+                projects:
+                    - name: SomeOtherProject
+                      dst: ../SomeOtherProject
+                      url: some-remote-server/SomeOtherProject.git
+                      tag: v1
+            """
+        And a git repository "SomeOtherProject.git"
+        And all projects are updated
+        When I run "dfetch update" in MyProject
+        Then the output shows
+            """
+            Dfetch (0.0.6)
+            Multiple manifests found, using .\dfetch.yaml
+              SomeProject         : up-to-date (v1)
+              SomeProject/SomeOtherProject: up-to-date (v1)
+            """
+        And 'MyProject' looks like:
+            """
+            MyProject/
+                ThirdParty/
+                    SomeOtherProject/
+                        .dfetch_data.yaml
+                        README.md
+                    SomeProject/
+                        .dfetch_data.yaml
+                        README.md
+                        dfetch.yaml
+                dfetch.yaml
+            """

--- a/features/use-found-manifest-in-project.feature
+++ b/features/use-found-manifest-in-project.feature
@@ -1,3 +1,4 @@
+@wip
 Feature: Use found manifest in project
 
     When a project has dependencies of its own, *Dfetch* should also fetch any dependencies in
@@ -66,7 +67,7 @@ Feature: Use found manifest in project
             """
             Dfetch (0.0.6)
               SomeProject         : Fetched v1
-            ThirdParty\SomeProject\dfetch.yaml: Schema validation failed:
+            ThirdParty/SomeProject/dfetch.yaml: Schema validation failed:
              - Value 'very-invalid-manifest' is not a dict. Value path: ''.
             """
         And 'MyProject' looks like:

--- a/features/use-found-manifest-in-project.feature
+++ b/features/use-found-manifest-in-project.feature
@@ -1,4 +1,3 @@
-@wip
 Feature: Use found manifest in project
 
     When a project has dependencies of its own, *Dfetch* should also fetch any dependencies in
@@ -40,6 +39,40 @@ Feature: Use found manifest in project
                     SomeOtherProject/
                         .dfetch_data.yaml
                         README.md
+                    SomeProject/
+                        .dfetch_data.yaml
+                        README.md
+                        dfetch.yaml
+                dfetch.yaml
+            """
+
+    Scenario: A subproject has an invalid manifest
+        Given the manifest 'dfetch.yaml' in MyProject
+            """
+            manifest:
+                version: 0.0
+                projects:
+                    - name: SomeProject
+                      dst: ThirdParty/SomeProject
+                      url: some-remote-server/SomeProject.git
+                      tag: v1
+            """
+        And a git-repository "SomeProject.git" with the manifest:
+            """
+            very-invalid-manifest
+            """
+        When I run "dfetch update" in MyProject
+        Then the output shows
+            """
+            Dfetch (0.0.6)
+              SomeProject         : Fetched v1
+            ThirdParty\SomeProject\dfetch.yaml: Schema validation failed:
+             - Value 'very-invalid-manifest' is not a dict. Value path: ''.
+            """
+        And 'MyProject' looks like:
+            """
+            MyProject/
+                ThirdParty/
                     SomeProject/
                         .dfetch_data.yaml
                         README.md

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -45,14 +45,19 @@ def test_check(name, projects):
             "dfetch.manifest.manifest.get_childmanifests"
         ) as mocked_get_childmanifests:
             with patch("dfetch.project.make") as mocked_make:
+                with patch("os.path.exists"):
+                    with patch("dfetch.commands.check.in_directory"):
 
-                mocked_get_manifest.return_value = (mock_manifest(name, projects), "/")
-                mocked_get_childmanifests.return_value = []
+                        mocked_get_manifest.return_value = (
+                            mock_manifest(name, projects),
+                            "/",
+                        )
+                        mocked_get_childmanifests.return_value = []
 
-                check(DEFAULT_ARGS)
+                        check(DEFAULT_ARGS)
 
-                for project in projects:
-                    mocked_make.return_value.check_for_update.assert_called()
+                        for project in projects:
+                            mocked_make.return_value.check_for_update.assert_called()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -13,6 +13,8 @@ from dfetch.commands.check import Check
 from dfetch.manifest.manifest import Manifest
 from dfetch.manifest.project import ProjectEntry
 
+DEFAULT_ARGS = argparse.Namespace(non_recursive=False)
+
 
 def mock_manifest(name, projects):
 
@@ -39,11 +41,15 @@ def test_check(name, projects):
     check = Check()
 
     with patch("dfetch.manifest.manifest.get_manifest") as mocked_get_manifest:
-        with patch("dfetch.project.make") as mocked_make:
+        with patch(
+            "dfetch.manifest.manifest.get_childmanifests"
+        ) as mocked_get_childmanifests:
+            with patch("dfetch.project.make") as mocked_make:
 
-            mocked_get_manifest.return_value = (mock_manifest(name, projects), "/")
+                mocked_get_manifest.return_value = (mock_manifest(name, projects), "/")
+                mocked_get_childmanifests.return_value = []
 
-            check(argparse.Namespace)
+                check(DEFAULT_ARGS)
 
-            for project in projects:
-                mocked_make.return_value.check_for_update.assert_called()
+                for project in projects:
+                    mocked_make.return_value.check_for_update.assert_called()

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -53,3 +53,30 @@ def test_check(name, projects):
 
                 for project in projects:
                     mocked_make.return_value.check_for_update.assert_called()
+
+
+@pytest.mark.parametrize(
+    "name, projects",
+    [
+        ("empty", []),
+        ("single_project", [{"name": "my_project"}]),
+        ("two_projects", [{"name": "first"}, {"name": "second"}]),
+    ],
+)
+def test_check_child_manifests(name, projects):
+
+    parent = ProjectEntry({"name": "parent"})
+
+    with patch(
+        "dfetch.manifest.manifest.get_childmanifests"
+    ) as mocked_get_childmanifests:
+        with patch("dfetch.project.make") as mocked_make:
+
+            mocked_get_childmanifests.return_value = [
+                (mock_manifest(name, projects), "/")
+            ]
+
+            Check._check_child_manifests(parent, "somepath")
+
+            for project in projects:
+                mocked_make.return_value.check_for_update.assert_called()

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -14,6 +14,8 @@ from dfetch.manifest.manifest import Manifest
 from dfetch.project.git import Submodule
 from dfetch.project.svn import External
 
+DEFAULT_ARGS = argparse.Namespace(non_recursive=False)
+
 FIRST_SUBMODULE = Submodule(
     name="submod1",
     sha="1234",

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -9,7 +9,7 @@ import pytest
 
 import dfetch.manifest.manifest
 from dfetch import DEFAULT_MANIFEST_NAME
-from dfetch.manifest.manifest import Manifest, find_manifest, get_submanifests
+from dfetch.manifest.manifest import Manifest, find_manifest, get_childmanifests
 from dfetch.manifest.project import ProjectEntry
 
 BASIC_MANIFEST = u"""
@@ -121,20 +121,20 @@ def test_single_manifest_found() -> None:
     "name, manifest_paths",
     [
         (
-            "no-submanifests",
+            "no-childmanifests",
             [],
         ),
         (
-            "single-submanifest",
+            "single-childmanifest",
             ["some-manifest.yaml"],
         ),
         (
-            "multi-submanifests",
+            "multi-childmanifests",
             ["some-manifest.yaml", "some-other-manifest.yaml"],
         ),
     ],
 )
-def test_get_submanifests(name, manifest_paths) -> None:
+def test_get_childmanifests(name, manifest_paths) -> None:
 
     parent = ProjectEntry({"name": "parent"})
 
@@ -143,8 +143,8 @@ def test_get_submanifests(name, manifest_paths) -> None:
             with patch("dfetch.manifest.manifest.Manifest"):
                 find_file_mock.return_value = manifest_paths
 
-                found_submanifests = get_submanifests(parent)
+                found_childmanifests = get_childmanifests(parent)
 
-                assert len(found_submanifests) == len(manifest_paths)
-                for path, result in zip(manifest_paths, found_submanifests):
+                assert len(found_childmanifests) == len(manifest_paths)
+                for path, result in zip(manifest_paths, found_childmanifests):
                     assert os.path.realpath(path) == result[1]

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -105,8 +105,7 @@ def test_multiple_manifests_found() -> None:
 
         find_file_mock.return_value = [DEFAULT_MANIFEST_NAME, "manifest2.yaml"]
 
-        with pytest.raises(RuntimeError):
-            find_manifest()
+        assert os.path.realpath(DEFAULT_MANIFEST_NAME) == find_manifest()
 
 
 def test_single_manifest_found() -> None:

--- a/tests/test_project_entry.py
+++ b/tests/test_project_entry.py
@@ -1,0 +1,44 @@
+"""Test the Version object command."""
+# mypy: ignore-errors
+# flake8: noqa
+
+import pytest
+
+from dfetch.manifest.project import ProjectEntry
+
+
+def test_projectentry_name():
+    assert ProjectEntry({"name": "SomeProject"}).name == "SomeProject"
+
+
+def test_projectentry_revision():
+    assert ProjectEntry({"name": "SomeProject", "revision": "123"}).revision == "123"
+
+
+def test_projectentry_remote():
+    assert (
+        ProjectEntry({"name": "SomeProject", "remote": "SomeRemote"}).remote
+        == "SomeRemote"
+    )
+
+
+def test_projectentry_source():
+    assert ProjectEntry({"name": "SomeProject", "src": "SomePath"}).source == "SomePath"
+
+
+def test_projectentry_vcs():
+    assert ProjectEntry({"name": "SomeProject", "vcs": "git"}).vcs == "git"
+
+
+def test_projectentry_as_yaml():
+    assert ProjectEntry({"name": "SomeProject"}).as_yaml() == {
+        "name": "SomeProject",
+        "dst": "SomeProject",
+    }
+
+
+def test_projectentry_as_str():
+    assert (
+        str(ProjectEntry({"name": "SomeProject"}))
+        == "SomeProject          latest  SomeProject"
+    )

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,0 +1,24 @@
+"""Test the resources."""
+# mypy: ignore-errors
+# flake8: noqa
+
+import os
+
+import dfetch.resources
+
+
+def test_schema_path() -> None:
+    """Test that schema path can be used as context manager."""
+
+    with dfetch.resources.schema_path() as schema_path:
+        assert os.path.isfile(schema_path)
+
+
+def test_call_schema_path_twice() -> None:
+    """Had a lot of problems with calling contextmanager twice."""
+
+    with dfetch.resources.schema_path() as schema_path:
+        assert os.path.isfile(schema_path)
+
+    with dfetch.resources.schema_path() as schema_path:
+        assert os.path.isfile(schema_path)

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -39,11 +39,15 @@ def test_update(name, projects):
     update = Update()
 
     with patch("dfetch.manifest.manifest.get_manifest") as mocked_get_manifest:
-        with patch("dfetch.project.make") as mocked_make:
+        with patch(
+            "dfetch.manifest.manifest.get_submanifests"
+        ) as mocked_get_submanifests:
+            with patch("dfetch.project.make") as mocked_make:
 
-            mocked_get_manifest.return_value = (mock_manifest(name, projects), "/")
+                mocked_get_manifest.return_value = (mock_manifest(name, projects), "/")
+                mocked_get_submanifests.return_value = []
 
-            update(argparse.Namespace)
+                update(argparse.Namespace)
 
-            for project in projects:
-                mocked_make.return_value.update.assert_called()
+                for project in projects:
+                    mocked_make.return_value.update.assert_called()

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -40,12 +40,12 @@ def test_update(name, projects):
 
     with patch("dfetch.manifest.manifest.get_manifest") as mocked_get_manifest:
         with patch(
-            "dfetch.manifest.manifest.get_submanifests"
-        ) as mocked_get_submanifests:
+            "dfetch.manifest.manifest.get_childmanifests"
+        ) as mocked_get_childmanifests:
             with patch("dfetch.project.make") as mocked_make:
 
                 mocked_get_manifest.return_value = (mock_manifest(name, projects), "/")
-                mocked_get_submanifests.return_value = []
+                mocked_get_childmanifests.return_value = []
 
                 update(argparse.Namespace)
 

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -13,6 +13,8 @@ from dfetch.commands.update import Update
 from dfetch.manifest.manifest import Manifest
 from dfetch.manifest.project import ProjectEntry
 
+DEFAULT_ARGS = argparse.Namespace(non_recursive=False)
+
 
 def mock_manifest(name, projects):
 
@@ -47,7 +49,7 @@ def test_update(name, projects):
                 mocked_get_manifest.return_value = (mock_manifest(name, projects), "/")
                 mocked_get_childmanifests.return_value = []
 
-                update(argparse.Namespace)
+                update(DEFAULT_ARGS)
 
                 for project in projects:
                     mocked_make.return_value.update.assert_called()

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -45,11 +45,15 @@ def test_update(name, projects):
             "dfetch.manifest.manifest.get_childmanifests"
         ) as mocked_get_childmanifests:
             with patch("dfetch.project.make") as mocked_make:
+                with patch("os.path.exists"):
+                    with patch("dfetch.commands.update.in_directory"):
+                        mocked_get_manifest.return_value = (
+                            mock_manifest(name, projects),
+                            "/",
+                        )
+                        mocked_get_childmanifests.return_value = []
 
-                mocked_get_manifest.return_value = (mock_manifest(name, projects), "/")
-                mocked_get_childmanifests.return_value = []
+                        update(DEFAULT_ARGS)
 
-                update(DEFAULT_ARGS)
-
-                for project in projects:
-                    mocked_make.return_value.update.assert_called()
+                        for project in projects:
+                            mocked_make.return_value.update.assert_called()


### PR DESCRIPTION
Issue #99  describes that fetched project could also have manifests

This PR implements it by:

Adding the concept of a parent for ProjectEntries.
During an update after each project, subprojects are searched inside the parent-project.