### PR TITLE
Feature/improve debugging

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -26,4 +26,7 @@ def before_scenario(context, scenario):
 
 
 def before_all(context):
+    context.config.log_capture = True
+    context.config.logging_format = "%(message)s"
+
     context.remotes_dir = "some-remote-server"


### PR DESCRIPTION
#143 was started for @jgeudens  who noticed debugging of dfetch during feature tests was hard.
This MR lets dfetch run as python script instead of subprocess. This enables debugging.

To keep the tests working, the output must be captured using the logging capture feature of Behave.
 This is enabled in the `before_all` hook and the captured log is cleared and stored in the regular `context.cmd_output`.

There is still a feature test failing, which needs some attention. I was under the impression the main implementation hasn't changed, but there seems to be an effect I'm unaware of.


Failing scenarios:
  features/update-child-projects.feature:57  A child-project has an invalid manifest
