### PR TITLE
Add gherkin scenario to documentation

### DIFF
--- a/dfetch/commands/check.py
+++ b/dfetch/commands/check.py
@@ -6,11 +6,6 @@ the available version. If there are new versions available this will be shown.
 .. uml:: /static/uml/check.puml
 
 .. scenario-include:: ../features/check-git-repo.feature
-   :scenario:
-        Git projects have changes
-        A newer tag is available than in manifest
-        Check is done after an update
-        Tag is updated in manifest
 
 Child-manifests
 ~~~~~~~~~~~~~~~

--- a/dfetch/commands/check.py
+++ b/dfetch/commands/check.py
@@ -5,6 +5,13 @@ the available version. If there are new versions available this will be shown.
 
 .. uml:: /static/uml/check.puml
 
+.. scenario-include:: ../features/check-git-repo.feature
+   :scenario:
+        Git projects have changes
+        A newer tag is available than in manifest
+        Check is done after an update
+        Tag is updated in manifest
+
 Child-manifests
 ~~~~~~~~~~~~~~~
 

--- a/dfetch/commands/diff.py
+++ b/dfetch/commands/diff.py
@@ -19,6 +19,11 @@ The below statement will generate a patch for ``some-project`` from your manifes
 
    dfetch diff some-project
 
+.. scenario-include:: ../features/diff-in-git.feature
+   :scenario:
+        A patch file is generated
+        Diff is generated on uncommitted changes
+
 
 Using the generated patch
 =========================

--- a/dfetch/commands/diff.py
+++ b/dfetch/commands/diff.py
@@ -20,10 +20,6 @@ The below statement will generate a patch for ``some-project`` from your manifes
    dfetch diff some-project
 
 .. scenario-include:: ../features/diff-in-git.feature
-   :scenario:
-        A patch file is generated
-        Diff is generated on uncommitted changes
-
 
 Using the generated patch
 =========================

--- a/dfetch/commands/freeze.py
+++ b/dfetch/commands/freeze.py
@@ -34,6 +34,9 @@ In our above example this would for instance result in:
            url: http://git.mycompany.local/mycompany/mymodule
            tag: v1.0.0
 
+.. scenario-include:: ../features/freeze-projects.feature
+   :scenario: Git projects are frozen
+
 """
 
 import argparse

--- a/dfetch/commands/freeze.py
+++ b/dfetch/commands/freeze.py
@@ -35,7 +35,6 @@ In our above example this would for instance result in:
            tag: v1.0.0
 
 .. scenario-include:: ../features/freeze-projects.feature
-   :scenario: Git projects are frozen
 
 """
 

--- a/dfetch/commands/import_.py
+++ b/dfetch/commands/import_.py
@@ -16,6 +16,8 @@ Migrating from git submodules
 * Download all your projects using :ref:`dfetch update<update>`.
 * Commit your projects as part of your project.
 
+.. scenario-include:: ../features/import-from-git.feature
+
 Switching branches
 ~~~~~~~~~~~~~~~~~~
 After importing submodules into a manifest in a branch, you might have some difficulties switching branches.
@@ -73,6 +75,8 @@ Migrating from SVN externals
 * Remove all svn externals (see `How do I remove svn::externals <https://stackoverflow.com/questions/1044649/>`_ ).
 * Download all your projects using :ref:`dfetch update<update>`.
 * Commit your projects as part of your project.
+
+.. scenario-include:: ../features/import-from-svn.feature
 
 """
 

--- a/dfetch/commands/update.py
+++ b/dfetch/commands/update.py
@@ -5,6 +5,11 @@ It tries to determine what kind of vcs it is: git, svn or something else.
 
 .. uml:: /static/uml/update.puml
 
+.. scenario-include:: ../features/fetch-git-repo.feature
+   :scenario:
+        Git projects are specified in the manifest
+        Tag is updated in manifest
+
 Child-manifests
 ~~~~~~~~~~~~~~~
 

--- a/dfetch/commands/update.py
+++ b/dfetch/commands/update.py
@@ -6,9 +6,6 @@ It tries to determine what kind of vcs it is: git, svn or something else.
 .. uml:: /static/uml/update.puml
 
 .. scenario-include:: ../features/fetch-git-repo.feature
-   :scenario:
-        Git projects are specified in the manifest
-        Tag is updated in manifest
 
 Child-manifests
 ~~~~~~~~~~~~~~~

--- a/dfetch/commands/validate.py
+++ b/dfetch/commands/validate.py
@@ -1,6 +1,12 @@
 """Note that you can validate your manifest using :ref:`validate`.
 
 This will parse your :ref:`Manifest` and check if all fields can be parsed.
+
+.. scenario-include:: ../features/validate-manifest.feature
+   :scenario:
+        A valid manifest is provided
+        An invalid manifest is provided
+
 """
 
 import argparse

--- a/dfetch/commands/validate.py
+++ b/dfetch/commands/validate.py
@@ -3,9 +3,6 @@
 This will parse your :ref:`Manifest` and check if all fields can be parsed.
 
 .. scenario-include:: ../features/validate-manifest.feature
-   :scenario:
-        A valid manifest is provided
-        An invalid manifest is provided
 
 """
 

--- a/dfetch/reporting/sbom_reporter.py
+++ b/dfetch/reporting/sbom_reporter.py
@@ -9,6 +9,10 @@ The tools track vulnerabilities or can enforce a license policy within an organi
 See https://cyclonedx.org/use-cases/ for more details.
 
 *Dfetch* will try to parse the license of project, this is retained during an :ref:`Update`.
+
+.. scenario-include:: ../features/report-sbom.feature
+   :scenario:
+        An fetched project generates an sbom
 """
 
 import json

--- a/doc/_ext/scenario_directive.py
+++ b/doc/_ext/scenario_directive.py
@@ -1,3 +1,30 @@
+"""
+This custom Sphinx directive dynamically includes scenarios from a Gherkin feature file.
+
+1. Enable the directive in your Sphinx `conf.py`:
+
+```python
+   extensions = ["your_extension_folder.scenario_directive"]
+```
+
+Use it in an .rst file:
+
+```rst
+.. scenario-include:: path/to/feature_file.feature
+   :scenario:
+      Scenario Title 1
+      Scenario Title 2
+```
+
+If `:scenario:` is omitted, all scenarios in the feature file will be included.
+The directive automatically detects Scenario: and Scenario Outline: titles.
+
+"""
+
+import os
+import re
+from typing import Iterable
+
 from docutils import nodes
 from docutils.parsers.rst import Directive
 
@@ -12,30 +39,53 @@ class ScenarioIncludeDirective(Directive):
         "scenario": str,
     }
 
+    def list_of_scenarios(self, feature_file_path: str) -> Iterable[str]:
+        """Parse the list of scenarios from the feature file"""
+        env = self.state.document.settings.env
+        feature_path = os.path.abspath(os.path.join(env.app.srcdir, feature_file_path))
+        if not os.path.exists(feature_path):
+            raise self.error(f"Feature file not found: {feature_path}")
+
+        with open(feature_path, encoding="utf-8") as f:
+            scenarios = [
+                m[1]
+                for m in re.findall(
+                    r"^\s*(Scenario(?: Outline)?):\s*(.+)$", f.read(), re.MULTILINE
+                )
+            ]
+        return scenarios
+
     def run(self):
+        """Generate the same literalinclude block for every scenario."""
         feature_file = self.arguments[0].strip()
+
+        scenarios_available = self.list_of_scenarios(feature_file)
+
         scenario_titles = [
             title.strip()
             for title in self.options.get("scenario", "").splitlines()
             if title.strip()
-        ]
-
-        if not scenario_titles:
-            raise self.error("At least one :scenario: must be provided.")
+        ] or scenarios_available
 
         container = nodes.section()
 
         for scenario_title in scenario_titles:
+            end_before = (
+                ":end-before: Scenario:"
+                if scenario_title != scenarios_available[-1]
+                else ""
+            )
+
             directive_rst = f"""
 .. details:: **Example**: {scenario_title}
 
     .. literalinclude:: {feature_file}
         :language: gherkin
         :caption: {feature_file}
-        :start-after: Scenario: {scenario_title}
-        :end-before: Scenario:
         :force:
         :dedent:
+        :start-after: Scenario: {scenario_title}
+        {end_before}
 """
             self.state.nested_parse(
                 self.state_machine.input_lines.__class__(directive_rst.splitlines()),
@@ -43,7 +93,7 @@ class ScenarioIncludeDirective(Directive):
                 container,
             )
 
-        return container.children  # Return parsed nodes instead of raw text
+        return container.children
 
 
 def setup(app):

--- a/doc/_ext/scenario_directive.py
+++ b/doc/_ext/scenario_directive.py
@@ -1,0 +1,50 @@
+from docutils import nodes
+from docutils.parsers.rst import Directive
+
+
+class ScenarioIncludeDirective(Directive):
+    """Custom directive to dynamically include scenarios from a Gherkin feature file."""
+
+    required_arguments = 1  # Only the feature file is required
+    optional_arguments = 0
+    final_argument_whitespace = False
+    option_spec = {
+        "scenario": str,
+    }
+
+    def run(self):
+        feature_file = self.arguments[0].strip()
+        scenario_titles = [
+            title.strip()
+            for title in self.options.get("scenario", "").splitlines()
+            if title.strip()
+        ]
+
+        if not scenario_titles:
+            raise self.error("At least one :scenario: must be provided.")
+
+        container = nodes.section()
+
+        for scenario_title in scenario_titles:
+            directive_rst = f"""
+.. details:: **Example**: {scenario_title}
+
+    .. literalinclude:: {feature_file}
+        :language: gherkin
+        :caption: {feature_file}
+        :start-after: Scenario: {scenario_title}
+        :end-before: Scenario:
+        :force:
+        :dedent:
+"""
+            self.state.nested_parse(
+                self.state_machine.input_lines.__class__(directive_rst.splitlines()),
+                self.content_offset,
+                container,
+            )
+
+        return container.children  # Return parsed nodes instead of raw text
+
+
+def setup(app):
+    app.add_directive("scenario-include", ScenarioIncludeDirective)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -18,10 +18,14 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import os
+import sys
 
 from dfetch import __version__
 
 # -- General configuration ------------------------------------------------
+
+ext_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "_ext"))
+sys.path.insert(0, ext_path)
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #
@@ -40,6 +44,7 @@ extensions = [
     "sphinxarg.ext",
     "sphinxcontrib.asciinema",
     "sphinxcontrib.details.directive",
+    "scenario_directive",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -32,13 +32,14 @@ from dfetch import __version__
 # ones.
 # extensions = ['sphinx.ext.autodoc', 'sphinx_autodoc_annotation', 'sphinx.ext.viewcode', 'sphinx.ext.napoleon', 'sphinxarg.ext', 'sphinx.ext.autosectionlabel']
 extensions = [
-    "sphinx.ext.autodoc",
-    "sphinx.ext.viewcode",
-    "sphinx.ext.napoleon",
-    "sphinxarg.ext",
-    "sphinx.ext.autosectionlabel",
     "plantweb.directive",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosectionlabel",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.viewcode",
+    "sphinxarg.ext",
     "sphinxcontrib.asciinema",
+    "sphinxcontrib.details.directive",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -31,6 +31,12 @@ All dependencies are pre-installed and makes it easy to get started.
 .. |CodespacesLink| image:: https://github.com/codespaces/badge.svg
 .. _CodespacesLink: https://codespaces.new/dfetch-org/dfetch
 
+.. tip::
+
+   You can preview the documentation locally by running, ``python -m http.server``
+   inside the ``doc/_build/html`` directory. Codespaces will automatically suggest to open the forwarded port 
+   to view the changes in your browser.
+
 Running in VSCode
 -----------------
 To debug or run directly from VSCode create the :ref:`virtual environment`.

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -91,29 +91,6 @@ Update
 
 .. automodule:: dfetch.commands.update
 
-Examples
-''''''''
-
-.. details:: **Example**: Git projects are specified in the manifest
-
-   .. literalinclude:: ../features/fetch-git-repo.feature
-      :prepend:
-         # -- FILE: features/fetch-git-repo.feature
-      :language: gherkin
-      :start-after: Scenario: Git projects are specified in the manifest
-      :end-before: Scenario:
-      :dedent:
-
-.. details:: **Example**: Tag is updated in manifest
-
-   .. literalinclude:: ../features/fetch-git-repo.feature
-      :prepend:
-         # -- FILE: features/fetch-git-repo.feature
-      :language: gherkin
-      :start-after: Scenario: Tag is updated in manifest
-      :end-before: Scenario:
-      :dedent:
-
 Validate
 --------
 .. argparse::

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -67,18 +67,6 @@ Software Bill-of-Materials
 
 .. asciinema:: asciicasts/sbom.cast
 
-Examples
-''''''''
-
-.. details:: **Example**: An fetched project generates an sbom
-
-   .. literalinclude:: ../features/report-sbom.feature
-      :prepend:
-         # -- FILE: features/report-sbom.feature
-      :language: gherkin
-      :start-after: Scenario: An fetched project generates an sbom
-      :dedent:
-
 Update
 ------
 .. argparse::

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -67,6 +67,18 @@ Software Bill-of-Materials
 
 .. asciinema:: asciicasts/sbom.cast
 
+Examples
+''''''''
+
+.. details:: **Example**: An fetched project generates an sbom
+
+   .. literalinclude:: ../features/report-sbom.feature
+      :prepend:
+         # -- FILE: features/report-sbom.feature
+      :language: gherkin
+      :start-after: Scenario: An fetched project generates an sbom
+      :dedent:
+
 Update
 ------
 .. argparse::
@@ -78,6 +90,29 @@ Update
 .. asciinema:: asciicasts/update.cast
 
 .. automodule:: dfetch.commands.update
+
+Examples
+''''''''
+
+.. details:: **Example**: Git projects are specified in the manifest
+
+   .. literalinclude:: ../features/fetch-git-repo.feature
+      :prepend:
+         # -- FILE: features/fetch-git-repo.feature
+      :language: gherkin
+      :start-after: Scenario: Git projects are specified in the manifest
+      :end-before: Scenario:
+      :dedent:
+
+.. details:: **Example**: Tag is updated in manifest
+
+   .. literalinclude:: ../features/fetch-git-repo.feature
+      :prepend:
+         # -- FILE: features/fetch-git-repo.feature
+      :language: gherkin
+      :start-after: Scenario: Tag is updated in manifest
+      :end-before: Scenario:
+      :dedent:
 
 Validate
 --------

--- a/features/check-git-repo.feature
+++ b/features/check-git-repo.feature
@@ -2,7 +2,7 @@ Feature: Checking dependencies from a git repository
 
     *DFetch* can check if there are new versions.
 
-    Scenario: Git projects are specified in the manifest
+    Scenario: Git projects have changes
         Given the manifest 'dfetch.yaml'
             """
             manifest:

--- a/features/freeze-projects.feature
+++ b/features/freeze-projects.feature
@@ -6,7 +6,7 @@ Feature: Freeze dependencies
 
     The same rules apply as for fetching, a tag has precedence over a branch and revision.
 
-    Scenario: Git projects are specified in the manifest
+    Scenario: Git projects are frozen
         Given the manifest 'dfetch.yaml'
             """
             manifest:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,8 @@ docs =[
     'sphinx-argparse==0.5.2',
     'plantweb==1.3.0',
     'sphinxcontrib.asciinema==0.4.2',
-    'sphinx_design==0.6.1'
+    'sphinx_design==0.6.1',
+    'sphinxcontrib-details-directive==0.1.0'
 ]
 test = [
     'pytest==8.3.4',


### PR DESCRIPTION
It is possible by adding this to .rst:

```rst
.. details:: **Example**: Git projects are specified in the manifest

   .. literalinclude:: ../features/fetch-git-repo.feature
      :prepend:
         # -- FILE: features/fetch-git-repo.feature
      :language: gherkin
      :start-after: Scenario: Git projects are specified in the manifest
      :end-before: Scenario:
      :dedent:

.. details:: **Example**: Tag is updated in manifest

   .. literalinclude:: ../features/fetch-git-repo.feature
      :prepend:
         # -- FILE: features/fetch-git-repo.feature
      :language: gherkin
      :start-after: Scenario: Tag is updated in manifest
      :end-before: Scenario:
      :dedent:
```

We can add it as collapsed example:

![afbeelding](https://github.com/user-attachments/assets/da1a13d8-c6d1-406b-88c5-7d35db6c215d)

Which would be a perfect up-to-date documentation.

Even better would be to add it to the module doc similar to the uml:

```py
"""Update is the main functionality of dfetch.

You can add Projects to your :ref:`Manifest` and update will fetch the version specified.
It tries to determine what kind of vcs it is: git, svn or something else.

.. uml:: /static/uml/update.puml

Examples
~~~~~~

.. featurs:: ../features/fetch-git-repo.feature

Child-manifests
~~~~~~~~~~~~~~~

It is possible that fetched projects have manifests of their own.
When these projects are fetched (with ``dfetch update``), the manifests are read as well
and will be checked to look for further dependencies. If you don't what recommendations, you can prevent *Dfetch*
checking child-manifests with ``--no-recommendations``.

"""
```


