### PR TITLE
Feature/guard against overwriting changes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Release 0.0.9 (under development)
 * Add copyright notices to documentation
 * Make it possible to check/update child-projects (#99)
 * Keep license files from repo, even when only checking only subdir (#50)
+* Guard against overwriting local changes (#93)
+* Add ``--force`` flag to ``dfetch update``
 
 Release 0.0.8 (released 2021-02-14)
 ===================================

--- a/dfetch/commands/update.py
+++ b/dfetch/commands/update.py
@@ -46,14 +46,14 @@ class Update(dfetch.commands.command.Command):
         """Add the menu for the update action."""
         parser = dfetch.commands.command.Command.parser(subparsers, Update)
         parser.add_argument(
-            "--non-recursive",
             "-N",
+            "--non-recursive",
             action="store_true",
             help="Don't recursively check for child manifests.",
         )
         parser.add_argument(
-            "--force",
             "-f",
+            "--force",
             action="store_true",
             help="Always perform update, ignoring version check or local changes.",
         )

--- a/dfetch/project/vcs.py
+++ b/dfetch/project/vcs.py
@@ -192,7 +192,7 @@ class VCS(ABC):
         )
 
     def _on_disk_hash(self) -> Optional[str]:
-        """Get the hash of the project on disk
+        """Get the hash of the project on disk.
 
         Returns:
             Str: Could be None if no on disk version
@@ -217,11 +217,12 @@ class VCS(ABC):
         """Check if there are local changes.
 
         Returns:
-           Bool: True if there are local changes, false if no were detected or no hash was found."""
+          Bool: True if there are local changes, false if no were detected or no hash was found.
+        """
         logger.debug(f"Checking if there were local changes in {self.local_path}")
         on_disk_hash = self._on_disk_hash()
 
-        return on_disk_hash and on_disk_hash != hash_directory(
+        return bool(on_disk_hash) and on_disk_hash != hash_directory(
             self.local_path, skiplist=[self.__metadata.FILENAME]
         )
 

--- a/dfetch/project/vcs.py
+++ b/dfetch/project/vcs.py
@@ -61,25 +61,35 @@ class VCS(ABC):
             Version(revision=on_disk.revision, branch=on_disk_branch),
         )
 
-    def update_is_required(self) -> Optional[Version]:
-        """Check if this project should be upgraded."""
+    def update_is_required(self, force: bool = False) -> Optional[Version]:
+        """Check if this project should be upgraded.
+
+        Args:
+            force (bool, optional): Ignore if versions match.
+                                    Defaults to False.
+        """
         wanted, current = self.check_wanted_with_local()
 
-        if wanted == current:
+        if not force and wanted == current:
             self._log_project(f"up-to-date ({current})")
             return None
 
         logger.debug(f"{self.__project.name} Current ({current}), Available ({wanted})")
         return wanted
 
-    def update(self) -> None:
-        """Update this VCS if required."""
-        to_fetch = self.update_is_required()
+    def update(self, force: bool = False) -> None:
+        """Update this VCS if required.
+
+        Args:
+            force (bool, optional): Ignore if version is ok or any local changes were done.
+                                    Defaults to False.
+        """
+        to_fetch = self.update_is_required(force)
 
         if not to_fetch:
             return
 
-        if self._are_there_local_changes():
+        if not force and self._are_there_local_changes():
             self._log_project(
                 "skipped - local changes after last update (use --force to overwrite)"
             )

--- a/doc/static/uml/update.puml
+++ b/doc/static/uml/update.puml
@@ -6,11 +6,20 @@ skinparam defaultFontName Frutiger
 
 partition "Update required" {
 
-    if (Project + Metadata on disk?) then (no)
-    elseif (Version in metadata,\nsame as in manifest?) then (no)
-    else (yes)
+    if (Project +\nMetadata on disk?) then (no)
+    elseif (Force flag given?) then (yes)
+    elseif (Version in metadata,\nsame as in manifest?) then (yes)
         stop
+    elseif (Hash on disk same\nas in metadata?) then (yes)
+    else (no)
+       stop
     endif
+
+    ' if (Hash on disk same\nas in metadata?) then (yes)
+    ' elseif (Force flag given?) then (yes)
+    ' else
+    '     stop
+    ' endif
 }
 
 partition "Prepare for update" {

--- a/features/fetch-git-repo.feature
+++ b/features/fetch-git-repo.feature
@@ -66,3 +66,23 @@ Feature: Fetching dependencies from a git repository
             Dfetch (0.0.6)
               ext/test-repo-tag   : Fetched v2.0
             """
+
+    Scenario: Version check ignored when force flag is given
+        Given the manifest 'dfetch.yaml'
+            """
+            manifest:
+              version: '0.0'
+
+              projects:
+                - name: ext/test-repo-tag
+                  url: https://github.com/dfetch-org/test-repo
+                  tag: v1
+
+            """
+        And all projects are updated
+        When I run "dfetch update --force"
+        Then the output shows
+            """
+            Dfetch (0.0.6)
+              ext/test-repo-tag   : Fetched v1
+            """

--- a/features/guard-against-overwriting.feature
+++ b/features/guard-against-overwriting.feature
@@ -1,0 +1,16 @@
+Feature: Guard against overwriting
+
+    Accidentally overwriting local changes could lead to introducing regressions.
+    To make developers aware of overwriting, store hash after an update and compare
+    this with hashes just before an update.
+
+    Scenario: No update is done when hash is different
+
+        Given MyProject with dependency "SomeProject.git" that must be updated
+        When "SomeProject/README.md" in MyProject is changed locally
+        And I run "dfetch update"
+        Then the output shows
+            """
+            Dfetch (0.0.6)
+              SomeProject         : skipped - local changes after last update (use --force to overwrite)
+            """

--- a/features/guard-against-overwriting.feature
+++ b/features/guard-against-overwriting.feature
@@ -5,7 +5,6 @@ Feature: Guard against overwriting
     this with hashes just before an update.
 
     Scenario: No update is done when hash is different
-
         Given MyProject with dependency "SomeProject.git" that must be updated
         When "SomeProject/README.md" in MyProject is changed locally
         And I run "dfetch update"
@@ -13,4 +12,14 @@ Feature: Guard against overwriting
             """
             Dfetch (0.0.6)
               SomeProject         : skipped - local changes after last update (use --force to overwrite)
+            """
+
+    Scenario: Force flag overrides local changes check
+        Given MyProject with dependency "SomeProject.git" that must be updated
+        When "SomeProject/README.md" in MyProject is changed locally
+        And I run "dfetch update --force"
+        Then the output shows
+            """
+            Dfetch (0.0.6)
+              SomeProject         : Fetched v2
             """

--- a/features/steps/generic_steps.py
+++ b/features/steps/generic_steps.py
@@ -8,6 +8,8 @@ import subprocess
 
 from behave import given, then, when  # pylint: disable=no-name-in-module
 
+from dfetch.util.util import in_directory
+
 ansi_escape = re.compile(r"\x1b(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
 dfetch_title = re.compile(r"Dfetch \(\d+.\d+.\d+\)")
 
@@ -81,6 +83,13 @@ def step_impl(context, cmd, path=None):
     except subprocess.CalledProcessError as exc:
         context.cmd_output = dfetch_title.sub("", exc.stdout)
         context.cmd_returncode = exc.returncode
+
+
+@when('"{path}" in {directory} is changed locally')
+def step_impl(context, directory, path):
+
+    with in_directory(directory):
+        extend_file(path, "Some text")
 
 
 @then("the output shows")

--- a/features/steps/git_steps.py
+++ b/features/steps/git_steps.py
@@ -82,3 +82,32 @@ def step_impl(context, name):
 
         commit_all("Initial commit")
         tag("v1")
+
+
+@given('MyProject with dependency "SomeProject.git" that must be updated')
+def step_impl(context):
+    context.execute_steps(
+        '''
+        Given the manifest 'dfetch.yaml' in MyProject
+            """
+            manifest:
+                version: 0.0
+                projects:
+                    - name: SomeProject
+                      url: some-remote-server/SomeProject.git
+                      tag: v1
+            """
+        And a git repository "SomeProject.git"
+        And all projects are updated in MyProject
+        And a new tag "v2" is added to git-repository "SomeProject.git"
+        When the manifest 'dfetch.yaml' in MyProject is changed to
+            """
+            manifest:
+                version: 0.0
+                projects:
+                    - name: SomeProject
+                      url: some-remote-server/SomeProject.git
+                      tag: v2
+            """
+        '''
+    )

--- a/features/steps/manifest_steps.py
+++ b/features/steps/manifest_steps.py
@@ -21,6 +21,7 @@ def generate_manifest(context, name="dfetch.yaml", path=None):
 @given("the manifest '{name}' in {path}")
 @given("the manifest '{name}'")
 @when("the manifest '{name}' is changed to")
+@when("the manifest '{name}' in {path} is changed to")
 def step_impl(context, name, path=None):
 
     if path:

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -85,3 +85,21 @@ def test_forced_update():
                         mocked_make.return_value.update.assert_called_once_with(
                             force=True
                         )
+
+
+def test_create_menu():
+
+    subparsers = argparse.ArgumentParser().add_subparsers()
+
+    Update.create_menu(subparsers)
+
+    assert "update" in subparsers.choices
+
+    options = [
+        ["-h", "--help"],
+        ["-N", "--non-recursive"],
+        ["-f", "--force"],
+    ]
+
+    for action, expected_options in zip(subparsers.choices["update"]._actions, options):
+        assert action.option_strings == expected_options

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -14,6 +14,7 @@ from dfetch.manifest.manifest import Manifest
 from dfetch.manifest.project import ProjectEntry
 
 DEFAULT_ARGS = argparse.Namespace(non_recursive=False)
+DEFAULT_ARGS.force = False
 
 
 def mock_manifest(name, projects):

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -59,3 +59,29 @@ def test_update(name, projects):
 
                         for project in projects:
                             mocked_make.return_value.update.assert_called()
+
+
+def test_forced_update():
+
+    update = Update()
+
+    with patch("dfetch.manifest.manifest.get_manifest") as mocked_get_manifest:
+        mocked_get_manifest.return_value = (
+            mock_manifest("MyProject", [{"name": "some_project"}]),
+            "/",
+        )
+        with patch(
+            "dfetch.manifest.manifest.get_childmanifests"
+        ) as mocked_get_childmanifests:
+            with patch("dfetch.project.make") as mocked_make:
+                with patch("os.path.exists"):
+                    with patch("dfetch.commands.update.in_directory"):
+                        mocked_get_childmanifests.return_value = []
+
+                        args = DEFAULT_ARGS
+                        args.force = True
+
+                        update(args)
+                        mocked_make.return_value.update.assert_called_once_with(
+                            force=True
+                        )

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -97,3 +97,24 @@ def test_check_wanted_with_local(
 
             assert wanted == expect_wanted
             assert have == expect_have
+
+
+@pytest.mark.parametrize(
+    "name, hash_in_metadata, current_hash, expectation",
+    [
+        ("no-hash", "", "1234", False),
+        ("different-hash", "5678", "1234", True),
+        ("same-hash", "1234", "1234", False),
+    ],
+)
+def test_are_there_local_changes(name, hash_in_metadata, current_hash, expectation):
+
+    with patch("dfetch.project.vcs.hash_directory") as mocked_hash_directory:
+        with patch("dfetch.project.vcs.VCS._on_disk_hash") as mocked_on_disk_hash:
+
+            vcs = ConcreteVCS(ProjectEntry({"name": "proj1"}))
+
+            mocked_on_disk_hash.return_value = hash_in_metadata
+            mocked_hash_directory.return_value = current_hash
+
+            assert expectation == vcs._are_there_local_changes()


### PR DESCRIPTION
When updating a project, check if the hash in the local directory is different with respect to the hash in the metadata file. If not skip the project to avoid overwriting local changes.

In order to force an update, add a `--force` flag to `dfetch update`. This will also bypass the version check.