### PR TITLE
Add correct permissions for uploading sarif

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -14,6 +14,9 @@ jobs:
 
   test-cygwin:
     runs-on: windows-latest
+    permissions:
+      contents: read
+      security-events: write
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -60,6 +63,9 @@ jobs:
         platform: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
     runs-on: ${{ matrix.platform }}
+    permissions:
+      contents: read
+      security-events: write
 
     steps:
       - name: Harden the runner (Audit all outbound calls)


### PR DESCRIPTION
Sarif uploading fails in main because  `security-events: write` permission is required

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Set GitHub Actions job permissions to allow uploading SARIF by adding:
- permissions: contents: read
- permissions: security-events: write
to both test-cygwin and matrix-based jobs in .github/workflows/run.yml.

### Why are these changes being made?
To enable uploading SARIF results from the workflow (code scanning) by granting the necessary security-events permission; this ensures SARIF data can be published during runs.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->