### PR TITLE
Fix trailing slash in URL causing ValueError in add command (issue #1137)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Release 0.14.0 (unreleased)
 * Edit manifest in-place when freezing inside a git or SVN superproject, preserving comments and layout (#1063)
 * Add new ``remove`` command to remove projects from manifest and disk (#26)
 * Fix "unsafe symlink target" error for archives containing relative ``..`` symlinks (#1122)
+* Fix ``dfetch add`` crashing with a ``ValueError`` when the remote URL has a trailing slash (#1137)
 
 Release 0.13.0 (released 2026-03-30)
 ====================================

--- a/dfetch/util/purl.py
+++ b/dfetch/util/purl.py
@@ -114,6 +114,7 @@ def vcs_url_to_purl(
     Supports GitHub, Bitbucket, SVN, SSH paths, and generic VCS URLs.
     Optionally specify version and subpath.
     """
+    vcs_url = vcs_url.rstrip("/")
     purl = _known_purl_types(vcs_url, version, subpath)
     if purl:
         return purl

--- a/tests/test_purl.py
+++ b/tests/test_purl.py
@@ -115,6 +115,18 @@ from dfetch.vcs.archive import archive_url_to_purl
             "git://git.git.savannah.gnu.org/automake.git",
             "pkg:generic/automake?vcs_url=git://git.git.savannah.gnu.org/automake.git",
         ),
+        # Trailing slash – issue #1137
+        ("https://github.com/cpputest/cpputest/", "pkg:github/cpputest/cpputest"),
+        ("https://github.com/dfetch-org/dfetch/", "pkg:github/dfetch-org/dfetch"),
+        ("https://bitbucket.org/team/repo/", "pkg:bitbucket/team/repo"),
+        (
+            "https://gitlab.com/group/project/",
+            "pkg:generic/group/project?vcs_url=https://gitlab.com/group/project",
+        ),
+        (
+            "https://vcs.example.com/org/repo/",
+            "pkg:generic/example/org/repo?vcs_url=https://vcs.example.com/org/repo",
+        ),
     ],
 )
 def test_remote_url_to_purl(url, expected):


### PR DESCRIPTION
Strip trailing slashes from VCS URLs at the entry point of vcs_url_to_purl
so that patterns like https://github.com/org/repo/ are normalised before
regex matching and path splitting. Add parametrized regression tests for
GitHub, Bitbucket, GitLab, and generic URLs with trailing slashes.

https://claude.ai/code/session_01HousmFCGC1BbEczgkmTSC6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed a crash in `dfetch add` command when remote URLs ended with a trailing slash.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->