### PR TITLE
dfetch report doesn't show default remote

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Release 0.10.0 (unreleased)
 * Support python 3.13
 * Fix too strict overlapping path check (#684)
 * Show complete URL of child manifests (#683)
+* Show remote name when using default remote (#445)
 
 Release 0.9.1 (released 2024-12-31)
 ===================================

--- a/dfetch/manifest/manifest.py
+++ b/dfetch/manifest/manifest.py
@@ -113,7 +113,9 @@ class Manifest:
         if not default_remotes:
             default_remotes = list(self._remotes.values())[0:1]
 
-        self._default_remote = None if not default_remotes else default_remotes[0]
+        self._default_remote_name = (
+            "" if not default_remotes else default_remotes[0].name
+        )
         self._projects = self._init_projects(manifest["projects"])
 
     def _init_projects(
@@ -131,15 +133,14 @@ class Manifest:
             Dict[str, ProjectEntry]: Dictionary with key: Name of project, Value: ProjectEntry
         """
         _projects: Dict[str, ProjectEntry] = {}
+
         for project in projects:
             if isinstance(project, dict):
                 last_project = _projects[project["name"]] = ProjectEntry.from_yaml(
-                    project, self._default_remote
+                    project, self._default_remote_name
                 )
             elif isinstance(project, ProjectEntry):
-                last_project = _projects[project.name] = ProjectEntry.copy(
-                    project, self._default_remote
-                )
+                last_project = _projects[project.name] = ProjectEntry.copy(project)
             else:
                 raise RuntimeError(f"{project} has unknown type")
 

--- a/dfetch/manifest/project.py
+++ b/dfetch/manifest/project.py
@@ -270,7 +270,7 @@ ProjectEntryDict = TypedDict(
         "repo-path": str,
         "vcs": str,
         "ignore": Sequence[str],
-        "default_remote": Optional[Remote],
+        "default_remote": str,
     },
     total=False,
 )
@@ -285,7 +285,7 @@ class ProjectEntry:  # pylint: disable=too-many-instance-attributes
         self._revision: str = kwargs.get("revision", "")
 
         self._remote: str = kwargs.get("remote", "")
-        self._remote_obj: Optional[Remote] = kwargs.get("default_remote", None)
+        self._remote_obj: Optional[Remote] = None
         self._src: str = kwargs.get("src", "")  # noqa
         self._dst: str = kwargs.get("dst", self._name)
         self._url: str = kwargs.get("url", "")
@@ -296,11 +296,14 @@ class ProjectEntry:  # pylint: disable=too-many-instance-attributes
         self._vcs: str = kwargs.get("vcs", "")
         self._ignore: Sequence[str] = kwargs.get("ignore", [])
 
+        if not self._remote and not self._url:
+            self._remote = kwargs.get("default_remote", "")
+
     @classmethod
     def from_yaml(
         cls,
         yamldata: Union[Dict[str, str], ProjectEntryDict],
-        default_remote: Optional[Remote] = None,
+        default_remote: str = "",
     ) -> "ProjectEntry":
         """Create a Project Entry from yaml data.
 
@@ -317,15 +320,9 @@ class ProjectEntry:  # pylint: disable=too-many-instance-attributes
         return cls(kwargs)
 
     @classmethod
-    def copy(
-        cls, other: "ProjectEntry", default_remote: Optional[Remote] = None
-    ) -> "ProjectEntry":
+    def copy(cls, other: "ProjectEntry") -> "ProjectEntry":
         """Create a Project Entry copy from a Project Entry."""
-        # pylint: disable=protected-access
-        the_copy = copy.copy(other)
-        if not the_copy._remote_obj:
-            the_copy._remote_obj = default_remote
-        return the_copy
+        return copy.copy(other)
 
     def set_remote(self, remote: Remote) -> None:
         """Set the remote."""

--- a/features/list-projects.feature
+++ b/features/list-projects.feature
@@ -9,10 +9,18 @@ Feature: List dependencies
             manifest:
               version: '0.0'
 
+              remotes:
+                - name: github-com-dfetch-org
+                  url-base: https://github.com/dfetch-org/test-repo
+
               projects:
                 - name: ext/test-repo-tag
                   url: https://github.com/dfetch-org/test-repo
                   branch: main
+
+                - name: ext/test-rev-and-branch
+                  tag: v1
+                  dst: ext/test-rev-and-branch
 
             """
         And all projects are updated
@@ -27,6 +35,15 @@ Feature: List dependencies
                   tag             : <none>
                   last fetch      : 02/07/2021, 20:25:56
                   revision        : e1fda19a57b873eb8e6ae37780594cbb77b70f1a
+                  patch           : <none>
+                  license         : MIT License
+              project             : ext/test-rev-and-branch
+                  remote          : github-com-dfetch-org
+                  remote url      : https://github.com/dfetch-org/test-repo
+                  branch          : master
+                  tag             : v1
+                  last fetch      : 02/07/2021, 20:25:56
+                  revision        : <none>
                   patch           : <none>
                   license         : MIT License
             """
@@ -69,7 +86,7 @@ Feature: List dependencies
             """
             Dfetch (0.9.1)
               project             : ext/test-repo-tag
-                  remote          : <none>
+                  remote          : github-com-dfetch-org
                   remote url      : https://github.com/dfetch-org/test-repo
                   branch          : master
                   tag             : v2.0


### PR DESCRIPTION
Fixes #445

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Update the `dfetch report` command to display the remote name when using the default remote configuration.

### Why are these changes being made?
The previous implementation did not show the remote name when default remotes were used, leading to incomplete information in reports. This change enhances report completeness and accuracy, providing users with the necessary context about their project dependencies, specifically ensuring visibility of remote details even when defaults are employed.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->