### PR TITLE
Fix/remote svn tests

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,7 +20,7 @@
         "tamasfe.even-better-toml",
         "trond-snekvik.simple-rst",
         "jebbs.plantuml",
-        "YouneselBarnoussi.vscode-behave-test-adapter"
+        "jimasp.behave-vsc"
       ],
       "settings": {
         "terminal.integrated.profiles.linux": {

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,19 +29,19 @@ jobs:
         run: |
           pip install .[development,test]
 
-      - run: codespell                                                                   # Check for typo's
-      - run: isort --diff dfetch                                                         # Checks import order
-      - run: black --check dfetch                                                        # Checks code style
-      # - run: flake8 dfetch                                                             # Checks pep8 conformance
-      - run: pylint dfetch                                                               # Checks pep8 conformance
-      - run: mypy --strict dfetch                                                        # Check types
-      - run: doc8 doc                                                                    # Checks documentation
-      - run: pydocstyle dfetch                                                           # Checks doc strings
-      - run: bandit -r dfetch                                                            # Checks security issues
-      - run: xenon -b B -m A -a A dfetch                                                 # Check code quality
-      - run: pytest --cov=dfetch  tests                                                  # Run tests
-      - run: coverage run --source=dfetch --append -m behave features --tags=~remote-svn # Run features tests
-      - run: coverage xml -o coverage.xml                                                # Create XML report
+      - run: codespell                                                 # Check for typo's
+      - run: isort --diff dfetch                                       # Checks import order
+      - run: black --check dfetch                                      # Checks code style
+      # - run: flake8 dfetch                                           # Checks pep8 conformance
+      - run: pylint dfetch                                             # Checks pep8 conformance
+      - run: mypy --strict dfetch                                      # Check types
+      - run: doc8 doc                                                  # Checks documentation
+      - run: pydocstyle dfetch                                         # Checks doc strings
+      - run: bandit -r dfetch                                          # Checks security issues
+      - run: xenon -b B -m A -a A dfetch                               # Check code quality
+      - run: pytest --cov=dfetch  tests                                # Run tests
+      - run: coverage run --source=dfetch --append -m behave features  # Run features tests
+      - run: coverage xml -o coverage.xml                              # Create XML report
 
       - name: Run codacy-coverage-reporter
         uses: codacy/codacy-coverage-reporter-action@master

--- a/dfetch.code-workspace
+++ b/dfetch.code-workspace
@@ -181,6 +181,7 @@
 			"ms-python.pylint",
 			"ms-python.python",
 			"trond-snekvik.simple-rst",
+			"jimasp.behave-vsc"
 		]
 	}
 }

--- a/features/check-svn-repo.feature
+++ b/features/check-svn-repo.feature
@@ -10,28 +10,28 @@ Feature: Checking dependencies from a svn repository
               version: '0.0'
 
               remotes:
-                - name: github-com-dfetch-org
-                  url-base: https://github.com/dfetch-org/test-repo
+                - name: cunit
+                  url-base: svn://svn.code.sf.net/p/cunit/code
 
               projects:
-                - name: ext/test-repo-rev-only
-                  revision: '2'
+                - name: cunit-svn-rev-only
+                  revision: '170'
                   vcs: svn
-                  dst: ext/test-repo-rev-only
+                  dst: ext/cunit-svn-rev-only
 
-                - name: ext/test-rev-and-branch
-                  revision: '1'
+                - name: cunit-svn-rev-and-branch
+                  revision: '156'
                   vcs: svn
-                  branch: some-branch
-                  dst: ext/test-rev-and-branch
+                  branch: mingw64
+                  dst: ext/cunit-svn-rev-and-branch
 
             """
         When I run "dfetch check"
         Then the output shows
             """
             Dfetch (0.8.0)
-              ext/test-repo-rev-only: wanted (2), available (trunk - 5)
-              ext/test-rev-and-branch: wanted (some-branch - 1), available (some-branch - 5)
+              cunit-svn-rev-only  : wanted (170), available (trunk - 170)
+              cunit-svn-rev-and-branch: wanted (mingw64 - 156), available (mingw64 - 170)
             """
 
     Scenario: A newer tag is available than in manifest
@@ -41,21 +41,21 @@ Feature: Checking dependencies from a svn repository
               version: '0.0'
 
               remotes:
-                - name: github-com-dfetch-org
-                  url-base: https://github.com/dfetch-org/test-repo
+                - name: cutter
+                  url-base: svn://svn.code.sf.net/p/cutter/svn/cutter
 
               projects:
-                - name: ext/test-repo-tag-v1
+                - name: cutter-svn-tag
                   vcs: svn
-                  tag: v1
-                  dst: ext/test-repo-tag-v1
+                  tag: 1.1.7
+                  dst: ext/cutter-svn-tag
 
             """
         When I run "dfetch check"
         Then the output shows
             """
             Dfetch (0.8.0)
-              ext/test-repo-tag-v1: wanted (v1), available (v2.0)
+              cutter-svn-tag      : wanted (1.1.7), available (1.1.8)
             """
 
     Scenario: Check is done after an update
@@ -65,20 +65,21 @@ Feature: Checking dependencies from a svn repository
               version: '0.0'
 
               remotes:
-                - name: github-com-dfetch-org
-                  url-base: https://github.com/dfetch-org/test-repo
+                - name: cunit
+                  url-base: svn://svn.code.sf.net/p/cunit/code
+                  default: true
 
               projects:
-                - name: ext/test-repo-rev-only
-                  revision: '2'
+                - name: cunit-svn-rev-only
+                  revision: '169'
                   vcs: svn
-                  dst: ext/test-repo-rev-only
+                  dst: ext/cunit-svn-rev-only
 
-                - name: ext/test-rev-and-branch
-                  revision: '1'
+                - name: cunit-svn-rev-and-branch
+                  revision: '156'
                   vcs: svn
-                  branch: trunk
-                  dst: ext/test-rev-and-branch
+                  branch: mingw64
+                  dst: ext/cunit-svn-rev-and-branch
 
                 - name: ext/test-non-standard-svn
                   url: some-remote-server/SomeProject
@@ -91,8 +92,8 @@ Feature: Checking dependencies from a svn repository
         Then the output shows
             """
             Dfetch (0.8.0)
-              ext/test-repo-rev-only: wanted (2), current (trunk - 2), available (trunk - 5)
-              ext/test-rev-and-branch: wanted & current (trunk - 1), available (trunk - 5)
+              cunit-svn-rev-only  : wanted (169), current (trunk - 169), available (trunk - 170)
+              cunit-svn-rev-and-branch: wanted & current (mingw64 - 156), available (mingw64 - 170)
               ext/test-non-standard-svn: wanted (latest), current (1), available (1)
             """
 
@@ -143,11 +144,11 @@ Feature: Checking dependencies from a svn repository
               version: '0.0'
 
               remotes:
-                - name: github-com-dfetch-org
-                  url-base: https://github.com/dfetch-org/test-repo
+                - name: cutter
+                  url-base: svn://svn.code.sf.net/p/cutter/svn/cutter
 
               projects:
-                - name: SomeProject
+                - name: cutter-svn-tag
                   vcs: svn
                   tag: non-existent-tag
             """
@@ -155,5 +156,5 @@ Feature: Checking dependencies from a svn repository
         Then the output shows
             """
             Dfetch (0.8.0)
-              SomeProject         : wanted (non-existent-tag), but not available at the upstream.
+              cutter-svn-tag      : wanted (non-existent-tag), but not available at the upstream.
             """

--- a/features/fetch-svn-repo.feature
+++ b/features/fetch-svn-repo.feature
@@ -16,33 +16,39 @@ Feature: Fetching dependencies from a svn repository
               version: '0.0'
 
               remotes:
-                - name: github-com-dfetch-org
-                  url-base: https://github.com/dfetch-org/test-repo
+                - name: cunit
+                  url-base: svn://svn.code.sf.net/p/cunit/code
+                  default: true
+
+                - name: cutter
+                  url-base: svn://svn.code.sf.net/p/cutter/svn/cutter
 
               projects:
-                - name: ext/test-repo-rev-only
-                  revision: '1'
+                - name: cunit-svn-rev-only
+                  revision: '170'
                   vcs: svn
-                  dst: ext/test-repo-rev-only
+                  dst: ext/cunit-svn-rev-only
 
-                - name: ext/test-rev-and-branch
-                  revision: '2'
-                  branch: trunk
+                - name: cunit-svn-rev-and-branch
+                  revision: '156'
                   vcs: svn
-                  dst: ext/test-rev-and branch
+                  branch: mingw64
+                  dst: ext/cunit-svn-rev-and-branch
 
-                - name: ext/test-repo-tag-v1
-                  tag: v1
+                - name: cutter-svn-tag
                   vcs: svn
-                  dst: ext/test-repo-tag-v1
+                  tag: 1.1.7
+                  src: acmacros
+                  dst: ext/cutter-svn-tag
+                  remote: cutter
 
             """
         When I run "dfetch update"
         Then the following projects are fetched
-            | path                       |
-            | ext/test-repo-rev-only     |
-            | ext/test-rev-and branch    |
-            | ext/test-repo-tag-v1       |
+            | path                         |
+            | ext/cunit-svn-rev-only       |
+            | ext/cunit-svn-rev-and-branch |
+            | ext/cutter-svn-tag           |
 
     Scenario: Directory in a non-standard SVN repository can be fetched
         Given the manifest 'dfetch.yaml' in MyProject

--- a/features/freeze-projects.feature
+++ b/features/freeze-projects.feature
@@ -41,9 +41,9 @@ Feature: Freeze dependencies
               version: '0.0'
 
               projects:
-                - name: ext/test-repo-tag
-                  url: https://github.com/dfetch-org/test-repo
+                - name: cunit-svn
                   vcs: svn
+                  url: svn://svn.code.sf.net/p/cunit/code
 
             """
         And all projects are updated
@@ -54,9 +54,9 @@ Feature: Freeze dependencies
               version: '0.0'
 
               projects:
-              - name: ext/test-repo-tag
-                revision: '5'
-                url: https://github.com/dfetch-org/test-repo
+              - name: cunit-svn
+                revision: '170'
+                url: svn://svn.code.sf.net/p/cunit/code
                 branch: trunk
                 vcs: svn
 

--- a/features/list-projects.feature
+++ b/features/list-projects.feature
@@ -39,10 +39,11 @@ Feature: List dependencies
               version: '0.0'
 
               projects:
-                - name: ext/test-repo-tag
-                  url: https://github.com/dfetch-org/test-repo
-                  tag: v2.0
+                - name: cutter-svn-tag
+                  url: svn://svn.code.sf.net/p/cutter/svn/cutter
+                  tag: 1.1.7
                   vcs: svn
+                  src: acmacros
 
             """
         And all projects are updated
@@ -50,15 +51,15 @@ Feature: List dependencies
         Then the output shows
             """
             Dfetch (0.8.0)
-              project             : ext/test-repo-tag
+              project             : cutter-svn-tag
                   remote          : <none>
-                  remote url      : https://github.com/dfetch-org/test-repo
+                  remote url      : svn://svn.code.sf.net/p/cutter/svn/cutter
                   branch          : <none>
-                  tag             : v2.0
-                  last fetch      : 02/07/2021, 20:25:56
-                  revision        : 5
+                  tag             : 1.1.7
+                  last fetch      : 29/12/2024, 20:09:21
+                  revision        : 4007
                   patch           : <none>
-                  license         : MIT License
+                  license         : <none>
             """
 
     Scenario: Git repo with applied patch

--- a/features/patch-after-fetch-svn.feature
+++ b/features/patch-after-fetch-svn.feature
@@ -11,32 +11,34 @@ Feature: Patch after fetching from svn repo
                 version: '0.0'
 
                 remotes:
-                - name: github-com-dfetch-org
-                  url-base: https://github.com/dfetch-org/test-repo
+                - name: cutter
+                  url-base: svn://svn.code.sf.net/p/cutter/svn/cutter
 
                 projects:
-                - name: ext/test-repo-tag
-                  tag: v2.0
+                - name: cutter
                   vcs: svn
-                  dst: ext/test-repo-tag
+                  tag: 1.1.7
+                  dst: ext/cutter
                   patch: diff.patch
+                  src: apt
             """
         And the patch file 'diff.patch'
             """
-            Index: README.md
+            Index: build-deb.sh
             ===================================================================
-            --- README.md	(revision 2)
-            +++ README.md	(revision 3)
-            @@ -1,2 +1,2 @@
-             # Test-repo
-            -A test repo for testing dfetch.
-            +A test repo for testing patch.
+            --- build-deb.sh	(revision 4007)
+            +++ build-deb.sh	(working copy)
+            @@ -1,4 +1,4 @@
+            -#!/bin/sh
+            +#!/bin/bash
+             
+             LANG=C
+             
             """
         When I run "dfetch update"
-        Then the patched 'ext/test-repo-tag/README.md' is
+        Then the first line of 'ext/cutter/build-deb.sh' is changed to
             """
-            # Test-repo
-            A test repo for testing patch.
+            #!/bin/bash
             """
 
     Scenario: Applying patch file fails
@@ -46,34 +48,37 @@ Feature: Patch after fetching from svn repo
                 version: '0.0'
 
                 remotes:
-                - name: github-com-dfetch-org
-                  url-base: https://github.com/dfetch-org/test-repo
+                - name: cutter
+                  url-base: svn://svn.code.sf.net/p/cutter/svn/cutter
 
                 projects:
-                - name: ext/test-repo-tag
-                  tag: v2.0
+                - name: cutter
                   vcs: svn
-                  dst: ext/test-repo-tag
+                  tag: 1.1.7
+                  dst: ext/cutter
                   patch: diff.patch
+                  src: apt
             """
         And the patch file 'diff.patch'
             """
-            Index: README.md
+            Index: build-deb.sh
             ===================================================================
-            --- README1.md	(revision 2)
-            +++ README1.md	(revision 3)
-            @@ -1,2 +1,2 @@
-             # Test-repo
-            -A test repo for testing dfetch.
-            +A test repo for testing patch.
+            --- build-deb2.sh	(revision 4007)
+            +++ build-deb2.sh	(working copy)
+            @@ -1,4 +1,4 @@
+            -#!/bin/sh
+            +#!/bin/bash
+             
+             LANG=C
+             
             """
         When I run "dfetch update"
         Then the output shows
             """
             Dfetch (0.8.0)
-              ext/test-repo-tag   : Fetched v2.0
+              cutter              : Fetched 1.1.7
             source/target file does not exist:
-              --- b'README1.md'
-              +++ b'README1.md'
+              --- b'build-deb2.sh'
+              +++ b'build-deb2.sh'
             Applying patch "diff.patch" failed
             """

--- a/features/steps/generic_steps.py
+++ b/features/steps/generic_steps.py
@@ -186,6 +186,13 @@ def step_impl(context, name):
     check_file(name, context.text)
 
 
+@then("the first line of '{name}' is changed to")
+def step_impl(context, name):
+    """Check the first line of the file."""
+    with open(name, "r") as file_to_check:
+        check_content(context.text.strip(), file_to_check.readline().strip())
+
+
 @then("the patch file '{name}' is generated")
 def step_impl(context, name):
     """Check a manifest."""


### PR DESCRIPTION
Fixes the remote-svn tests after github dropped their svn api, see #428 