### PR TITLE
fix: pass secrets to test workflow so coverage upload runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
     uses: ./.github/workflows/test.yml
     permissions:
       contents: read
+    secrets: inherit
 
   docs:
     uses: ./.github/workflows/docs.yml


### PR DESCRIPTION
The test job in ci.yml was missing `secrets: inherit`, so
CODACY_PROJECT_TOKEN was never available and the coverage upload
step's condition always evaluated to false.

https://claude.ai/code/session_013sZvFxPLqJJzVpiRegohYm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow configuration to enable secret inheritance in testing operations, improving consistency between test and documentation jobs. This ensures proper secret management across automated testing processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->