### PR TITLE
Fixes Subfolders remain when usng src #163

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
-Release 0.X.0 (under development)
+Release 0.1.1 (under development)
 ===================================
 
+* Fix empty folder remains after using ``src:`` with subfolder in git (#163)
 * New logo
 
 Release 0.1.0 (released 2021-05-13)

--- a/dfetch/project/git.py
+++ b/dfetch/project/git.py
@@ -5,6 +5,7 @@ import pathlib
 import re
 import shutil
 from collections import namedtuple
+from pathlib import PurePath
 from typing import Dict, List, Optional, Tuple
 
 from dfetch.log import get_logger
@@ -205,7 +206,7 @@ class GitRepo(VCS):
 
             for file_to_copy in os.listdir(src):
                 shutil.move(src + "/" + file_to_copy, ".")
-            safe_rmtree(src)
+            safe_rmtree(PurePath(src).parts[0])
 
     @staticmethod
     def _ls_remote(remote: str) -> Dict[str, str]:

--- a/features/fetch-single-file-git.feature
+++ b/features/fetch-single-file-git.feature
@@ -11,12 +11,12 @@ Feature: Fetch single file from git repo
                 projects:
                     - name: SomeProjectWithAnInterestingFile
                       url: some-remote-server/SomeProjectWithAnInterestingFile.git
-                      src: SomeFolder/
+                      src: SomeFolder/SomeSubFolder
                       tag: v1
             """
         And a git-repository "SomeProjectWithAnInterestingFile.git" with the files
             | path                                  |
-            | SomeFolder/SomeFile.txt               |
+            | SomeFolder/SomeSubFolder/SomeFile.txt |
             | SomeOtherFolder/SomeOtherFile.txt     |
         When I run "dfetch update"
         Then the output shows


### PR DESCRIPTION
Remove the entire directory tree, not only the
last subfolder.

Fixes #163