### PR TITLE
Add version (e.g. 0.10.0)  to msi file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,8 @@ jobs:
     - name: Install binary
       if: matrix.platform == 'windows-latest'
       run: |
-        $file = "dfetch.msi"
+        $file = Get-ChildItem dfetch*.msi | Select-Object -First 1
+        if (-not $file) { throw "MSI not found" }
         $log = "install.log"
         $procMain = Start-Process "msiexec" "/i `"$file`" /qn /l*! `"$log`"" -NoNewWindow -PassThru
         $procLog = Start-Process "powershell" "Get-Content -Path `"$log`" -Wait" -NoNewWindow -PassThru

--- a/script/package.py
+++ b/script/package.py
@@ -243,6 +243,8 @@ def package_windows() -> None:
         ["dotnet", "build", str(wix_proj), "-c", "Release", "-o", str(OUTPUT_DIR)]
     )
 
+    shutil.move(OUTPUT_DIR / "dfetch.msi", msi_file)
+
     print(f"MSI generated at {msi_file}")
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Windows installer build: generated MSI is now renamed to include the package version for clearer distribution.
  * Added validation and selection during the Windows installer step to automatically pick the built MSI and fail early if none is found.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->