### PR TITLE
Installation from .zip fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ pip install dfetch
 ### latest version
 
 ```bash
-pip install https://github.com/dfetch-org/dfetch/archive/main.zip
+pip install git+https://github.com/dfetch-org/dfetch.git#egg=dfetch
 ```
 
 ## Github Action


### PR DESCRIPTION
Fixes #812

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update installation instruction to install dfetch via Git URL instead of downloading a .zip archive.

### Why are these changes being made?
To fix installation failures when using a .zip URL by using the correct pip install method (git+ URL) for the package.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->