### PR TITLE
Use other method to set default branch

### DIFF
--- a/features/steps/git_steps.py
+++ b/features/steps/git_steps.py
@@ -12,7 +12,9 @@ from features.steps.manifest_steps import generate_manifest
 
 
 def create_repo():
-    subprocess.call(["git", "init", "--initial-branch=master"])
+    subprocess.call(["git", "config", "init.defaultBranch", "master"])
+    subprocess.call(["git", "init"])
+
     subprocess.call(["git", "config", "user.email", "you@example.com"])
     subprocess.call(["git", "config", "user.name", "John Doe"])
 


### PR DESCRIPTION
Support old git clients (pre 2.28.0) without support for initial-branch option and newer.

My ubuntu installation has an older git client (2.27.0) which doesn't support the initial-branch option. This method should work on older and newer git clients.