### PR TITLE
Fixes #223: Space in dest path breaks svn export

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,7 @@ Release 0.X.0 (unreleased)
 ===================================
 
 * Add patch info to list command (#198)
+* Don't break when there is a space in SVN dest path (#223)
 
 Release 0.3.0 (released 2021-07-19)
 ===================================

--- a/dfetch/project/svn.py
+++ b/dfetch/project/svn.py
@@ -220,7 +220,7 @@ class SvnRepo(VCS):
     def _export(url: str, rev: str = "", dst: str = ".") -> None:
         run_on_cmdline(
             logger,
-            f"svn export --force {rev} {url} {dst}",
+            ["svn", "export", "--force"] + rev.split(" ") + [url, dst],
         )
 
     @staticmethod

--- a/features/fetch-svn-repo.feature
+++ b/features/fetch-svn-repo.feature
@@ -28,7 +28,7 @@ Feature: Fetching dependencies from a svn repository
                   revision: '2'
                   branch: trunk
                   vcs: svn
-                  dst: ext/test-rev-and-branch
+                  dst: ext/test-rev-and branch
 
                 - name: ext/test-repo-tag-v1
                   tag: v1
@@ -40,7 +40,7 @@ Feature: Fetching dependencies from a svn repository
         Then the following projects are fetched
             | path                       |
             | ext/test-repo-rev-only     |
-            | ext/test-rev-and-branch    |
+            | ext/test-rev-and branch    |
             | ext/test-repo-tag-v1       |
 
     Scenario: Directory in a non-standard SVN repository can be fetched


### PR DESCRIPTION
Add quotes to be able to handle spaces in paths