### PR TITLE
Git: Auto-select HEAD branch as default branch

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Release 0.10.0 (unreleased)
 * Fix too strict overlapping path check (#684)
 * Show complete URL of child manifests (#683)
 * Show remote name when using default remote (#445)
+* Select HEAD branch as default in git (#689)
 
 Release 0.9.1 (released 2024-12-31)
 ===================================

--- a/dfetch/project/svn.py
+++ b/dfetch/project/svn.py
@@ -356,3 +356,7 @@ class SvnRepo(VCS):
             cmd += f":{new_revision}"
 
         return "\n".join(run_on_cmdline(logger, cmd).stdout.decode().splitlines())
+
+    def get_default_branch(self) -> str:
+        """Get the default branch of this repository."""
+        return self.DEFAULT_BRANCH

--- a/dfetch/project/vcs.py
+++ b/dfetch/project/vcs.py
@@ -28,7 +28,6 @@ class VCS(ABC):
     """
 
     NAME = ""
-    DEFAULT_BRANCH = ""
     LICENSE_GLOBS = ["licen[cs]e*", "copying*", "copyright*"]
 
     def __init__(self, project: dfetch.manifest.project.ProjectEntry) -> None:
@@ -52,7 +51,7 @@ class VCS(ABC):
 
         wanted_branch, on_disk_branch = "", ""
         if not (self.wanted_version.revision and self.revision_is_enough()):
-            wanted_branch = self.wanted_version.branch or self.DEFAULT_BRANCH
+            wanted_branch = self.wanted_version.branch or self.get_default_branch()
             on_disk_branch = on_disk.branch
 
         wanted_revision = (
@@ -313,7 +312,7 @@ class VCS(ABC):
         if self.wanted_version.branch == " ":
             branch = ""
         else:
-            branch = self.wanted_version.branch or self.DEFAULT_BRANCH
+            branch = self.wanted_version.branch or self.get_default_branch()
 
         if (
             not self.wanted_version.branch
@@ -357,6 +356,10 @@ class VCS(ABC):
     @abstractmethod
     def get_diff(self, old_revision: str, new_revision: Optional[str]) -> str:
         """Get the diff of two revisions."""
+
+    @abstractmethod
+    def get_default_branch(self) -> str:
+        """Get the default branch of this repository."""
 
     @staticmethod
     def is_license_file(filename: str) -> bool:

--- a/features/list-projects.feature
+++ b/features/list-projects.feature
@@ -40,7 +40,7 @@ Feature: List dependencies
               project             : ext/test-rev-and-branch
                   remote          : github-com-dfetch-org
                   remote url      : https://github.com/dfetch-org/test-repo
-                  branch          : master
+                  branch          : main
                   tag             : v1
                   last fetch      : 02/07/2021, 20:25:56
                   revision        : <none>
@@ -88,7 +88,7 @@ Feature: List dependencies
               project             : ext/test-repo-tag
                   remote          : github-com-dfetch-org
                   remote url      : https://github.com/dfetch-org/test-repo
-                  branch          : master
+                  branch          : main
                   tag             : v2.0
                   last fetch      : 02/07/2021, 20:25:56
                   revision        : <none>

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -49,6 +49,9 @@ class ConcreteVCS(VCS):
     def get_diff(self, old_revision, new_revision):
         return ""
 
+    def get_default_branch(self):
+        return ""
+
 
 @pytest.mark.parametrize(
     "name, given_on_disk, given_wanted, expect_wanted, expect_have",


### PR DESCRIPTION
Fixes #689

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the code to automatically select the HEAD branch as the default branch in Git repositories instead of assuming "master".

### Why are these changes being made?

This change addresses the evolving industry standards where "main" or other branches are often used as the primary branch instead of "master". It ensures that our tool dynamically determines the default branch, improving compatibility and flexibility with different repository configurations.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->