### PR TITLE
Fix flake8 5.x  & Sphinx dep hell by removing flake8 (for now)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       - run: codespell                                                # Check for typo's
       - run: isort --diff dfetch                                      # Checks import order
       - run: black --check dfetch                                     # Checks code style
-      - run: flake8 dfetch                                            # Checks pep8 conformance
+      # - run: flake8 dfetch                                            # Checks pep8 conformance
       - run: pylint dfetch                                            # Checks pep8 conformance
       - run: mypy --strict dfetch                                     # Check types
       - run: doc8 doc                                                 # Checks documentation

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,12 +26,12 @@ repos:
         language: system
         files: ^dfetch/
         types: [file, python]
-    -   id: flake8
-        name: flake8
-        entry: flake8
-        language: system
-        files: ^dfetch/
-        types: [file, python]
+    # -   id: flake8
+    #     name: flake8
+    #     entry: flake8
+    #     language: system
+    #     files: ^dfetch/
+    #     types: [file, python]
     -   id: mypy
         name: mypy
         entry: mypy

--- a/create_venv.py
+++ b/create_venv.py
@@ -29,8 +29,8 @@ class MyEnvBuilder(venv.EnvBuilder):
         print("Upgrading pip")
         self.pip_install(context, "--upgrade", "pip")
         for reqs in self.requirements:
-            print("Installing requirements from {}".format(reqs))
-            self.pip_install(context, "-r", reqs)
+            print(f"Installing requirements from {reqs}")
+            self.pip_install(context, "--use-pep517", "-r", reqs)
         print("Installing package")
         self.pip_install(context, "-e", ".")
 

--- a/dfetch.code-workspace
+++ b/dfetch.code-workspace
@@ -11,7 +11,7 @@
 		"python.linting.pydocstyleEnabled": true,
 		"python.linting.pylintEnabled": true,
 		"python.linting.mypyEnabled": true,
-		"python.linting.flake8Enabled": true,
+		"python.linting.flake8Enabled": false,
 		"python.linting.lintOnSave": true,
 		"isort.check": true,
 		"python.formatting.provider": "black",

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ xenon==0.9.0
 types-PyYAML==6.0.12.2
 codespell==2.2.2
 mypy==0.991
-flake8==6.0.0
+# flake8==5.0.4 # version 6.x.x requires python >= 3.8.1 (but 3.7 support window is until 2023-06-27)
 bandit==1.7.4
 vulture==2.6
 pyroma==4.1


### PR DESCRIPTION
Our main development is currently still on python 3.7 and we will be upgrading to newer version before python end-of-support on 2023-06-27.

For now it is impossible to both have sphinx & flake8 installed concurrently in the same venv on python 3.7.
Which makes on-the-fly-linting and doc generation possible in VSCode our main editor.

See https://github.com/sphinx-doc/sphinx/issues/10241 & https://github.com/PyCQA/flake8/issues/1582.

Codacy does run flake8, so not all is lost, but until the summer when we move to latest python remove flake8.
 