### PR TITLE
Allow dst on single file checkout (#120)

### DIFF
--- a/dfetch/project/git.py
+++ b/dfetch/project/git.py
@@ -200,9 +200,14 @@ class GitRepo(VCS):
         run_on_cmdline(logger, "git reset --hard FETCH_HEAD")
 
         if src:
-            for file_to_copy in os.listdir(src):
-                shutil.move(src + "/" + file_to_copy, ".")
-            safe_rmtree(src)
+            if os.path.isfile(src):
+                dest_dir = os.path.dirname(src)
+            else:
+                dest_dir = src
+
+            for file_to_copy in os.listdir(dest_dir):
+                shutil.move(dest_dir + "/" + file_to_copy, ".")
+            safe_rmtree(dest_dir)
 
     @staticmethod
     def _ls_remote(remote: str) -> Dict[str, str]:

--- a/dfetch/project/git.py
+++ b/dfetch/project/git.py
@@ -201,13 +201,11 @@ class GitRepo(VCS):
 
         if src:
             if os.path.isfile(src):
-                dest_dir = os.path.dirname(src)
-            else:
-                dest_dir = src
+                src = os.path.dirname(src)
 
-            for file_to_copy in os.listdir(dest_dir):
-                shutil.move(dest_dir + "/" + file_to_copy, ".")
-            safe_rmtree(dest_dir)
+            for file_to_copy in os.listdir(src):
+                shutil.move(src + "/" + file_to_copy, ".")
+            safe_rmtree(src)
 
     @staticmethod
     def _ls_remote(remote: str) -> Dict[str, str]:

--- a/features/fetch-single-file-git.feature
+++ b/features/fetch-single-file-git.feature
@@ -32,3 +32,34 @@ Feature: Fetch single file from git repo
                     SomeFile.txt
                 dfetch.yaml
             """
+
+    Scenario: A single file is fetched from a repo (dst)
+        Given the manifest 'dfetch.yaml' in MyProject
+            """
+            manifest:
+                version: 0.0
+                projects:
+                    - name: SomeProjectWithAnInterestingFile
+                      url: some-remote-server/SomeProjectWithAnInterestingFile.git
+                      dst: ext
+                      src: SomeFolder/SomeFile.txt
+                      tag: v1
+            """
+        And a git-repository "SomeProjectWithAnInterestingFile.git" with the files
+            | path                                  |
+            | SomeFolder/SomeFile.txt               |
+            | SomeOtherFolder/SomeOtherFile.txt     |
+        When I run "dfetch update"
+        Then the output shows
+            """
+            Dfetch (0.0.6)
+              SomeProjectWithAnInterestingFile: Fetched v1
+            """
+        Then 'MyProject' looks like:
+            """
+            MyProject/
+                dfetch.yaml
+                ext/
+                    .dfetch_data.yaml
+                    SomeFile.txt
+            """


### PR DESCRIPTION
As discussed in #120 and on gitter, the dst can't be a file, only a folder. It is the responsibility of the user to don't use a file name.

This PR allows to use a dst when checking out a single file.