### PR TITLE
Feature/non standard svn

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 Release 0.0.10 (In development)
 ===================================
 
-* A new functionality
+* Support for non-standard SVN repositories (#135)
 
 Release 0.0.9 (released 2021-03-16)
 ===================================

--- a/dfetch/manifest/project.py
+++ b/dfetch/manifest/project.py
@@ -43,8 +43,9 @@ revisions must be complete 40 character long SHA-hashes.
          - name: myothermodule
            revision: dcc92d0ab6c4ce022162a23566d44f673251eee4
 
-.. note:: For svn a `standard layout`_ is assumed. Meaning the top of the repository has a ``trunk``,
-          ``branches`` and ``tags`` folder.
+.. note:: For svn a `standard layout`_ is adviced. Meaning the top of the repository has a ``trunk``,
+          ``branches`` and ``tags`` folder. If this is not the case, you can indicate this by using
+          ``branch: ' '``.
 
 .. _`standard layout`:
     https://stackoverflow.com/questions/3859009/how-to-create-a-subversion-repository-with-standard-layout

--- a/dfetch/project/svn.py
+++ b/dfetch/project/svn.py
@@ -158,6 +158,9 @@ class SvnRepo(VCS):
         if version.tag:
             branch_path = f"tags/{version.tag}/"
             branch = ""
+        elif version.branch == " ":
+            branch_path = ""
+            branch = ""
         else:
             branch = version.branch or self.DEFAULT_BRANCH
             branch_path = (
@@ -178,7 +181,9 @@ class SvnRepo(VCS):
         branch, branch_path, revision = self._determine_what_to_fetch(version)
         rev_arg = f"--revision {revision}" if revision else ""
 
-        complete_path = "/".join([self.remote, branch_path, self.source]).strip("/")
+        complete_path = "/".join(
+            filter(None, [self.remote, branch_path, self.source])
+        ).strip("/")
 
         # When exporting a file, the destination directory must already exist
         pathlib.Path(os.path.dirname(self.local_path)).mkdir(

--- a/dfetch/project/vcs.py
+++ b/dfetch/project/vcs.py
@@ -209,8 +209,10 @@ class VCS(ABC):
             return Version(
                 tag=latest_tag_from_list(self.wanted_version.tag, self._list_of_tags())
             )
-
-        branch = self.wanted_version.branch or self.DEFAULT_BRANCH
+        if self.wanted_version.branch == " ":
+            branch = ""
+        else:
+            branch = self.wanted_version.branch or self.DEFAULT_BRANCH
         return Version(revision=self._latest_revision_on_branch(branch), branch=branch)
 
     def _are_there_local_changes(self) -> bool:

--- a/features/check-svn-repo.feature
+++ b/features/check-svn-repo.feature
@@ -1,6 +1,6 @@
 Feature: Checking dependencies from a svn repository
 
-    *DFetch* can check if there are new versions.
+    *DFetch* can check if there are new versions in a SVN repository.
 
     Scenario: SVN projects are specified in the manifest
         Given the manifest 'dfetch.yaml'
@@ -87,4 +87,23 @@ Feature: Checking dependencies from a svn repository
             Dfetch (0.0.7)
               ext/test-repo-rev-only: wanted (2), current (trunk - 2), available (trunk - 4)
               ext/test-rev-and-branch: wanted & current (trunk - 1), available (trunk - 4)
+            """
+
+    Scenario: A non-standard SVN repository can be checked
+        Given the manifest 'dfetch.yaml' in MyProject
+            """
+            manifest:
+                version: 0.0
+                projects:
+                    - name: SomeProject
+                      url: some-remote-server/SomeProject
+                      branch: ' '
+            """
+        And a non-standard svn-server "SomeProject"
+        And all projects are updated
+        When I run "dfetch check" in MyProject
+        Then the output shows
+            """
+            Dfetch (0.0.7)
+              SomeProject         : up-to-date (1)
             """

--- a/features/fetch-svn-repo.feature
+++ b/features/fetch-svn-repo.feature
@@ -3,6 +3,10 @@ Feature: Fetching dependencies from a svn repository
     The main functionality of *DFetch* is fetching remote dependencies.
     A key VCS that is used in the world is svn. *DFetch* makes it possible to
     fetch svn repositories, using the revision, branch, tag or a combination.
+    Typically SVN repositories are set-up with a standard layout.
+    This means there is a 'trunk', 'branches/' and 'tags/'.
+    Sometimes people don't do this, a user should be able to check
+    a non-standard SVN repository as well.
 
     Scenario: SVN projects are specified in the manifest
         Given the manifest 'dfetch.yaml'
@@ -38,3 +42,28 @@ Feature: Fetching dependencies from a svn repository
             | ext/test-repo-rev-only     |
             | ext/test-rev-and-branch    |
             | ext/test-repo-tag-v1       |
+
+    Scenario: Directory in a non-standard SVN repository can be fetched
+        Given the manifest 'dfetch.yaml' in MyProject
+            """
+            manifest:
+                version: 0.0
+                projects:
+                    - name: SomeProject
+                      url: some-remote-server/SomeProject
+                      src: SomeFolder/
+                      branch: ' '
+            """
+        And a non-standard svn-server "SomeProject" with the files
+            | path                                  |
+            | SomeFolder/SomeFile.txt               |
+            | SomeOtherFolder/SomeOtherFile.txt     |
+        When I run "dfetch update"
+        Then 'MyProject' looks like:
+            """
+            MyProject/
+                SomeProject/
+                    .dfetch_data.yaml
+                    SomeFile.txt
+                dfetch.yaml
+            """

--- a/features/steps/svn_steps.py
+++ b/features/steps/svn_steps.py
@@ -72,3 +72,20 @@ def step_impl(context, name):
             for file in context.table:
                 generate_file(file["path"], "some content")
         add_and_commit("Added files")
+
+@given(u'a non-standard svn-server "{name}" with the files')
+def step_impl(context, name):
+    repo_path = create_svn_server_and_repo(context, name)
+
+    with in_directory(repo_path):
+        for file in context.table:
+            generate_file(file["path"], "some content")
+        add_and_commit("Added files")
+
+@given(u'a non-standard svn-server "{name}"')
+def step_impl(context, name):
+    repo_path = create_svn_server_and_repo(context, name)
+
+    with in_directory(repo_path):
+        generate_file("SomeFolder/SomeFile.txt", "some content")
+        add_and_commit("Added files")


### PR DESCRIPTION
In #135 non-standard SVN layout support was requested, this branch makes it possible by letting a user use a single space as a branch name.

```yaml
    branch: ' '
``` 