### PR TITLE
Use native line breaks in `dfetch import` and `dfetch freeze` manifests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,7 @@ Release 0.11.0 (unreleased)
 * Don't consider ignored files for determining local changes (#350)
 * Avoid waiting for user input in ``git`` & ``svn`` commands (#570)
 * Extend git ssh command to run in BatchMode (#570)
+* Use native line breaks in ``dfetch freeze`` & ``dfetch import`` (#327)
 
 Release 0.10.0 (released 2025-03-12)
 ====================================

--- a/dfetch/manifest/manifest.py
+++ b/dfetch/manifest/manifest.py
@@ -328,7 +328,11 @@ class Manifest:
         """Dump metadata file to correct path."""
         with open(path, "w+", encoding="utf-8") as manifest_file:
             yaml.dump(
-                self._as_dict(), manifest_file, Dumper=ManifestDumper, sort_keys=False
+                self._as_dict(),
+                manifest_file,
+                Dumper=ManifestDumper,
+                sort_keys=False,
+                line_break=os.linesep,
             )
 
     def find_name_in_manifest(self, name: str) -> ManifestEntryLocation:
@@ -412,12 +416,12 @@ class ManifestDumper(yaml.SafeDumper):  # pylint: disable=too-many-ancestors
 
     def write_line_break(self, data: Any = None) -> None:
         """Write a line break."""
-        super().write_line_break(data)  # type: ignore[unused-ignore]
+        super().write_line_break(data)  # type: ignore[unused-ignore, no-untyped-call]
 
         if len(self.indents) == 2 and getattr(self.event, "value", "") != "version":
-            super().write_line_break()  # type: ignore[unused-ignore]
+            super().write_line_break()  # type: ignore[unused-ignore, no-untyped-call]
 
         if len(self.indents) == 3 and self._last_additional_break != 2:
-            super().write_line_break()  # type: ignore[unused-ignore]
+            super().write_line_break()  # type: ignore[unused-ignore, no-untyped-call]
 
         self._last_additional_break = len(self.indents)


### PR DESCRIPTION
Fixes #327

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Manifest files now use native operating system line breaks when written, ensuring consistent formatting across different platforms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->