### PR TITLE
Add patch info to list cmd

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 Release 0.X.0 (unreleased)
 ===================================
 
-* Some new feature!
+* Add patch info to list command (#198)
 
 Release 0.3.0 (released 2021-07-19)
 ===================================

--- a/dfetch/commands/list.py
+++ b/dfetch/commands/list.py
@@ -50,5 +50,6 @@ class List(dfetch.commands.command.Command):
                     logger.print_info_field("    tag", metadata.tag)
                     logger.print_info_field("    last fetch", metadata.last_fetch)
                     logger.print_info_field("    revision", metadata.revision)
+                    logger.print_info_field("    patch", metadata.patch)
                 except FileNotFoundError:
                     logger.print_info_field("    last fetch", "never")

--- a/dfetch/project/metadata.py
+++ b/dfetch/project/metadata.py
@@ -100,7 +100,7 @@ class Metadata:
 
     @property
     def remote_url(self) -> str:
-        """Branch as stored in the metadata."""
+        """Remote url as stored in the metadata."""
         return self._remote_url
 
     @property
@@ -114,12 +114,12 @@ class Metadata:
 
     @property
     def hash(self) -> str:
-        """Hash of directory."""
+        """Hash of directory as stored in the metadata.."""
         return self._hash
 
     @property
     def patch(self) -> str:
-        """Applied patch."""
+        """Applied patch as stored in the metadata.."""
         return self._patch
 
     @property

--- a/dfetch/project/metadata.py
+++ b/dfetch/project/metadata.py
@@ -37,9 +37,11 @@ class Metadata:
             "last_fetch", datetime.datetime(2000, 1, 1, 0, 0, 0)
         )
 
-        self._branch: str = str(kwargs.get("branch", ""))
-        self._tag: str = str(kwargs.get("tag", ""))
-        self._revision: str = str(kwargs.get("revision", ""))
+        self._version: Version = Version(
+            branch=str(kwargs.get("branch", "")),
+            tag=str(kwargs.get("tag", "")),
+            revision=str(kwargs.get("revision", "")),
+        )
         self._remote_url: str = str(kwargs.get("remote_url", ""))
         self._destination: str = str(kwargs.get("destination", ""))
         self._hash: str = str(kwargs.get("hash", ""))
@@ -72,31 +74,29 @@ class Metadata:
     def fetched(self, version: Version, hash_: str = "", patch_: str = "") -> None:
         """Update metadata."""
         self._last_fetch = datetime.datetime.now()
-        self._branch = version.branch
-        self._tag = version.tag
-        self._revision = version.revision
+        self._version = version
         self._hash = hash_
         self._patch = patch_
 
     @property
     def version(self) -> Version:
         """Get the version."""
-        return Version(tag=self.tag, branch=self.branch, revision=self.revision)
+        return self._version
 
     @property
     def branch(self) -> str:
         """Branch as stored in the metadata."""
-        return self._branch
+        return self._version.branch
 
     @property
     def tag(self) -> str:
         """Tag as stored in the metadata."""
-        return self._tag
+        return self._version.tag
 
     @property
     def revision(self) -> str:
         """Revision as stored in the metadata."""
-        return self._revision
+        return self._version.revision
 
     @property
     def remote_url(self) -> str:
@@ -140,9 +140,9 @@ class Metadata:
         return all(
             [
                 other.remote_url == self.remote_url,
-                other.tag == self.tag,
-                other.branch == self.branch,
-                other.revision == self.revision,
+                other._version.tag == self._version.tag,
+                other._version.branch == self._version.branch,
+                other._version.revision == self._version.revision,
                 other.hash == self.hash,
                 other.patch == self.patch,
             ]
@@ -153,10 +153,10 @@ class Metadata:
         metadata = {
             "dfetch": {
                 "remote_url": self.remote_url,
-                "branch": self.branch,
-                "revision": self.revision,
+                "branch": self._version.branch,
+                "revision": self._version.revision,
                 "last_fetch": self.last_fetch_string(),
-                "tag": self.tag,
+                "tag": self._version.tag,
                 "hash": self.hash,
                 "patch": self.patch,
             }

--- a/dfetch/project/metadata.py
+++ b/dfetch/project/metadata.py
@@ -21,6 +21,7 @@ class Options(TypedDict):
     remote_url: str
     destination: str
     hash: str
+    patch: str
 
 
 class Metadata:
@@ -42,6 +43,7 @@ class Metadata:
         self._remote_url: str = str(kwargs.get("remote_url", ""))
         self._destination: str = str(kwargs.get("destination", ""))
         self._hash: str = str(kwargs.get("hash", ""))
+        self._patch: str = str(kwargs.get("patch", ""))
 
     @classmethod
     def from_project_entry(
@@ -56,6 +58,7 @@ class Metadata:
             "destination": project.destination,
             "last_fetch": datetime.datetime(2000, 1, 1, 0, 0, 0),
             "hash": "",
+            "patch": project.patch,
         }
         return cls(data)
 
@@ -66,13 +69,14 @@ class Metadata:
             data: Options = yaml.safe_load(metadata_file)["dfetch"]
             return cls(data)
 
-    def fetched(self, version: Version, hash_: str = "") -> None:
+    def fetched(self, version: Version, hash_: str = "", patch_: str = "") -> None:
         """Update metadata."""
         self._last_fetch = datetime.datetime.now()
         self._branch = version.branch
         self._tag = version.tag
         self._revision = version.revision
         self._hash = hash_
+        self._patch = patch_
 
     @property
     def version(self) -> Version:
@@ -114,6 +118,11 @@ class Metadata:
         return self._hash
 
     @property
+    def patch(self) -> str:
+        """Applied patch."""
+        return self._patch
+
+    @property
     def path(self) -> str:
         """Path to metadata file."""
         if os.path.isdir(self._destination):
@@ -135,6 +144,7 @@ class Metadata:
                 other.branch == self.branch,
                 other.revision == self.revision,
                 other.hash == self.hash,
+                other.patch == self.patch,
             ]
         )
 
@@ -148,6 +158,7 @@ class Metadata:
                 "last_fetch": self.last_fetch_string(),
                 "tag": self.tag,
                 "hash": self.hash,
+                "patch": self.patch,
             }
         }
 

--- a/dfetch/project/metadata.py
+++ b/dfetch/project/metadata.py
@@ -119,7 +119,7 @@ class Metadata:
 
     @property
     def patch(self) -> str:
-        """Applied patch as stored in the metadata.."""
+        """The applied patch as stored in the metadata."""
         return self._patch
 
     @property

--- a/dfetch/project/vcs.py
+++ b/dfetch/project/vcs.py
@@ -104,15 +104,18 @@ class VCS(ABC):
         actually_fetched = self._fetch_impl(to_fetch)
         self._log_project(f"Fetched {actually_fetched}")
 
+        applied_patch = ""
         if self.__project.patch:
             if os.path.exists(self.__project.patch):
                 self.apply_patch()
+                applied_patch = self.__project.patch
             else:
                 logger.warning(f"Skipping non-existent patch {self.__project.patch}")
 
         self.__metadata.fetched(
             actually_fetched,
             hash_=hash_directory(self.local_path, skiplist=[self.__metadata.FILENAME]),
+            patch_=applied_patch,
         )
 
         logger.debug(f"Writing repo metadata to: {self.__metadata.path}")

--- a/features/list-projects.feature
+++ b/features/list-projects.feature
@@ -57,3 +57,19 @@ Feature: List dependencies
                   revision        : 4
                   patch           : <none>
             """
+
+    Scenario: Git repo with applied patch
+        Given MyProject with applied patch 'diff.patch'
+        When I run "dfetch list"
+        Then the output shows
+            """
+            Dfetch (0.2.0)
+              project             : ext/test-repo-tag
+                  remote          : <none>
+                  remote url      : https://github.com/dfetch-org/test-repo
+                  branch          : master
+                  tag             : v2.0
+                  last fetch      : 02/07/2021, 20:25:56
+                  revision        : <none>
+                  patch           : diff.patch
+            """

--- a/features/list-projects.feature
+++ b/features/list-projects.feature
@@ -27,6 +27,7 @@ Feature: List dependencies
                   tag             : <none>
                   last fetch      : 02/07/2021, 20:25:56
                   revision        : e1fda19a57b873eb8e6ae37780594cbb77b70f1a
+                  patch           : <none>
             """
 
     Scenario: SVN projects are specified in the manifest
@@ -54,4 +55,5 @@ Feature: List dependencies
                   tag             : v2.0
                   last fetch      : 02/07/2021, 20:25:56
                   revision        : 4
+                  patch           : <none>
             """

--- a/features/steps/git_steps.py
+++ b/features/steps/git_steps.py
@@ -113,3 +113,38 @@ def step_impl(context):
             """
         '''
     )
+
+
+@given("MyProject with applied patch 'diff.patch'")
+def step_impl(context):
+    context.execute_steps(
+        '''
+        Given the manifest 'dfetch.yaml'
+            """
+            manifest:
+                version: '0.0'
+
+                remotes:
+                - name: github-com-dfetch-org
+                  url-base: https://github.com/dfetch-org/test-repo
+
+                projects:
+                - name: ext/test-repo-tag
+                  tag: v2.0
+                  dst: ext/test-repo-tag
+                  patch: diff.patch
+            """
+        And the patch file 'diff.patch'
+            """
+            diff --git a/README.md b/README.md
+            index 32d9fad..62248b7 100644
+            --- a/README.md
+            +++ b/README.md
+            @@ -1,2 +1,2 @@
+             # Test-repo
+            -A test repo for testing dfetch.
+            +A test repo for testing patch.
+            """
+        When I run "dfetch update"
+        '''
+    )


### PR DESCRIPTION
This PR adds the patch info to the metadata so it can be shown  by the list command. This was logged as #198.

I have added a dedicated feature test, because otherwise it would make an existing test more complex.