### PR TITLE
Fix asciinema path in manual documentation

### DIFF
--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -121,7 +121,7 @@ Update patch
    :prog: dfetch
    :path: update-patch
 
-.. asciinema:: asciicasts/update_patch.cast
+.. asciinema:: asciicasts/update-patch.cast
 
 .. automodule:: dfetch.commands.update_patch
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed reference path in Update patch documentation section to ensure the asciinema resource displays correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->