### PR TITLE
New alternatives

### DIFF
--- a/doc/alternatives.rst
+++ b/doc/alternatives.rst
@@ -20,6 +20,8 @@ Dfetch_                     ✔    ✔       ✔        ✔             ✔     
 `CPM.cmake`_                ✔    ✘       ✔        ✔         ✘ (C/C++)             ✘ (CMake)
 `CPPAN`_                    ✔    ✘       ✔        ✔         ✘ (C/C++)               ✔
 `degasolv`_                 ✔    ✘       ✔        ✔             ✔                   ✔
+`depman`_                   ✔    ✘       ✔        ✔             ✔                   ✔
+`depman bitrise`_           ✔    ✘       ✘        ✔             ✔                   ✔
 `Garden`_                   ✔    ✘       ✘        ✔             ✔                   ✔
 `gil`_                      ✔    ✘       ✔        ✔             ✔                   ✔
 `Git submodules`_           ✔    ✘       ✔        ✔             ✔                   ✔
@@ -68,6 +70,8 @@ Dfetch_                     ✔    ✔       ✔        ✔             ✔     
 .. _`CPM.cmake`: https://github.com/cpm-cmake/CPM.cmake
 .. _`CPPAN`: https://github.com/cppan/cppan
 .. _`degasolv`: https://github.com/djha-skin/degasolv
+.. _`depman`: https://github.com/depman-org/depman
+.. _`depman bitrise`: https://github.com/bitrise-io/depman
 .. _`Garden`: https://github.com/davvid/garden
 .. _`gil`: https://github.com/chronoxor/gil
 .. _`Git submodules`: https://git-scm.com/book/en/v2/Git-Tools-Submodules


### PR DESCRIPTION
Fixes #688

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Add `depman` and `depman bitrise` to the list of alternatives in the documentation.

### Why are these changes being made?
The additions ensure a more comprehensive list of tools by including options relevant to project management. This enhances user awareness of available alternatives, particularly for those interested in these specific tools.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->