### PR TITLE
Suggest full url from child manifest

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ Release 0.10.0 (unreleased)
 
 * Support python 3.13
 * Fix too strict overlapping path check (#684)
+* Show complete URL of child manifests (#683)
 
 Release 0.9.1 (released 2024-12-31)
 ===================================

--- a/dfetch/manifest/project.py
+++ b/dfetch/manifest/project.py
@@ -426,6 +426,10 @@ class ProjectEntry:  # pylint: disable=too-many-instance-attributes
         recommendation = self.copy(self)
         recommendation._dst = ""  # pylint: disable=protected-access
         recommendation._patch = ""  # pylint: disable=protected-access
+        recommendation._url = self.remote_url  # pylint: disable=protected-access
+        recommendation._remote = ""  # pylint: disable=protected-access
+        recommendation._remote_obj = None  # pylint: disable=protected-access
+        recommendation._repo_path = ""  # pylint: disable=protected-access
         return recommendation
 
     def as_yaml(self) -> Dict[str, str]:

--- a/features/checked-project-has-dependencies.feature
+++ b/features/checked-project-has-dependencies.feature
@@ -48,9 +48,16 @@ Feature: Check for dependencies in projects
             """
             manifest:
                 version: 0.0
+                remotes:
+                    - name: github-com-dfetch-org
+                      url-base: https://github.com/dfetch-org/test-repo
+
                 projects:
                     - name: SomeOtherProject
                       url: some-remote-server/SomeOtherProject.git
+                      tag: v1
+
+                    - name: ext/test-repo-tag-v1
                       tag: v1
             """
         And a git repository "SomeOtherProject.git"
@@ -67,6 +74,9 @@ Feature: Check for dependencies in projects
 
             -   name: SomeOtherProject
                 url: some-remote-server/SomeOtherProject.git
+                tag: v1
+            -   name: ext/test-repo-tag-v1
+                url: https://github.com/dfetch-org/test-repo
                 tag: v1
             """
 

--- a/features/updated-project-has-dependencies.feature
+++ b/features/updated-project-has-dependencies.feature
@@ -23,10 +23,17 @@ Feature: Updated project has dependencies
             """
             manifest:
                 version: 0.0
+                remotes:
+                    - name: github-com-dfetch-org
+                      url-base: https://github.com/dfetch-org/test-repo
+
                 projects:
                     - name: SomeOtherProject
                       dst: SomeOtherProject
                       url: some-remote-server/SomeOtherProject.git
+                      tag: v1
+
+                    - name: ext/test-repo-tag-v1
                       tag: v1
             """
         And a git repository "SomeProjectWithoutChild.git"
@@ -41,6 +48,9 @@ Feature: Updated project has dependencies
 
             -   name: SomeOtherProject
                 url: some-remote-server/SomeOtherProject.git
+                tag: v1
+            -   name: ext/test-repo-tag-v1
+                url: https://github.com/dfetch-org/test-repo
                 tag: v1
 
               SomeProjectWithoutChild: Fetched v1


### PR DESCRIPTION
Fixes #683

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Show complete URL of child manifests in project recommendations.

### Why are these changes being made?

This change improves the clarity and usability of the project recommendations by displaying the full URLs for child manifests, especially when dealing with dependencies that span multiple repositories. It addresses user feedback for better transparency and consistency in manifest management.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->