### PR TITLE
Fix mobile button overlap on landing page

### DIFF
--- a/doc/landing-page/index.rst
+++ b/doc/landing-page/index.rst
@@ -34,7 +34,8 @@ Dfetch
 no hidden external links. Dependencies live as plain, readable files inside your own repository.
 You stay in full control of every line.
 
-.. grid:: 3
+.. grid:: 1 1 3 3
+   :gutter: 3
 
     .. grid-item::
 


### PR DESCRIPTION
Change hero button grid from fixed 3 columns to responsive 1 1 3 3,
so buttons stack vertically on mobile/tablet instead of overlapping.

https://claude.ai/code/session_01P4pAKE18ux6WQrQV2mEkF6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved landing page grid layout for better responsiveness and spacing across different screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->