### PR TITLE
Drop python 3.6 support

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -7,12 +7,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
-        exclude:
-          - platform: macos-latest
-            python-version: 3.6
-          - platform: windows-latest
-            python-version: 3.6
+        python-version: ['3.7', '3.8', '3.9', '3.10']
     runs-on: ${{ matrix.platform }}
 
     steps:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,7 @@ Release 0.8.0 (unreleased)
 ===================================
 
 * Don't break if no suggestion found (#358)
+* Drop python 3.6 support
 
 Release 0.7.0 (released 2022-06-22)
 ===================================

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ setup(
         "Environment :: Console",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
Python 3.6 is End-of-Life.
Drop support since dependencies are also dropping support and this hinders upgrading them.