### PR TITLE
Prototype extended data

### DIFF
--- a/dfetch/project/metadata.py
+++ b/dfetch/project/metadata.py
@@ -196,15 +196,15 @@ class Metadata:
             "dfetch": {
                 "remote_url": self.remote_url,
                 "branch": self._version.branch,
-                "revision": self._version.revision,
-                "last_fetch": self.last_fetch_string(),
-                "tag": self._version.tag,
                 "hash": self.hash,
+                "last_fetch": self.last_fetch_string(),
                 "patch": self.patch,
+                "revision": self._version.revision,
+                "tag": self._version.tag,
                 "files": [str(info) for info in self._files or []],
             }
         }
 
         with open(self.path, "w+", encoding="utf-8") as metadata_file:
             metadata_file.write(DONT_EDIT_WARNING)
-            yaml.dump(metadata, metadata_file)
+            yaml.dump(metadata, metadata_file, sort_keys=False)

--- a/dfetch/project/metadata.py
+++ b/dfetch/project/metadata.py
@@ -2,6 +2,8 @@
 
 import datetime
 import os
+from dataclasses import dataclass
+from typing import Iterable, Optional
 
 import yaml
 from typing_extensions import TypedDict
@@ -15,6 +17,29 @@ DONT_EDIT_WARNING = """\
 """
 
 
+@dataclass
+class FileInfo:
+    """Information about a single fetched file."""
+
+    path: str
+    hash: str
+    permissions: str  # octal
+
+    def __repr__(self) -> str:
+        return f"{self.path.replace("|", r"\|")}|{self.hash}|{self.permissions}"
+
+    @staticmethod
+    def from_list(data: Iterable[str]) -> Iterable["FileInfo"]:
+        """Create a list of FileInfo's from a string"""
+        parsed = []
+        for entry in data:
+            path, hash_digest, permissions = (
+                entry.split("|", maxsplit=3) + ["", "", ""]
+            )[:3]
+            parsed.append(FileInfo(path, hash_digest, permissions.zfill(3)))
+        return parsed
+
+
 class Options(TypedDict):  # pylint: disable=too-many-ancestors
     """Argument types for Metadata class construction."""
 
@@ -26,6 +51,7 @@ class Options(TypedDict):  # pylint: disable=too-many-ancestors
     destination: str
     hash: str
     patch: str
+    files: Optional[Iterable[FileInfo]] = None
 
 
 class Metadata:
@@ -50,6 +76,9 @@ class Metadata:
         self._destination: str = str(kwargs.get("destination", ""))
         self._hash: str = str(kwargs.get("hash", ""))
         self._patch: str = str(kwargs.get("patch", ""))
+        self._files: Optional[Iterable[FileInfo]] = FileInfo.from_list(
+            kwargs.get("files", [])
+        )
 
     @classmethod
     def from_project_entry(
@@ -65,6 +94,7 @@ class Metadata:
             "last_fetch": datetime.datetime(2000, 1, 1, 0, 0, 0),
             "hash": "",
             "patch": project.patch,
+            "files": [],
         }
         return cls(data)
 
@@ -75,12 +105,19 @@ class Metadata:
             data: Options = yaml.safe_load(metadata_file)["dfetch"]
             return cls(data)
 
-    def fetched(self, version: Version, hash_: str = "", patch_: str = "") -> None:
+    def fetched(
+        self,
+        version: Version,
+        hash_: str = "",
+        patch_: str = "",
+        files: Optional[Iterable[FileInfo]] = None,
+    ) -> None:
         """Update metadata."""
         self._last_fetch = datetime.datetime.now()
         self._version = version
         self._hash = hash_
         self._patch = patch_
+        self._files = files
 
     @property
     def version(self) -> Version:
@@ -149,6 +186,7 @@ class Metadata:
                 other._version.revision == self._version.revision,
                 other.hash == self.hash,
                 other.patch == self.patch,
+                other._files == self._files,
             ]
         )
 
@@ -163,6 +201,7 @@ class Metadata:
                 "tag": self._version.tag,
                 "hash": self.hash,
                 "patch": self.patch,
+                "files": [str(info) for info in self._files or []],
             }
         }
 

--- a/dfetch/project/metadata.py
+++ b/dfetch/project/metadata.py
@@ -130,6 +130,11 @@ class Metadata:
         return self._version.branch
 
     @property
+    def files(self) -> Iterable[FileInfo]:
+        """File info as stored in the metadata."""
+        return self._files
+
+    @property
     def tag(self) -> str:
         """Tag as stored in the metadata."""
         return self._version.tag

--- a/dfetch/project/vcs.py
+++ b/dfetch/project/vcs.py
@@ -13,8 +13,13 @@ import dfetch.manifest.manifest
 from dfetch.log import get_logger
 from dfetch.manifest.version import Version
 from dfetch.project.abstract_check_reporter import AbstractCheckReporter
-from dfetch.project.metadata import Metadata
-from dfetch.util.util import hash_directory, safe_rm
+from dfetch.project.metadata import FileInfo, Metadata
+from dfetch.util.util import (
+    hash_directory,
+    hash_file_normalized,
+    recursive_listdir,
+    safe_rm,
+)
 from dfetch.util.versions import latest_tag_from_list
 
 logger = get_logger(__name__)
@@ -122,10 +127,34 @@ class VCS(ABC):
             else:
                 logger.warning(f"Skipping non-existent patch {self.__project.patch}")
 
+        if os.path.isfile(self.local_path):
+            files_list = (
+                FileInfo(
+                    os.path.basename(self.local_path),
+                    hash_file_normalized(os.path.join(self.local_path)).hexdigest(),
+                    oct(os.stat(os.path.join(self.local_path)).st_mode)[-3:],
+                ),
+            )
+        else:
+            all_files = (
+                file_path
+                for file_path in recursive_listdir(self.local_path)
+                if file_path is not self.__metadata.FILENAME
+            )
+            files_list = (
+                FileInfo(
+                    os.path.relpath(file_path, self.local_path),
+                    hash_file_normalized(file_path).hexdigest(),
+                    oct(os.stat(file_path).st_mode)[-3:],
+                )
+                for file_path in all_files
+            )
+
         self.__metadata.fetched(
             actually_fetched,
             hash_=hash_directory(self.local_path, skiplist=[self.__metadata.FILENAME]),
             patch_=applied_patch,
+            files=files_list,
         )
 
         logger.debug(f"Writing repo metadata to: {self.__metadata.path}")

--- a/dfetch/project/vcs.py
+++ b/dfetch/project/vcs.py
@@ -4,7 +4,7 @@ import fnmatch
 import os
 import pathlib
 from abc import ABC, abstractmethod
-from typing import List, Optional, Sequence, Tuple
+from typing import Iterable, List, Optional, Sequence, Tuple
 
 from halo import Halo
 from patch_ng import fromfile
@@ -309,23 +309,24 @@ class VCS(ABC):
             )
             return None
 
-    def _on_disk_hash(self) -> Optional[str]:
+    def _on_disk_hash(self) -> Tuple[Iterable[FileInfo], Optional[str]]:
         """Get the hash of the project on disk.
 
         Returns:
             Str: Could be None if no on disk version
         """
         if not os.path.exists(self.__metadata.path):
-            return None
+            return [], None
 
         try:
-            return Metadata.from_file(self.__metadata.path).hash
+            metadata = Metadata.from_file(self.__metadata.path)
+            return metadata.files, metadata.hash
         except TypeError:
             logger.warning(
                 f"{pathlib.Path(self.__metadata.path).relative_to(os.getcwd()).as_posix()}"
                 " is an invalid metadata file, not checking local hash!"
             )
-            return None
+            return [], None
 
     def _check_for_newer_version(self) -> Optional[Version]:
         """Check if a newer version is available on the given branch.
@@ -365,11 +366,24 @@ class VCS(ABC):
           Bool: True if there are local changes, false if no were detected or no hash was found.
         """
         logger.debug(f"Checking if there were local changes in {self.local_path}")
-        on_disk_hash = self._on_disk_hash()
 
-        return bool(on_disk_hash) and on_disk_hash != hash_directory(
-            self.local_path, skiplist=[self.__metadata.FILENAME]
-        )
+        file_info, on_disk_hash = self._on_disk_hash()
+
+        if not file_info:
+            return bool(on_disk_hash) and on_disk_hash != hash_directory(
+                self.local_path, skiplist=[self.__metadata.FILENAME]
+            )
+
+        for file in file_info:
+            full_path = os.path.join(self.local_path, file.path)
+            if hash_file_normalized(full_path).hexdigest() != file.hash:
+                logger.debug(f"The hash of {full_path} changed!")
+                return True
+            if oct(os.stat(full_path).st_mode)[-3:] != file.permissions:
+                logger.debug(f"The file permissions of {full_path} changed!")
+                return True
+
+        return False
 
     @abstractmethod
     def _fetch_impl(self, version: Version) -> Version:

--- a/dfetch/project/vcs.py
+++ b/dfetch/project/vcs.py
@@ -4,6 +4,7 @@ import fnmatch
 import os
 import pathlib
 from abc import ABC, abstractmethod
+from contextlib import suppress
 from typing import Iterable, List, Optional, Sequence, Tuple
 
 from halo import Halo
@@ -109,7 +110,20 @@ class VCS(ABC):
 
         if os.path.exists(self.local_path):
             logger.debug(f"Clearing destination {self.local_path}")
-            safe_rm(self.local_path)
+
+            with suppress(TypeError):
+                metadata_files = Metadata.from_file(self.__metadata.path).files
+
+            if metadata_files:
+                for file in metadata_files:
+                    full_path = os.path.join(self.local_path, file.path)
+                    safe_rm(full_path)
+                    parent_dir = os.path.dirname(full_path)
+                    # remove parent if empty
+                    if not os.listdir(parent_dir):
+                        safe_rm(parent_dir)
+            else:
+                safe_rm(self.local_path)
 
         with Halo(
             text=f"Fetching {self.__project.name} {to_fetch}",

--- a/dfetch/util/util.py
+++ b/dfetch/util/util.py
@@ -3,6 +3,7 @@
 import fnmatch
 import hashlib
 import os
+import re
 import shutil
 import stat
 from contextlib import contextmanager
@@ -102,6 +103,21 @@ def find_file(name: str, path: str = ".") -> List[str]:
     ]
 
 
+def recursive_listdir(directory):
+    """List all entries in the current directory."""
+    entries = os.listdir(directory)
+
+    for entry in entries:
+        full_path = os.path.join(directory, entry)
+
+        if os.path.isdir(full_path):
+            # If the entry is a directory, recurse into it
+            yield from recursive_listdir(full_path)
+        else:
+            # If the entry is a file, yield its path
+            yield full_path
+
+
 def hash_directory(path: str, skiplist: Optional[List[str]]) -> str:
     """Hash a directory with all its files."""
     digest = hashlib.md5()  # nosec
@@ -126,6 +142,25 @@ def hash_file(file_path: str, digest: "hashlib._Hash") -> "hashlib._Hash":
             buf = f_obj.read(1024 * 1024)
             while buf:
                 digest.update(buf)
+                buf = f_obj.read(1024 * 1024)
+
+    return digest
+
+
+def hash_file_normalized(file_path: str) -> "hashlib._Hash":
+    """
+    hash a file's contents, ignoring line feed differences (line ending normalization)
+    """
+    digest = hashlib.sha1(usedforsecurity=False)
+
+    if os.path.isfile(file_path):
+        normalize_re = re.compile(b"\r\n|\r")
+
+        with open(file_path, "rb") as f_obj:
+            buf = f_obj.read(1024 * 1024)
+            while buf:
+                normalized_buf = normalize_re.sub(b"\n", buf)
+                digest.update(normalized_buf)  # nosec
                 buf = f_obj.read(1024 * 1024)
 
     return digest


### PR DESCRIPTION
This is a prototype of enriching the metadata (`.dfetch_data.yml`) with data about each individual fetched file.

```yaml
files:
- <path>|<SHA-1 hash>|<file permissions>
```

This could help solve a few issues:

- #616 Non destructive file updates --> only tracked files are deleted
- #334 Using dfetch for template tracking --> only tracked files are deleted
- #350 Hashing untracked files --> only tracked files are hashed
- #267 Metadata part of patch --> only tracked files are hashed
- #90 Line endings --> hash can be implemented with normalized line endings

Next to that, it may assist in more enhancements later on:

- Report what exact file changed
- Also check changed file permissions
- Multiple single files in same dir? May need to bring multiple projects in a single metadata file.
- `dfetch diff` only creates a patch for fetched files.

A disadvantage would be that the metadata file becomes longer and `dfetch` becomes slower.
This branch sort of works, but it is proof-of-concept. Some things still required:

- [ ] normalized path separators in file paths.
- [ ] optimize / reduce data in metadata.
- [ ] determining what files were fetched and what files were existing.
- [ ] showing error if overwriting a file during an update and no `--force` was provided.

> [!NOTE]
> Since this may have significant impact on users, I would especially like to get the metadata layout right. 
> Backwards compatibility is off-course something that is a must to not annoy current users. 
> I'm looking for any feedback, positive or negative :wink: ( @jgeudens @sach-edna @deminngi
) .
>
> - Is a bigger and changed manifest & potential performance impact worth the additional possibilities?
> - Should `dfetch` make it possible to skip adding the extra info?
> - Do you see any problems I'm overlooking?
> - Should `dfetch` track more outside the content and permissions?
>

Here is a part of the beginning of the metadata file from an example project:

```yaml
# This is a generated file by dfetch. Don't edit this, but edit the manifest.
# For more info see https://dfetch.rtfd.io/en/latest/getting_started.html
dfetch:
  remote_url: https://github.com/cpputest/cpputest.git
  branch: master
  revision: ''
  last_fetch: 01/02/2025, 21:45:26
  tag: v3.4
  hash: ade6fb38b21bee516ffc657068c7058d
  patch: ''
  files:
  - docs/WalkThrough_VS21010.docx|b6d355e565db026333573739df74b499dd6dae90|666
  - makeVc6.bat|92fbc98a4d82c40aca5e0833a98daef552b37712|666
  - cpputest.pc.in|01c412b209793b6e9ea9d591341ee549ce06da05|666
  - tests/TestHarness_cTestCFile.c|e6f64813ba90a04b13bbe7bc2bd30c4c21bde449|666
  - tests/AllTests.vcproj|549a9949a25ff5ec0bd074df485f42e8090cdeef|666
  - tests/MemoryLeakDetectorTest.cpp|9c23efb92a5ccb04650aad7dbd45409bab290f1d|666
  - tests/CommandLineArgumentsTest.cpp|5acb1877eee2b7f55ac8871d6e40d4351709e9ac|666
  - tests/AllocLetTestFreeTest.cpp|ad22965b1decd3609bf227a708a65185b55d2cf2|666
  - tests/AllocLetTestFree.c|970be9610f9a7bd23b5ab45b8fa82b01f08bf419|666
  - tests/JUnitOutputTest.cpp|9f8528dbd8060709c5da79cb327a64323c8aabc9|666
  - tests/TestMemoryAllocatorTest.cpp|5c59b8eb2d57bdec178b1b30ef8586534930be24|666
  - tests/AllocationInCppFile.h|88e6bf900873c193d2acd0042bf40910805f90ab|666
  - tests/UtestTest.cpp|88ae650bf6f1f579cbbee206bf2e8505cf9cf795|666
  - tests/TestOutputTest.cpp|ff410d97e5db0f422732d66e276da36bebdd0f89|666
  - tests/TestHarness_cTest.cpp|456e0a6f32429540b5f3f998b9fba0dbe85580e1|666
  - tests/CppUTestExt/TestMockExpectedFunctionsList.cpp|064a721cda26f5b95ea180b5587e4b1fd547137d|666
  - tests/CppUTestExt/TestMemoryReportAllocator.cpp|a0892be7ab4c81ed50a7f50f8c10fa29066b8cd1|666
  - tests/CppUTestExt/TestMemoryReporterPlugin.cpp|fd09b5388139446301a2de109f87dc2738ad4f5a|666
  - tests/CppUTestExt/TestMockCheatSheet.cpp|c663bdbe20f2b9df17dda636e79f17dafd1487d3|666
  - tests/CppUTestExt/TestMockSupport.cpp|dc65526c4e4c70a588b13da583480958a8349aec|666
```
