### PR TITLE
Fix/pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -103,6 +103,7 @@ repos:
         description: Checks for common misspellings in text files.
         entry: codespell
         language: python
+        exclude: ^doc/_ext/sphinxcontrib_asciinema/_static/asciinema-player_3.12.1.js
         types: [text]
     -   id: ruff
         name: ruff


### PR DESCRIPTION
Running the quality task failed since pre-commit calls the tools file-per-file and for some tools this ignores the skip or exclusion list 

We should implement #19

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update pre-commit configuration to upgrade hooks and refine exclusions:
- Bump pre-commit-hooks from v5.0.0 to v6.0.0.
- Exclude generated asciinema-related assets from isort, Black, and codespell checks; and exclude the asciinema player JS file from codespell.
- Bump gitleaks from v8.16.3 to v8.28.0.

### Why are these changes being made?
Keep tooling up-to-date and reduce noise from generated documentation assets during checks; ensure scanning covers newer hook behavior and updated leak-detection rules.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->