### PR TITLE
Drop python 3.7 & 3.8 support

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -61,7 +61,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     runs-on: ${{ matrix.platform }}
     permissions:
       contents: read

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Release 0.11.0 (unreleased)
 ====================================
 
+* Drop python 3.7, 3.8 support (#801)
 * Don't show animation when running in CI (#702)
 * Improve logic for creating Purls in SBoM (#780)
 * Add External VCS reference to SBoM if possible (#780)

--- a/dfetch/reporting/check/code_climate_reporter.py
+++ b/dfetch/reporting/check/code_climate_reporter.py
@@ -38,7 +38,7 @@ See `gitlab code quality reports`_ for more information.
 .. code-block:: yaml
 
     dfetch:
-      image: "python:3.7"
+      image: "python:3.13"
       script:
       - pip install dfetch
       - dfetch check --code-climate dfetch.json

--- a/dfetch/resources/__init__.py
+++ b/dfetch/resources/__init__.py
@@ -1,10 +1,6 @@
 """Resources needed when dfetch is distributed."""
 
-try:
-    import importlib.resources as importlib_resources
-except ModuleNotFoundError:
-    import importlib_resources  # type:ignore
-
+import importlib.resources as importlib_resources
 import sys
 from pathlib import Path
 from typing import ContextManager

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "dfetch"
 authors = [{ name = "Ben Spoor", email = "dfetch@spoor.cc" }]
 description = "Dependency fetcher"
 readme = { file = "README.md", content-type = "text/markdown" }
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 keywords = [
     "dfetch",
     "dependency management",
@@ -29,8 +29,6 @@ classifiers = [
     "Environment :: Console",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -46,15 +44,11 @@ dependencies = [
     "pykwalify==1.8.0",
     "halo==0.0.31",
     "colorama==0.4.6",
-    "typing-extensions==4.7.1; python_version <= '3.7.0'",
-    "typing-extensions==4.13.2; python_version <= '3.8.0'",
-    "typing-extensions==4.15.0; python_version > '3.8.0'",
-    "tldextract==5.1.2; python_version <= '3.8.0'",
-    "tldextract==5.3.0; python_version > '3.8.0'",
+    "typing-extensions==4.15.0",
+    "tldextract==5.3.0",
     "sarif-om==1.0.4",
     "semver==3.0.4",
     "patch-ng==1.18.1",
-    "importlib-resources==5.4.0; python_version <= '3.7.0'",
     "cyclonedx-python-lib==4.2.2",
     "infer-license==0.1.0; python_version <= '3.10.0'",
     "infer-license==0.2.0; python_version > '3.10.0'",


### PR DESCRIPTION
Both are EOL >6 months

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Drop Python 3.7 and 3.8 support and update CI, dependencies, and resource handling to reflect a minimum Python 3.9.

### Why are these changes being made?

Align with newer Python features and ecosystem changes; simplify compatibility shims and dependency constraints while updating CI image and release notes.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->