### PR TITLE
Feature/retain license

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ Release 0.0.9 (under development)
 
 * Add copyright notices to documentation
 * Make it possible to check/update child-projects (#99)
+* Keep license files from repo, even when only checking only subdir (#50)
 
 Release 0.0.8 (released 2021-02-14)
 ===================================

--- a/dfetch/commands/check.py
+++ b/dfetch/commands/check.py
@@ -59,7 +59,7 @@ class Check(dfetch.commands.command.Command):
                 with catch_runtime_exceptions(exceptions) as exceptions:
                     dfetch.project.make(project).check_for_update()
 
-                if not args.non_recursive and os.path.exists(project.destination):
+                if not args.non_recursive and os.path.isdir(project.destination):
                     with in_directory(project.destination):
                         exceptions += Check._check_child_manifests(project, path)
 

--- a/dfetch/commands/update.py
+++ b/dfetch/commands/update.py
@@ -62,7 +62,7 @@ class Update(dfetch.commands.command.Command):
                 with catch_runtime_exceptions(exceptions) as exceptions:
                     dfetch.project.make(project).update()
 
-                if not args.non_recursive and os.path.exists(project.destination):
+                if not args.non_recursive and os.path.isdir(project.destination):
                     with in_directory(project.destination):
                         exceptions += Update.__update_child_manifests(project, path)
 

--- a/dfetch/manifest/project.py
+++ b/dfetch/manifest/project.py
@@ -95,11 +95,8 @@ In larger projects or mono-repo's it is often desirable to retrieve only a subfo
 of an external project. *Dfetch* makes this possible through the ``src:`` attribute.
 
 For instance if you are only interested in the ``src`` folder of ``cpputest`` you can
-limit the checkout to only that folder.
-
-.. note::
-    *Dfetch* (currently) will only checkout that folder, it could be that you are not compliant
-    with a software license. Please check the original project's license and also comply with that.
+limit the checkout to only that folder. *Dfetch* will retain any license file in the
+root of the repository.
 
 .. code-block:: yaml
 

--- a/dfetch/project/git.py
+++ b/dfetch/project/git.py
@@ -192,7 +192,7 @@ class GitRepo(VCS):
         if src:
             run_on_cmdline(logger, "git config core.sparsecheckout true")
             with open(".git/info/sparse-checkout", "a") as sparse_checkout_file:
-                sparse_checkout_file.write("\n".join(["/" + src, "LICENSE", "COPYING"]))
+                sparse_checkout_file.write("\n".join(["/" + src, "LICENSE*", "COPYING*"]))
 
         run_on_cmdline(logger, f"git fetch --depth 1 origin {version}")
         run_on_cmdline(logger, "git reset --hard FETCH_HEAD")

--- a/dfetch/project/git.py
+++ b/dfetch/project/git.py
@@ -192,7 +192,9 @@ class GitRepo(VCS):
         if src:
             run_on_cmdline(logger, "git config core.sparsecheckout true")
             with open(".git/info/sparse-checkout", "a") as sparse_checkout_file:
-                sparse_checkout_file.write("\n".join(["/" + src, "LICENSE*", "COPYING*"]))
+                sparse_checkout_file.write(
+                    "\n".join(["/" + src, "LICENSE*", "COPYING*"])
+                )
 
         run_on_cmdline(logger, f"git fetch --depth 1 origin {version}")
         run_on_cmdline(logger, "git reset --hard FETCH_HEAD")

--- a/dfetch/project/git.py
+++ b/dfetch/project/git.py
@@ -192,7 +192,7 @@ class GitRepo(VCS):
         if src:
             run_on_cmdline(logger, "git config core.sparsecheckout true")
             with open(".git/info/sparse-checkout", "a") as sparse_checkout_file:
-                sparse_checkout_file.write("/" + src)
+                sparse_checkout_file.write("\n".join(["/" + src, "LICENSE", "COPYING"]))
 
         run_on_cmdline(logger, f"git fetch --depth 1 origin {version}")
         run_on_cmdline(logger, "git reset --hard FETCH_HEAD")

--- a/dfetch/project/svn.py
+++ b/dfetch/project/svn.py
@@ -189,6 +189,17 @@ class SvnRepo(VCS):
             logger, f"svn export --force {rev_arg} {complete_path} {self.local_path}"
         )
 
+        if self.source:
+            root_branch_path = "/".join([self.remote, branch_path]).strip("/")
+            try:
+                run_on_cmdline(logger, f"svn info {root_branch_path}/LICENSE")
+                run_on_cmdline(
+                    logger,
+                    f"svn export --force {rev_arg} {root_branch_path}/LICENSE {self.local_path}",
+                )
+            except SubprocessCommandError:
+                pass
+
         return Version(tag=version.tag, branch=branch, revision=revision)
 
     def _get_info(self, branch: str) -> Dict[str, str]:

--- a/dfetch/project/svn.py
+++ b/dfetch/project/svn.py
@@ -191,7 +191,11 @@ class SvnRepo(VCS):
             root_branch_path = "/".join([self.remote, branch_path]).strip("/")
 
             for file in SvnRepo._license_files(root_branch_path):
-                dest = self.local_path if os.path.isdir(self.local_path) else os.path.dirname(self.local_path)
+                dest = (
+                    self.local_path
+                    if os.path.isdir(self.local_path)
+                    else os.path.dirname(self.local_path)
+                )
                 SvnRepo._export(f"{root_branch_path}/{file}", rev_arg, dest)
                 break
 

--- a/dfetch/project/svn.py
+++ b/dfetch/project/svn.py
@@ -213,9 +213,12 @@ class SvnRepo(VCS):
 
     @staticmethod
     def _files_in_path(url_path: str) -> List[str]:
-        return (
-            run_on_cmdline(logger, f"svn list {url_path}").stdout.decode().splitlines()
-        )
+        return [
+            str(line)
+            for line in run_on_cmdline(logger, f"svn list {url_path}")
+            .stdout.decode()
+            .splitlines()
+        ]
 
     @staticmethod
     def _license_files(url_path: str) -> List[str]:

--- a/dfetch/project/vcs.py
+++ b/dfetch/project/vcs.py
@@ -69,7 +69,7 @@ class VCS(ABC):
             self._log_project(f"up-to-date ({current})")
             return None
 
-        logger.debug(self.__project.name, f"Current ({current}), Available ({wanted})")
+        logger.debug(f"{self.__project.name} Current ({current}), Available ({wanted})")
         return wanted
 
     def update(self) -> None:

--- a/features/keep-license-in-project.feature
+++ b/features/keep-license-in-project.feature
@@ -5,7 +5,7 @@ Feature: Keep license in project
     When fetching only a part of a repository with the 'src:' tag, the risk
     is you forget the license file.
 
-    Scenario:
+    Scenario: License is preserved in git repo sparse checkout
         Given the manifest 'dfetch.yaml' in MyProject
             """
             manifest:
@@ -26,6 +26,37 @@ Feature: Keep license in project
             """
             Dfetch (0.0.6)
               SomeProjectWithLicense: Fetched v1
+            """
+        Then 'MyProject' looks like:
+            """
+            MyProject/
+                SomeProjectWithLicense/
+                    .dfetch_data.yaml
+                    LICENSE
+                    SomeFile.txt
+                dfetch.yaml
+            """
+
+    Scenario: License is preserved in svn repo sparse checkout
+        Given the manifest 'dfetch.yaml' in MyProject
+            """
+            manifest:
+                version: 0.0
+                projects:
+                    - name: SomeProjectWithLicense
+                      url: some-remote-server/SomeProjectWithLicense
+                      src: SomeFolder/
+            """
+        And a svn-server "SomeProjectWithLicense" with the files
+            | path                                  |
+            | LICENSE                               |
+            | SomeFolder/SomeFile.txt               |
+            | SomeOtherFolder/SomeOtherFile.txt     |
+        When I run "dfetch update"
+        Then the output shows
+            """
+            Dfetch (0.0.6)
+              SomeProjectWithLicense: Fetched trunk - 1
             """
         Then 'MyProject' looks like:
             """

--- a/features/keep-license-in-project.feature
+++ b/features/keep-license-in-project.feature
@@ -1,0 +1,38 @@
+Feature: Keep license in project
+
+    A lot of people in the world do a lot of hard work to create software
+    to use freely. They only ask to keep the license with their code.
+    When fetching only a part of a repository with the 'src:' tag, the risk
+    is you forget the license file.
+
+    Scenario:
+        Given the manifest 'dfetch.yaml' in MyProject
+            """
+            manifest:
+                version: 0.0
+                projects:
+                    - name: SomeProjectWithLicense
+                      url: some-remote-server/SomeProjectWithLicense.git
+                      src: SomeFolder/
+                      tag: v1
+            """
+        And a git-repository "SomeProjectWithLicense.git" with the files
+            | path                                  |
+            | LICENSE                               |
+            | SomeFolder/SomeFile.txt               |
+            | SomeOtherFolder/SomeOtherFile.txt     |
+        When I run "dfetch update"
+        Then the output shows
+            """
+            Dfetch (0.0.6)
+              SomeProjectWithLicense: Fetched v1
+            """
+        Then 'MyProject' looks like:
+            """
+            MyProject/
+                SomeProjectWithLicense/
+                    .dfetch_data.yaml
+                    LICENSE
+                    SomeFile.txt
+                dfetch.yaml
+            """

--- a/features/keep-license-in-project.feature
+++ b/features/keep-license-in-project.feature
@@ -67,3 +67,34 @@ Feature: Keep license in project
                     SomeFile.txt
                 dfetch.yaml
             """
+
+    Scenario: A single file is fetched from svn repo
+        Given the manifest 'dfetch.yaml' in MyProject
+            """
+            manifest:
+                version: 0.0
+                projects:
+                    - name: SomeProjectWithLicense
+                      dst: SomeFile.txt
+                      url: some-remote-server/SomeProjectWithLicense
+                      src: SomeFolder/SomeFile.txt
+            """
+        And a svn-server "SomeProjectWithLicense" with the files
+            | path                                  |
+            | COPYING.txt                           |
+            | SomeFolder/SomeFile.txt               |
+            | SomeOtherFolder/SomeOtherFile.txt     |
+        When I run "dfetch update"
+        Then the output shows
+            """
+            Dfetch (0.0.6)
+              SomeProjectWithLicense: Fetched trunk - 1
+            """
+        Then 'MyProject' looks like:
+            """
+            MyProject/
+                .dfetch_data-SomeFile.txt.yaml
+                COPYING.txt
+                SomeFile.txt
+                dfetch.yaml
+            """

--- a/features/steps/generic_steps.py
+++ b/features/steps/generic_steps.py
@@ -2,6 +2,7 @@
 
 import difflib
 import os
+import pathlib
 import re
 import subprocess
 
@@ -12,6 +13,11 @@ dfetch_title = re.compile(r"Dfetch \(\d+.\d+.\d+\)")
 
 
 def generate_file(path, content):
+
+    opt_dir = path.rsplit("/", maxsplit=1)
+
+    if len(opt_dir) > 1:
+        pathlib.Path(opt_dir[0]).mkdir(parents=True, exist_ok=True)
 
     with open(path, "w") as new_file:
         for line in content.splitlines():

--- a/features/steps/git_steps.py
+++ b/features/steps/git_steps.py
@@ -67,3 +67,18 @@ def step_impl(context, name):
 
         commit_all("Initial commit")
         tag("v1")
+
+
+@given('a git-repository "{name}" with the files')
+def step_impl(context, name):
+    remote_path = os.path.join(context.remotes_dir, name)
+    pathlib.Path(remote_path).mkdir(parents=True, exist_ok=True)
+
+    with in_directory(remote_path):
+        create_repo()
+
+        for file in context.table:
+            generate_file(file["path"], "some content")
+
+        commit_all("Initial commit")
+        tag("v1")

--- a/features/steps/manifest_steps.py
+++ b/features/steps/manifest_steps.py
@@ -13,7 +13,7 @@ def generate_manifest(context, name="dfetch.yaml", path=None):
     abs_server_path = "/".join(context.remotes_dir_path.split(os.sep))
 
     manifest = context.text.replace(
-        "url: some-remote-server", f"url: {abs_server_path}"
+        "url: some-remote-server", f"url: file:///{abs_server_path}"
     )
     generate_file(os.path.join(path or os.getcwd(), name), manifest)
 

--- a/features/steps/svn_steps.py
+++ b/features/steps/svn_steps.py
@@ -1,23 +1,43 @@
 """Steps for features tests."""
 
 import os
+import pathlib
 import subprocess
 
 from behave import given  # pylint: disable=no-name-in-module
 
+from dfetch.util.util import in_directory
+from features.steps.generic_steps import generate_file, list_dir
 
-def create_svn_server_and_repo():
+
+def create_svn_server_and_repo(context, name="svn-server"):
     """Create an local svn server and repo and return the path to the repo."""
 
-    server_path = "svn-server"
+    server_path = os.path.relpath(context.remotes_dir_path) + "/" + name
     repo_path = "svn-repo"
 
+    pathlib.Path(server_path).mkdir(parents=True, exist_ok=True)
     subprocess.call(["svnadmin", "create", "--fs-type", "fsfs", server_path])
 
     current_path = "/".join(os.getcwd().split(os.path.sep) + [server_path])
     subprocess.call(["svn", "checkout", f"file:///{current_path}", repo_path])
 
     return repo_path
+
+
+def create_stdlayout():
+    pathlib.Path("trunk").mkdir(parents=True, exist_ok=True)
+    pathlib.Path("branches").mkdir(parents=True, exist_ok=True)
+    pathlib.Path("tags").mkdir(parents=True, exist_ok=True)
+
+
+def add_and_commit(msg):
+    subprocess.call(["svn", "add", "--force", "."])
+    subprocess.call(["svn", "ci", "-m", f'"{msg}"'])
+
+
+def commit_all(msg):
+    subprocess.call(["svn", "commit", "--depth", "empty", ".", "-m", f'"{msg}"'])
 
 
 def add_externals(externals):
@@ -29,15 +49,26 @@ def add_externals(externals):
             )
 
     subprocess.call(["svn", "propset", "svn:externals", "-F", external_list.name, "."])
-    subprocess.call(
-        ["svn", "commit", "--depth", "empty", ".", "-m", '"Added externals"']
-    )
+    commit_all("Added externals")
     subprocess.call(["svn", "update"])
 
 
 @given("a svn repo with the following externals")
 def step_impl(context):
 
-    repo_path = create_svn_server_and_repo()
+    repo_path = create_svn_server_and_repo(context)
     os.chdir(repo_path)
     add_externals(context.table)
+
+
+@given('a svn-server "{name}" with the files')
+def step_impl(context, name):
+    repo_path = create_svn_server_and_repo(context, name)
+
+    with in_directory(repo_path):
+
+        create_stdlayout()
+        with in_directory("trunk"):
+            for file in context.table:
+                generate_file(file["path"], "some content")
+        add_and_commit("Added files")

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -23,6 +23,7 @@ def mock_manifest(name, projects):
     for project in projects:
         mock_project = Mock(spec=ProjectEntry)
         mock_project.name = project["name"]
+        mock_project.destination = "some_dest"
         project_mocks += [mock_project]
 
     return MagicMock(spec=Manifest, projects=project_mocks)

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -23,6 +23,7 @@ def mock_manifest(name, projects):
     for project in projects:
         mock_project = Mock(spec=ProjectEntry)
         mock_project.name = project["name"]
+        mock_project.destination = "some_dest"
         project_mocks += [mock_project]
 
     return MagicMock(spec=Manifest, projects=project_mocks)


### PR DESCRIPTION
In #50 it is described a license should be parsed. As a first step, when `src:` keyword is used, at least retain the license with the code.