### PR TITLE
Add @command behave tags to all feature files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,9 @@ behave features/
 # Single feature file
 behave features/git-fetch.feature
 
+# Feature tests for a specific command (e.g. update, check, diff, report)
+behave features/ --tags=update
+
 # Full test run with coverage (as CI does it)
 pytest --cov=dfetch tests/
 coverage run --source=dfetch --append -m behave features
@@ -87,6 +90,7 @@ Implement the abstract interfaces in `dfetch/project/subproject.py` and `dfetch/
 
 - **Unit tests** live in `tests/` and use `pytest`. Test files mirror module names (e.g., `tests/test_manifest.py`).
 - **BDD feature tests** live in `features/` and use `behave`. Step definitions are in `features/steps/`. Feature files describe end-to-end workflows.
+- Feature files are tagged with the command they exercise (e.g. `@update`, `@check`). If your change affects a command, run its feature tests using the command tag: `behave features/ --tags=<command>`.
 - Docstrings in test functions follow Google style as a convention (CI runs `pydocstyle dfetch` and does not check `tests/`, so this is not enforced automatically).
 
 ## Code quality rules

--- a/doc/_ext/latex_tabs.py
+++ b/doc/_ext/latex_tabs.py
@@ -1,0 +1,166 @@
+"""PDF/LaTeX styling for sphinx-tabs directives.
+
+sphinx-tabs only registers HTML visitors for its custom node types.  For all
+other builders it falls back to plain ``nodes.container`` nodes, so the tab
+labels render as unstyled text with no visual separation between variants.
+
+This extension inserts a ``SphinxTransform`` (LaTeX/rinoh builds only) that
+rewrites the generic container tree produced by sphinx-tabs into custom
+``LatexTabsGroup`` / ``LatexTabEntry`` nodes, and registers LaTeX visitors
+that emit a small coloured label box before each tab's content.
+
+Expected result in PDF::
+
+    ┌──────────────────────────────┐
+    │  [Git]  ← coloured pill      │
+    │  content …                   │
+    │  ──────────────────────────  │
+    │  [SVN]                       │
+    │  content …                   │
+    │  ──────────────────────────  │
+    │  [Archive]                   │
+    │  content …                   │
+    └──────────────────────────────┘
+
+The styling uses the ``dfaccent`` and ``dfnearblack`` colours already defined
+in conf.py's LaTeX preamble.
+"""
+
+import re
+
+from docutils import nodes
+from sphinx.transforms import SphinxTransform
+
+# ---------------------------------------------------------------------------
+# Custom node types
+# ---------------------------------------------------------------------------
+
+
+class LatexTabsGroup(nodes.General, nodes.Element):
+    """Outer wrapper replacing a ``sphinx-tabs`` container in LaTeX output."""
+
+
+class LatexTabEntry(nodes.General, nodes.Element):
+    """One tab (label + content) inside a ``LatexTabsGroup``."""
+
+
+# ---------------------------------------------------------------------------
+# Transform: rewrite sphinx-tabs containers for LaTeX
+# ---------------------------------------------------------------------------
+
+_LATEX_SPECIAL = re.compile(r"([&%$#_{}~^\\])")
+
+
+def _escape_latex(text: str) -> str:
+    return _LATEX_SPECIAL.sub(lambda m: "\\" + m.group(1), text)
+
+
+class LatexTabsTransform(SphinxTransform):
+    """Convert sphinx-tabs containers into styled LatexTabsGroup nodes.
+
+    Only runs for latex/rinoh builders.  The sphinx-tabs fallback structure
+    for non-HTML builders is::
+
+        nodes.container [classes: ['sphinx-tabs']]
+          nodes.container  (outer per tab)
+            nodes.container  (tab — holds the label)
+            nodes.container  (panel — holds the content)
+
+    This transform converts that into::
+
+        LatexTabsGroup
+          LatexTabEntry [label="Git"]
+            <panel content nodes>
+          LatexTabEntry [label="SVN"]
+            <panel content nodes>
+          …
+    """
+
+    default_priority = 500
+
+    def apply(self, **kwargs) -> None:
+        if self.app.builder.name not in ("latex", "rinoh"):
+            return
+
+        for tabs_node in self.document.traverse(
+            lambda n: isinstance(n, nodes.container)
+            and "sphinx-tabs" in n.get("classes", [])
+        ):
+            group = LatexTabsGroup()
+            for outer in list(tabs_node.children):
+                if not isinstance(outer, nodes.container) or len(outer.children) < 2:
+                    continue
+                tab_container = outer.children[0]
+                panel = outer.children[1]
+
+                entry = LatexTabEntry()
+                entry["label"] = tab_container.astext().strip()
+                entry += list(panel.children)
+                group += entry
+
+            tabs_node.replace_self(group)
+
+
+# ---------------------------------------------------------------------------
+# LaTeX visitors
+# ---------------------------------------------------------------------------
+
+
+def visit_latex_tabs_group(translator, _node) -> None:
+    """Emit an opening rule before the tabs group."""
+    translator.body.append(
+        "\n\\vspace{4pt}\\noindent{\\color{dfaccent!40}\\rule{\\linewidth}{0.6pt}}\\vspace{-2pt}\n"
+    )
+
+
+def depart_latex_tabs_group(translator, _node) -> None:
+    """Emit a closing rule after the tabs group."""
+    translator.body.append(
+        "\n{\\color{dfaccent!40}\\rule{\\linewidth}{0.6pt}}\\vspace{4pt}\n"
+    )
+
+
+def visit_latex_tab_entry(translator, node) -> None:
+    """Emit a coloured pill label before the tab content."""
+    label = _escape_latex(node["label"])
+    translator.body.append(
+        f"\n\\noindent\\colorbox{{dfaccent!15}}{{\\strut\\textbf{{\\small\\textcolor{{dfaccent}}{{{label}}}}}}}"
+        f"\\par\\vspace{{2pt}}\n"
+    )
+
+
+def depart_latex_tab_entry(translator, _node) -> None:
+    """Emit a separator rule after the tab content."""
+    translator.body.append(
+        "\n\\vspace{2pt}\\noindent{\\color{dfaccent!25}\\rule{\\linewidth}{0.4pt}}\\vspace{-2pt}\n"
+    )
+
+
+def _html_skip(translator, node) -> None:
+    raise nodes.SkipNode
+
+
+# ---------------------------------------------------------------------------
+# Extension setup
+# ---------------------------------------------------------------------------
+
+
+def setup(app):
+    """Register nodes, visitors, and the LaTeX transform."""
+    app.add_node(
+        LatexTabsGroup,
+        latex=(visit_latex_tabs_group, depart_latex_tabs_group),
+        html=(_html_skip, None),
+    )
+    app.add_node(
+        LatexTabEntry,
+        latex=(visit_latex_tab_entry, depart_latex_tab_entry),
+        html=(_html_skip, None),
+    )
+    app.add_transform(LatexTabsTransform)
+
+    return {
+        "version": "0.1",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/doc/_ext/scenario_directive.py
+++ b/doc/_ext/scenario_directive.py
@@ -43,7 +43,10 @@ from typing import Dict, FrozenSet, List, Tuple
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
 from docutils.statemachine import StringList
+from sphinx.util import logging
 from sphinx.util.nodes import make_refnode
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Custom node types
@@ -309,6 +312,19 @@ class ScenarioIncludeDirective(Directive):
         available = _all_scenarios(feature_abs)
         scenario_titles = self._requested_scenarios(available)
 
+        if "scenario" in self.options:
+            available_titles = {title for _, title in available}
+            requested = [
+                t.strip() for t in self.options["scenario"].splitlines() if t.strip()
+            ]
+            missing = [t for t in requested if t not in available_titles]
+            if missing:
+                raise self.error(
+                    f"Scenario(s) not found in {feature_file}: {', '.join(missing)}"
+                )
+            if not scenario_titles:
+                raise self.error(f"No scenarios matched in {feature_file}.")
+
         if self._is_pdf() and "inline" not in self.options:
             return self._render_pdf(feature_file, feature_abs, scenario_titles)
 
@@ -454,6 +470,12 @@ def resolve_scenario_appendix_refs(
             else:
                 para += nodes.Text(" in the Appendix.")
         else:
+            logger.warning(
+                "PDF build will omit deferred scenario examples because no "
+                "'.. scenario-appendix::' directive was found in the document tree; "
+                "add it to a page (e.g. an appendix) to include deferred examples.",
+                location=ref_node,
+            )
             para += nodes.Text(f"See \u201c{title}\u201d {examples} in the Appendix.")
 
         ref_node.replace_self(para)

--- a/doc/_ext/scenario_directive.py
+++ b/doc/_ext/scenario_directive.py
@@ -1,104 +1,229 @@
 """
-This custom Sphinx directive dynamically includes scenarios from a Gherkin feature file.
+Custom Sphinx directive for including Gherkin scenarios from feature files.
 
-1. Enable the directive in your Sphinx `conf.py`:
+Usage in conf.py:
 
-```python
-   extensions = ["your_extension_folder.scenario_directive"]
-```
+    extensions = ["scenario_directive"]
 
-Use it in an .rst file:
+Usage in .rst files:
 
-```rst
-.. scenario-include:: path/to/feature_file.feature
-   :scenario:
-      Scenario Title 1
-      Scenario Title 2
-```
+    .. scenario-include:: ../features/fetch-git-repo.feature
+       :scenario:
+          Scenario Title 1
+          Scenario Title 2
 
-If `:scenario:` is omitted, all scenarios in the feature file will be included.
-The directive automatically detects Scenario: and Scenario Outline: titles.
+If ``:scenario:`` is omitted, all scenarios in the feature file are included.
 
+**PDF / LaTeX builds** automatically move scenarios to an appendix grouped by
+the behave command-tag (``@update``, ``@check``, …) that was placed on the
+feature file.  The directive's original location receives a cross-reference to
+the appendix entry instead.
+
+Use the ``:inline:`` flag to keep a specific inclusion in place even when
+building a PDF:
+
+    .. scenario-include:: ../features/fetch-git-repo.feature
+       :inline:
+
+The appendix itself is rendered by placing the companion directive anywhere in
+the document tree:
+
+    .. scenario-appendix::
+
+Behave tags treated as *command tags* map to the appendix sections.  Any tag
+that appears in ``_NON_COMMAND_TAGS`` (e.g. ``remote-svn``) is ignored when
+determining the command tag.
 """
 
 import html
 import os
 import re
-from typing import Tuple
+from typing import Dict, List, Optional, Tuple
 
 from docutils import nodes
-from docutils.parsers.rst import Directive
+from docutils.parsers.rst import Directive, directives
 from docutils.statemachine import StringList
 
 
-class ScenarioIncludeDirective(Directive):
-    """Custom directive to dynamically include scenarios from a Gherkin feature file."""
+# ---------------------------------------------------------------------------
+# Tags that are NOT command-name tags (infrastructure / skip markers).
+# ---------------------------------------------------------------------------
+_NON_COMMAND_TAGS = {"remote-svn"}
 
-    required_arguments = 1  # Only the feature file is required
+# Human-readable section titles for each command tag.
+_TAG_LABELS: Dict[str, str] = {
+    "update": "``dfetch update`` scenarios",
+    "check": "``dfetch check`` scenarios",
+    "add": "``dfetch add`` scenarios",
+    "remove": "``dfetch remove`` scenarios",
+    "diff": "``dfetch diff`` scenarios",
+    "update-patch": "``dfetch update-patch`` scenarios",
+    "format-patch": "``dfetch format-patch`` scenarios",
+    "freeze": "``dfetch freeze`` scenarios",
+    "import": "``dfetch import`` scenarios",
+    "report": "``dfetch report`` scenarios",
+    "validate": "``dfetch validate`` scenarios",
+}
+
+# Canonical display order for command tags in the appendix.
+_TAG_ORDER = [
+    "update",
+    "check",
+    "add",
+    "remove",
+    "diff",
+    "update-patch",
+    "format-patch",
+    "freeze",
+    "import",
+    "report",
+    "validate",
+]
+
+
+# ---------------------------------------------------------------------------
+# Custom node types
+# ---------------------------------------------------------------------------
+
+
+class scenario_appendix_placeholder(nodes.General, nodes.Element):
+    """Replaced by the full appendix content during the resolve phase."""
+
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+
+def _feature_tags(feature_path: str) -> List[str]:
+    """Return all behave tags declared before the ``Feature:`` line."""
+    tags: List[str] = []
+    with open(feature_path, encoding="utf-8") as fh:
+        for line in fh:
+            stripped = line.strip()
+            if stripped.startswith("Feature:"):
+                break
+            if stripped.startswith("@"):
+                tags.extend(t.lstrip("@") for t in stripped.split())
+    return tags
+
+
+def _command_tag(feature_path: str) -> str:
+    """Return the first non-infrastructure tag from the feature file, or 'other'."""
+    for tag in _feature_tags(feature_path):
+        if tag not in _NON_COMMAND_TAGS:
+            return tag
+    return "other"
+
+
+def _feature_title(feature_path: str) -> str:
+    """Return the text after ``Feature:`` in the feature file."""
+    with open(feature_path, encoding="utf-8") as fh:
+        for line in fh:
+            match = re.match(r"^\s*Feature:\s*(.+)$", line)
+            if match:
+                return match.group(1).strip()
+    return os.path.basename(feature_path)
+
+
+def _all_scenarios(feature_path: str) -> Tuple[str, ...]:
+    """Return all scenario titles in the feature file (preserves order)."""
+    with open(feature_path, encoding="utf-8") as fh:
+        return tuple(
+            re.findall(
+                r"^\s*Scenario(?:\s+Outline)?:\s*(.+)$", fh.read(), re.MULTILINE
+            )
+        )
+
+
+def _full_feature_content(feature_path: str) -> str:
+    """Return the complete textual content of a feature file."""
+    with open(feature_path, encoding="utf-8") as fh:
+        return fh.read()
+
+
+# ---------------------------------------------------------------------------
+# scenario-include directive
+# ---------------------------------------------------------------------------
+
+
+class ScenarioIncludeDirective(Directive):
+    """Include Gherkin scenarios from a feature file.
+
+    In PDF/LaTeX builds the scenarios are moved to a dedicated appendix and
+    replaced inline by a cross-reference, unless ``:inline:`` is given.
+    """
+
+    required_arguments = 1
     optional_arguments = 0
     final_argument_whitespace = False
     option_spec = {
         "scenario": str,
+        "inline": directives.flag,  # keep inline even in PDF mode
     }
 
-    def list_of_scenarios(self, feature_file_path: str) -> Tuple[str]:
-        """Parse the list of scenarios from the feature file"""
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _is_pdf(self) -> bool:
         env = self.state.document.settings.env
-        feature_path = os.path.abspath(os.path.join(env.app.srcdir, feature_file_path))
-        if not os.path.exists(feature_path):
-            raise self.error(f"Feature file not found: {feature_path}")
+        return env.app.builder.name in ("latex", "rinoh")
 
-        with open(feature_path, encoding="utf-8") as f:
-            scenarios = tuple(
-                m[1]
-                for m in re.findall(
-                    r"^\s*(Scenario(?: Outline)?):\s*(.+)$", f.read(), re.MULTILINE
-                )
-            )
-        return scenarios
-
-    def run(self):
-        """Generate the same literalinclude block for every scenario."""
+    def _feature_abs(self, feature_file: str) -> str:
         env = self.state.document.settings.env
-        feature_file = self.arguments[0].strip()
+        path = os.path.abspath(os.path.join(env.app.srcdir, feature_file))
+        if not os.path.exists(path):
+            raise self.error(f"Feature file not found: {path}")
+        return path
 
-        scenarios_available = self.list_of_scenarios(feature_file)
+    def _include_path(self, feature_abs: str) -> str:
+        """Path for literalinclude, relative to the current RST document."""
+        env = self.state.document.settings.env
+        current_doc_dir = os.path.dirname(
+            os.path.join(env.app.srcdir, env.docname)
+        )
+        return os.path.relpath(feature_abs, current_doc_dir)
 
-        # Compute a path for literalinclude that is relative to the current
-        # RST document's directory.  literalinclude resolves relative to the
-        # source file, while list_of_scenarios uses srcdir as the base — these
-        # differ once RST files are in sub-directories.
-        feature_abs = os.path.abspath(os.path.join(env.app.srcdir, feature_file))
-        current_doc_dir = os.path.dirname(os.path.join(env.app.srcdir, env.docname))
-        include_path = os.path.relpath(feature_abs, current_doc_dir)
+    def _requested_scenarios(
+        self, available: Tuple[str, ...]
+    ) -> List[str]:
+        return [
+            t.strip()
+            for t in self.options.get("scenario", "").splitlines()
+            if t.strip()
+        ] or list(available)
 
-        scenario_titles = [
-            title.strip()
-            for title in self.options.get("scenario", "").splitlines()
-            if title.strip()
-        ] or scenarios_available
+    # ------------------------------------------------------------------
+    # HTML / inline rendering (original behaviour)
+    # ------------------------------------------------------------------
 
+    def _render_html(
+        self,
+        include_path: str,
+        feature_file: str,
+        scenario_titles: List[str],
+        available: Tuple[str, ...],
+    ) -> List[nodes.Node]:
         container = nodes.section()
-
-        for scenario_title in scenario_titles:
+        for title in scenario_titles:
             end_before = (
                 ":end-before: Scenario:"
-                if scenario_title != scenarios_available[-1]
+                if title != available[-1]
                 else ""
             )
-
             directive_rst = f"""
 .. raw:: html
 
    <details>
-   <summary><strong>Example</strong>: {html.escape(scenario_title)}</summary>
+   <summary><strong>Example</strong>: {html.escape(title)}</summary>
 
 .. literalinclude:: {include_path}
     :language: gherkin
     :caption: {feature_file}
     :force:
     :dedent:
-    :start-after: Scenario: {scenario_title}
+    :start-after: Scenario: {title}
     {end_before}
 
 .. raw:: html
@@ -108,16 +233,227 @@ class ScenarioIncludeDirective(Directive):
             viewlist = StringList()
             for i, line in enumerate(directive_rst.splitlines()):
                 viewlist.append(line, source=f"<{self.name} directive>", offset=i)
-
-            self.state.nested_parse(
-                viewlist,
-                self.content_offset,
-                container,
-            )
-
+            self.state.nested_parse(viewlist, self.content_offset, container)
         return container.children
+
+    # ------------------------------------------------------------------
+    # PDF rendering: register for appendix, return cross-reference
+    # ------------------------------------------------------------------
+
+    def _render_pdf(
+        self,
+        feature_file: str,
+        feature_abs: str,
+        scenario_titles: List[str],
+    ) -> List[nodes.Node]:
+        env = self.state.document.settings.env
+        basename = os.path.splitext(os.path.basename(feature_abs))[0]
+        label = f"appendix-{basename}"
+        tag = _command_tag(feature_abs)
+        title = _feature_title(feature_abs)
+
+        # ----------------------------------------------------------
+        # Store entry so the appendix directive can render it later.
+        # The dict is keyed by absolute path to deduplicate across
+        # multiple RST files that reference the same feature.
+        # ----------------------------------------------------------
+        if not hasattr(env, "scenario_appendix_entries"):
+            env.scenario_appendix_entries = {}
+
+        if feature_abs not in env.scenario_appendix_entries:
+            env.scenario_appendix_entries[feature_abs] = {
+                "feature_file": feature_file,
+                "feature_abs": feature_abs,
+                "feature_title": title,
+                "command_tag": tag,
+                "label": label,
+                "source_doc": env.docname,
+                "scenarios": list(scenario_titles),
+            }
+        else:
+            existing = env.scenario_appendix_entries[feature_abs]
+            for s in scenario_titles:
+                if s not in existing["scenarios"]:
+                    existing["scenarios"].append(s)
+
+        # ----------------------------------------------------------
+        # Return a short paragraph pointing to the appendix.
+        # nodes.reference(internal=True, refid=...) produces a
+        # \hyperref in LaTeX, which works within one compiled PDF.
+        # ----------------------------------------------------------
+        para = nodes.paragraph()
+        para += nodes.emphasis(text="Scenarios: see ")
+        ref = nodes.reference("", title, internal=True, refid=label)
+        para += ref
+        para += nodes.emphasis(text=" in the appendix.")
+        return [para]
+
+    # ------------------------------------------------------------------
+    # Entry point
+    # ------------------------------------------------------------------
+
+    def run(self) -> List[nodes.Node]:
+        feature_file = self.arguments[0].strip()
+        feature_abs = self._feature_abs(feature_file)
+        available = _all_scenarios(feature_abs)
+        scenario_titles = self._requested_scenarios(available)
+
+        if self._is_pdf() and "inline" not in self.options:
+            return self._render_pdf(feature_file, feature_abs, scenario_titles)
+
+        return self._render_html(
+            self._include_path(feature_abs),
+            feature_file,
+            scenario_titles,
+            available,
+        )
+
+
+# ---------------------------------------------------------------------------
+# scenario-appendix directive
+# ---------------------------------------------------------------------------
+
+
+class ScenarioAppendixDirective(Directive):
+    """Render the appendix of all PDF-deferred scenarios.
+
+    Place this directive once in the document (typically in an appendix
+    page).  During the write phase it is replaced by sections grouped by
+    command tag, containing the full content of each referenced feature file.
+
+    In HTML builds scenarios appear inline in the main text, so this
+    directive emits an explanatory note instead.
+    """
+
+    required_arguments = 0
+    optional_arguments = 0
+    has_content = False
+
+    def run(self) -> List[nodes.Node]:
+        env = self.state.document.settings.env
+        if env.app.builder.name not in ("latex", "rinoh"):
+            # HTML: scenarios are inline; provide a brief orientation note.
+            note = nodes.note()
+            para = nodes.paragraph()
+            para += nodes.Text(
+                "In the HTML edition, feature scenarios appear as expandable "
+                "examples directly within each guide section. "
+                "In the PDF edition they are collected here, grouped by command."
+            )
+            note += para
+            return [note]
+
+        node = scenario_appendix_placeholder()
+        return [node]
+
+
+# ---------------------------------------------------------------------------
+# Event: replace placeholder with actual appendix content
+# ---------------------------------------------------------------------------
+
+def _build_appendix_nodes(
+    entries: Dict,
+) -> List[nodes.Node]:
+    """Build docutils section nodes for every collected appendix entry."""
+    # Group by command tag
+    by_tag: Dict[str, List] = {}
+    for entry in entries.values():
+        by_tag.setdefault(entry["command_tag"], []).append(entry)
+
+    # Determine display order
+    ordered_tags = sorted(
+        by_tag.keys(),
+        key=lambda t: (
+            _TAG_ORDER.index(t) if t in _TAG_ORDER else len(_TAG_ORDER),
+            t,
+        ),
+    )
+
+    result: List[nodes.Node] = []
+    for tag in ordered_tags:
+        tag_entries = sorted(by_tag[tag], key=lambda e: e["feature_title"])
+        label = f"appendix-{tag}"
+        section_title = _TAG_LABELS.get(tag, f"``dfetch {tag}`` scenarios")
+
+        tag_section = nodes.section()
+        tag_section["ids"] = [label]
+        tag_section["names"] = [label]
+        tag_section += nodes.title(text=section_title)
+
+        for entry in tag_entries:
+            feat_section = nodes.section()
+            feat_section["ids"] = [entry["label"]]
+            feat_section["names"] = [entry["label"]]
+            feat_section += nodes.title(text=entry["feature_title"])
+
+            content = _full_feature_content(entry["feature_abs"])
+            code = nodes.literal_block(content, content)
+            code["language"] = "gherkin"
+            feat_section += code
+
+            tag_section += feat_section
+
+        result.append(tag_section)
+
+    return result
+
+
+def process_scenario_appendix(
+    app, doctree: nodes.document, fromdocname: str
+) -> None:
+    """Replace scenario_appendix_placeholder nodes with generated content."""
+    placeholders = list(doctree.traverse(scenario_appendix_placeholder))
+    if not placeholders:
+        return
+
+    entries = getattr(app.env, "scenario_appendix_entries", {})
+    appendix_nodes = _build_appendix_nodes(entries) if entries else []
+
+    for placeholder in placeholders:
+        placeholder.replace_self(appendix_nodes)
+
+
+def purge_scenario_appendix(app, env, docname: str) -> None:
+    """Remove appendix entries that originated from a re-read document."""
+    if not hasattr(env, "scenario_appendix_entries"):
+        return
+    env.scenario_appendix_entries = {
+        k: v
+        for k, v in env.scenario_appendix_entries.items()
+        if v.get("source_doc") != docname
+    }
+
+
+def merge_scenario_appendix(app, env, docnames, other) -> None:
+    """Merge appendix entries from a parallel read worker."""
+    if not hasattr(env, "scenario_appendix_entries"):
+        env.scenario_appendix_entries = {}
+    for key, entry in getattr(other, "scenario_appendix_entries", {}).items():
+        if key not in env.scenario_appendix_entries:
+            env.scenario_appendix_entries[key] = entry
+        else:
+            existing = env.scenario_appendix_entries[key]
+            for scenario in entry["scenarios"]:
+                if scenario not in existing["scenarios"]:
+                    existing["scenarios"].append(scenario)
+
+
+# ---------------------------------------------------------------------------
+# Sphinx extension setup
+# ---------------------------------------------------------------------------
 
 
 def setup(app):
-    """Setup the directive."""
+    """Register directives, nodes, and event hooks."""
     app.add_directive("scenario-include", ScenarioIncludeDirective)
+    app.add_directive("scenario-appendix", ScenarioAppendixDirective)
+    app.add_node(scenario_appendix_placeholder)
+    app.connect("doctree-resolved", process_scenario_appendix)
+    app.connect("env-purge-doc", purge_scenario_appendix)
+    app.connect("env-merge-info", merge_scenario_appendix)
+
+    return {
+        "version": "0.2",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/doc/_ext/scenario_directive.py
+++ b/doc/_ext/scenario_directive.py
@@ -1,5 +1,5 @@
 """
-Custom Sphinx directive for including Gherkin scenarios from feature files.
+Custom Sphinx directive for including feature examples from feature files.
 
 Usage in conf.py:
 
@@ -14,12 +14,12 @@ Usage in .rst files:
 
     .. scenario-include:: ../features/fetch-git-repo.feature
        :scenario:
-          Scenario Title 1
-          Scenario Title 2
+          Example Title 1
+          Example Title 2
 
-If ``:scenario:`` is omitted, all scenarios in the feature file are included.
+If ``:scenario:`` is omitted, all examples in the feature file are included.
 
-**PDF / LaTeX builds** automatically move scenarios to an appendix grouped by
+**PDF / LaTeX builds** automatically move examples to an appendix grouped by
 the first non-excluded behave tag found on the feature file.  The directive's
 original location receives a cross-reference to the appendix entry instead.
 
@@ -144,9 +144,9 @@ def _tag_section_title(tag: str) -> str:
 
 
 class ScenarioIncludeDirective(Directive):
-    """Include Gherkin scenarios from a feature file.
+    """Include feature examples from a feature file.
 
-    In PDF/LaTeX builds the scenarios are moved to a dedicated appendix and
+    In PDF/LaTeX builds the examples are moved to a dedicated appendix and
     replaced inline by a cross-reference, unless ``:inline:`` is given.
     """
 
@@ -295,9 +295,9 @@ class ScenarioIncludeDirective(Directive):
         ref_node["label"] = label
         ref_node["reftitle"] = title
         para = nodes.paragraph()
-        para += nodes.emphasis(text="Scenarios: see ")
+        para += nodes.Text("See the example \u201c")
         para += ref_node
-        para += nodes.emphasis(text=" in the appendix.")
+        para += nodes.Text("\u201d in the Appendix.")
         return [para]
 
     # ------------------------------------------------------------------
@@ -327,14 +327,14 @@ class ScenarioIncludeDirective(Directive):
 
 
 class ScenarioAppendixDirective(Directive):
-    """Render the appendix of all PDF-deferred scenarios.
+    """Render the appendix of all PDF-deferred feature examples.
 
     Place this directive once in the document (typically in an appendix
     page).  During the write phase it is replaced by sections grouped by
     the first non-excluded tag, sorted alphabetically, containing the full
     content of each referenced feature file.
 
-    In HTML builds scenarios appear inline in the main text, so this
+    In HTML builds examples appear inline in the main text, so this
     directive emits an explanatory note instead.
     """
 
@@ -348,9 +348,9 @@ class ScenarioAppendixDirective(Directive):
             note = nodes.note()
             para = nodes.paragraph()
             para += nodes.Text(
-                "In the HTML edition, feature scenarios appear as expandable "
-                "examples directly within each guide section. "
-                "In the PDF edition they are collected here, grouped by tag."
+                "In the HTML edition, feature examples appear as expandable "
+                "blocks directly within each guide section. "
+                "In the PDF edition they are collected here, grouped by command."
             )
             note += para
             return [note]

--- a/doc/_ext/scenario_directive.py
+++ b/doc/_ext/scenario_directive.py
@@ -53,6 +53,15 @@ class ScenarioAppendixPlaceholder(nodes.General, nodes.Element):
     """Replaced by the full appendix content during the resolve phase."""
 
 
+class ScenarioAppendixRef(nodes.General, nodes.Inline, nodes.Element):
+    """Deferred cross-reference to a scenario appendix entry.
+
+    Stores ``label`` and ``reftitle`` as attributes.  Resolved to a proper
+    ``nodes.reference`` with ``refdocname`` set during ``doctree-resolved``,
+    once the appendix document name is known from the environment.
+    """
+
+
 # ---------------------------------------------------------------------------
 # Helper functions
 # ---------------------------------------------------------------------------
@@ -276,13 +285,18 @@ class ScenarioIncludeDirective(Directive):
 
         # ----------------------------------------------------------
         # Return a short paragraph pointing to the appendix.
-        # nodes.reference(internal=True, refid=...) produces a
-        # \hyperref in LaTeX, which works within one compiled PDF.
+        # Use a deferred ScenarioAppendixRef node; it is resolved to a
+        # nodes.reference with refdocname set in doctree-resolved, once
+        # the appendix document name is known.  Sphinx's LaTeX writer
+        # requires refdocname to construct the \hyperref[docname:id]
+        # label correctly — omitting it silently drops the hyperlink.
         # ----------------------------------------------------------
+        ref_node = ScenarioAppendixRef()
+        ref_node["label"] = label
+        ref_node["reftitle"] = title
         para = nodes.paragraph()
         para += nodes.emphasis(text="Scenarios: see ")
-        ref = nodes.reference("", title, internal=True, refid=label)
-        para += ref
+        para += ref_node
         para += nodes.emphasis(text=" in the appendix.")
         return [para]
 
@@ -341,6 +355,9 @@ class ScenarioAppendixDirective(Directive):
             note += para
             return [note]
 
+        # Record which document hosts the appendix so that ScenarioAppendixRef
+        # nodes in other documents can be resolved with the correct refdocname.
+        env.scenario_appendix_docname = env.docname
         node = ScenarioAppendixPlaceholder()
         return [node]
 
@@ -386,6 +403,29 @@ def _build_appendix_nodes(entries: Dict) -> List[nodes.Node]:
     return result
 
 
+def resolve_scenario_appendix_refs(
+    app, doctree: nodes.document, _fromdocname: str
+) -> None:
+    """Replace ScenarioAppendixRef nodes with resolved cross-references.
+
+    Called for every document during doctree-resolved.  By that point all
+    source files have been read, so ``env.scenario_appendix_docname`` is set.
+    Sphinx's LaTeX writer needs ``refdocname`` on internal references to build
+    the ``docname:id`` label key used for ``\\hyperref`` targets.
+    """
+    appendix_docname = getattr(app.env, "scenario_appendix_docname", None)
+    for ref_node in doctree.traverse(ScenarioAppendixRef):
+        label = ref_node["label"]
+        title = ref_node["reftitle"]
+        if appendix_docname:
+            ref = nodes.reference(
+                "", title, internal=True, refid=label, refdocname=appendix_docname
+            )
+        else:
+            ref = nodes.inline("", title)
+        ref_node.replace_self(ref)
+
+
 def process_scenario_appendix(app, doctree: nodes.document, _fromdocname: str) -> None:
     """Replace ScenarioAppendixPlaceholder nodes with generated content."""
     placeholders = list(doctree.traverse(ScenarioAppendixPlaceholder))
@@ -414,6 +454,10 @@ def purge_scenario_appendix(_app, env, docname: str) -> None:
 
 def merge_scenario_appendix(_app, env, _docnames, other) -> None:
     """Merge appendix entries from a parallel read worker."""
+    if hasattr(other, "scenario_appendix_docname") and not hasattr(
+        env, "scenario_appendix_docname"
+    ):
+        env.scenario_appendix_docname = other.scenario_appendix_docname
     if not hasattr(env, "scenario_appendix_entries"):
         env.scenario_appendix_entries = {}
     for key, entry in getattr(other, "scenario_appendix_entries", {}).items():
@@ -438,6 +482,8 @@ def setup(app):
     app.add_directive("scenario-include", ScenarioIncludeDirective)
     app.add_directive("scenario-appendix", ScenarioAppendixDirective)
     app.add_node(ScenarioAppendixPlaceholder)
+    app.add_node(ScenarioAppendixRef)
+    app.connect("doctree-resolved", resolve_scenario_appendix_refs)
     app.connect("doctree-resolved", process_scenario_appendix)
     app.connect("env-purge-doc", purge_scenario_appendix)
     app.connect("env-merge-info", merge_scenario_appendix)

--- a/doc/_ext/scenario_directive.py
+++ b/doc/_ext/scenario_directive.py
@@ -43,6 +43,7 @@ from typing import Dict, FrozenSet, List, Tuple
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
 from docutils.statemachine import StringList
+from sphinx.util.nodes import make_refnode
 
 # ---------------------------------------------------------------------------
 # Custom node types
@@ -53,12 +54,12 @@ class ScenarioAppendixPlaceholder(nodes.General, nodes.Element):
     """Replaced by the full appendix content during the resolve phase."""
 
 
-class ScenarioAppendixRef(nodes.General, nodes.Inline, nodes.Element):
+class ScenarioAppendixRef(nodes.General, nodes.Element):
     """Deferred cross-reference to a scenario appendix entry.
 
-    Stores ``label`` and ``reftitle`` as attributes.  Resolved to a proper
-    ``nodes.reference`` with ``refdocname`` set during ``doctree-resolved``,
-    once the appendix document name is known from the environment.
+    Stores ``label``, ``reftitle``, ``group_tag``, and ``group_label`` as
+    attributes.  Resolved to a paragraph with ``make_refnode`` links during
+    ``doctree-resolved``, once the appendix document name is known.
     """
 
 
@@ -284,21 +285,19 @@ class ScenarioIncludeDirective(Directive):
                     existing["scenarios"].append(s)
 
         # ----------------------------------------------------------
-        # Return a short paragraph pointing to the appendix.
-        # Use a deferred ScenarioAppendixRef node; it is resolved to a
-        # nodes.reference with refdocname set in doctree-resolved, once
-        # the appendix document name is known.  Sphinx's LaTeX writer
-        # requires refdocname to construct the \hyperref[docname:id]
-        # label correctly — omitting it silently drops the hyperlink.
+        # Return a deferred ScenarioAppendixRef block node.  It is
+        # resolved to a full paragraph with make_refnode links during
+        # doctree-resolved, once the appendix document name is known.
+        # Sphinx's make_refnode handles LaTeX/HTML builder differences,
+        # producing a proper \hyperref in PDF output.
         # ----------------------------------------------------------
         ref_node = ScenarioAppendixRef()
         ref_node["label"] = label
         ref_node["reftitle"] = title
-        para = nodes.paragraph()
-        para += nodes.Text("See the example \u201c")
-        para += ref_node
-        para += nodes.Text("\u201d in the Appendix.")
-        return [para]
+        ref_node["group_tag"] = tag
+        ref_node["group_label"] = f"appendix-{tag}"
+        ref_node["scenario_count"] = len(scenario_titles)
+        return [ref_node]
 
     # ------------------------------------------------------------------
     # Entry point
@@ -404,26 +403,60 @@ def _build_appendix_nodes(entries: Dict) -> List[nodes.Node]:
 
 
 def resolve_scenario_appendix_refs(
-    app, doctree: nodes.document, _fromdocname: str
+    app, doctree: nodes.document, fromdocname: str
 ) -> None:
-    """Replace ScenarioAppendixRef nodes with resolved cross-references.
+    """Replace ScenarioAppendixRef nodes with a paragraph containing clickable links.
 
     Called for every document during doctree-resolved.  By that point all
-    source files have been read, so ``env.scenario_appendix_docname`` is set.
-    Sphinx's LaTeX writer needs ``refdocname`` on internal references to build
-    the ``docname:id`` label key used for ``\\hyperref`` targets.
+    source files have been read so ``env.scenario_appendix_docname`` is set.
+    ``make_refnode`` is used so that both the HTML and LaTeX (PDF) builders
+    receive a properly formed internal reference — LaTeX needs this to emit a
+    working ``\\hyperref``.
+
+    The paragraph text names the group section so readers can locate the entry
+    without guessing where in the appendix it lives, e.g.:
+
+        See "Fetch Git Repo" example in the Fetch section of the Appendix.
     """
     appendix_docname = getattr(app.env, "scenario_appendix_docname", None)
     for ref_node in doctree.traverse(ScenarioAppendixRef):
         label = ref_node["label"]
         title = ref_node["reftitle"]
+        group_tag = ref_node.get("group_tag", "")
+        group_label = ref_node.get("group_label", "")
+
+        count = ref_node.get("scenario_count", 1)
+        examples = "examples" if count > 1 else "example"
+
+        para = nodes.paragraph()
         if appendix_docname:
-            ref = nodes.reference(
-                "", title, internal=True, refid=label, refdocname=appendix_docname
+            feat_ref = make_refnode(
+                app.builder,
+                fromdocname,
+                appendix_docname,
+                label,
+                nodes.inline("", title),
             )
+            para += nodes.Text("See \u201c")
+            para += feat_ref
+            para += nodes.Text(f"\u201d {examples}")
+            if group_label and group_tag:
+                group_ref = make_refnode(
+                    app.builder,
+                    fromdocname,
+                    appendix_docname,
+                    group_label,
+                    nodes.inline("", _tag_section_title(group_tag)),
+                )
+                para += nodes.Text(" in the ")
+                para += group_ref
+                para += nodes.Text(" section of the Appendix.")
+            else:
+                para += nodes.Text(" in the Appendix.")
         else:
-            ref = nodes.inline("", title)
-        ref_node.replace_self(ref)
+            para += nodes.Text(f"See \u201c{title}\u201d {examples} in the Appendix.")
+
+        ref_node.replace_self(para)
 
 
 def process_scenario_appendix(app, doctree: nodes.document, _fromdocname: str) -> None:

--- a/doc/_ext/scenario_directive.py
+++ b/doc/_ext/scenario_directive.py
@@ -5,6 +5,11 @@ Usage in conf.py:
 
     extensions = ["scenario_directive"]
 
+    # Tags that are NOT group keys (e.g. environment markers).
+    # The first tag on a feature file that is not in this list becomes
+    # the appendix section for that file.  Default: no exclusions.
+    scenario_non_command_tags = ["remote-svn"]
+
 Usage in .rst files:
 
     .. scenario-include:: ../features/fetch-git-repo.feature
@@ -15,9 +20,8 @@ Usage in .rst files:
 If ``:scenario:`` is omitted, all scenarios in the feature file are included.
 
 **PDF / LaTeX builds** automatically move scenarios to an appendix grouped by
-the behave command-tag (``@update``, ``@check``, …) that was placed on the
-feature file.  The directive's original location receives a cross-reference to
-the appendix entry instead.
+the first non-excluded behave tag found on the feature file.  The directive's
+original location receives a cross-reference to the appendix entry instead.
 
 Use the ``:inline:`` flag to keep a specific inclusion in place even when
 building a PDF:
@@ -29,64 +33,23 @@ The appendix itself is rendered by placing the companion directive anywhere in
 the document tree:
 
     .. scenario-appendix::
-
-Behave tags treated as *command tags* map to the appendix sections.  Any tag
-that appears in ``_NON_COMMAND_TAGS`` (e.g. ``remote-svn``) is ignored when
-determining the command tag.
 """
 
 import html
 import os
 import re
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, FrozenSet, List, Tuple
 
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
 from docutils.statemachine import StringList
-
-
-# ---------------------------------------------------------------------------
-# Tags that are NOT command-name tags (infrastructure / skip markers).
-# ---------------------------------------------------------------------------
-_NON_COMMAND_TAGS = {"remote-svn"}
-
-# Human-readable section titles for each command tag.
-_TAG_LABELS: Dict[str, str] = {
-    "update": "``dfetch update`` scenarios",
-    "check": "``dfetch check`` scenarios",
-    "add": "``dfetch add`` scenarios",
-    "remove": "``dfetch remove`` scenarios",
-    "diff": "``dfetch diff`` scenarios",
-    "update-patch": "``dfetch update-patch`` scenarios",
-    "format-patch": "``dfetch format-patch`` scenarios",
-    "freeze": "``dfetch freeze`` scenarios",
-    "import": "``dfetch import`` scenarios",
-    "report": "``dfetch report`` scenarios",
-    "validate": "``dfetch validate`` scenarios",
-}
-
-# Canonical display order for command tags in the appendix.
-_TAG_ORDER = [
-    "update",
-    "check",
-    "add",
-    "remove",
-    "diff",
-    "update-patch",
-    "format-patch",
-    "freeze",
-    "import",
-    "report",
-    "validate",
-]
-
 
 # ---------------------------------------------------------------------------
 # Custom node types
 # ---------------------------------------------------------------------------
 
 
-class scenario_appendix_placeholder(nodes.General, nodes.Element):
+class ScenarioAppendixPlaceholder(nodes.General, nodes.Element):
     """Replaced by the full appendix content during the resolve phase."""
 
 
@@ -108,10 +71,10 @@ def _feature_tags(feature_path: str) -> List[str]:
     return tags
 
 
-def _command_tag(feature_path: str) -> str:
-    """Return the first non-infrastructure tag from the feature file, or 'other'."""
+def _group_tag(feature_path: str, non_group_tags: FrozenSet[str]) -> str:
+    """Return the first tag not in *non_group_tags*, or ``'other'``."""
     for tag in _feature_tags(feature_path):
-        if tag not in _NON_COMMAND_TAGS:
+        if tag not in non_group_tags:
             return tag
     return "other"
 
@@ -126,12 +89,13 @@ def _feature_title(feature_path: str) -> str:
     return os.path.basename(feature_path)
 
 
-def _all_scenarios(feature_path: str) -> Tuple[str, ...]:
-    """Return all scenario titles in the feature file (preserves order)."""
+def _all_scenarios(feature_path: str) -> Tuple[Tuple[str, str], ...]:
+    """Return (header, title) pairs for all scenarios in the feature file."""
     with open(feature_path, encoding="utf-8") as fh:
         return tuple(
-            re.findall(
-                r"^\s*Scenario(?:\s+Outline)?:\s*(.+)$", fh.read(), re.MULTILINE
+            (m[0], m[1])
+            for m in re.findall(
+                r"^\s*(Scenario(?:\s+Outline)?):\s*(.+)$", fh.read(), re.MULTILINE
             )
         )
 
@@ -140,6 +104,29 @@ def _full_feature_content(feature_path: str) -> str:
     """Return the complete textual content of a feature file."""
     with open(feature_path, encoding="utf-8") as fh:
         return fh.read()
+
+
+def _selected_scenarios_content(feature_path: str, scenario_titles: List[str]) -> str:
+    """Return content containing only the selected scenario blocks."""
+    with open(feature_path, encoding="utf-8") as fh:
+        content = fh.read()
+    blocks = []
+    for title in scenario_titles:
+        pattern = re.compile(
+            r"([ \t]*Scenario(?:[ \t]+Outline)?:[ \t]*"
+            + re.escape(title)
+            + r"[ \t]*\n(?:(?![ \t]*Scenario(?:[ \t]+Outline)?:).)*)",
+            re.DOTALL,
+        )
+        match = pattern.search(content)
+        if match:
+            blocks.append(match.group(1).rstrip())
+    return "\n\n".join(blocks)
+
+
+def _tag_section_title(tag: str) -> str:
+    """Human-readable section title derived from *tag* alone."""
+    return tag.replace("-", " ").title()
 
 
 # ---------------------------------------------------------------------------
@@ -166,12 +153,14 @@ class ScenarioIncludeDirective(Directive):
     # Internal helpers
     # ------------------------------------------------------------------
 
+    def _env(self):
+        return self.state.document.settings.env
+
     def _is_pdf(self) -> bool:
-        env = self.state.document.settings.env
-        return env.app.builder.name in ("latex", "rinoh")
+        return self._env().app.builder.name in ("latex", "rinoh")
 
     def _feature_abs(self, feature_file: str) -> str:
-        env = self.state.document.settings.env
+        env = self._env()
         path = os.path.abspath(os.path.join(env.app.srcdir, feature_file))
         if not os.path.exists(path):
             raise self.error(f"Feature file not found: {path}")
@@ -179,20 +168,29 @@ class ScenarioIncludeDirective(Directive):
 
     def _include_path(self, feature_abs: str) -> str:
         """Path for literalinclude, relative to the current RST document."""
-        env = self.state.document.settings.env
-        current_doc_dir = os.path.dirname(
-            os.path.join(env.app.srcdir, env.docname)
-        )
+        env = self._env()
+        current_doc_dir = os.path.dirname(os.path.join(env.app.srcdir, env.docname))
         return os.path.relpath(feature_abs, current_doc_dir)
 
-    def _requested_scenarios(
-        self, available: Tuple[str, ...]
-    ) -> List[str]:
+    @staticmethod
+    def _end_before(available: Tuple[Tuple[str, str], ...], title: str) -> str:
+        """Return the :end-before: value for *title*, or '' for the last scenario."""
+        all_titles = tuple(t for _, t in available)
+        try:
+            idx = all_titles.index(title)
+        except ValueError:
+            return ""
+        if idx < len(available) - 1:
+            next_header, next_title = available[idx + 1]
+            return f":end-before: {next_header}: {next_title}"
+        return ""
+
+    def _requested_scenarios(self, available: Tuple[Tuple[str, str], ...]) -> List[str]:
         return [
             t.strip()
             for t in self.options.get("scenario", "").splitlines()
             if t.strip()
-        ] or list(available)
+        ] or [title for _, title in available]
 
     # ------------------------------------------------------------------
     # HTML / inline rendering (original behaviour)
@@ -203,15 +201,13 @@ class ScenarioIncludeDirective(Directive):
         include_path: str,
         feature_file: str,
         scenario_titles: List[str],
-        available: Tuple[str, ...],
+        available: Tuple[Tuple[str, str], ...],
     ) -> List[nodes.Node]:
+        title_to_header = {title: header for header, title in available}
         container = nodes.section()
         for title in scenario_titles:
-            end_before = (
-                ":end-before: Scenario:"
-                if title != available[-1]
-                else ""
-            )
+            header = title_to_header.get(title, "Scenario")
+            end_before = self._end_before(available, title)
             directive_rst = f"""
 .. raw:: html
 
@@ -223,7 +219,7 @@ class ScenarioIncludeDirective(Directive):
     :caption: {feature_file}
     :force:
     :dedent:
-    :start-after: Scenario: {title}
+    :start-after: {header}: {title}
     {end_before}
 
 .. raw:: html
@@ -246,10 +242,11 @@ class ScenarioIncludeDirective(Directive):
         feature_abs: str,
         scenario_titles: List[str],
     ) -> List[nodes.Node]:
-        env = self.state.document.settings.env
+        env = self._env()
+        non_group_tags = frozenset(getattr(env.config, "scenario_non_command_tags", []))
         basename = os.path.splitext(os.path.basename(feature_abs))[0]
         label = f"appendix-{basename}"
-        tag = _command_tag(feature_abs)
+        tag = _group_tag(feature_abs, non_group_tags)
         title = _feature_title(feature_abs)
 
         # ----------------------------------------------------------
@@ -265,13 +262,14 @@ class ScenarioIncludeDirective(Directive):
                 "feature_file": feature_file,
                 "feature_abs": feature_abs,
                 "feature_title": title,
-                "command_tag": tag,
+                "group_tag": tag,
                 "label": label,
-                "source_doc": env.docname,
+                "source_docs": {env.docname},
                 "scenarios": list(scenario_titles),
             }
         else:
             existing = env.scenario_appendix_entries[feature_abs]
+            existing["source_docs"].add(env.docname)
             for s in scenario_titles:
                 if s not in existing["scenarios"]:
                     existing["scenarios"].append(s)
@@ -319,7 +317,8 @@ class ScenarioAppendixDirective(Directive):
 
     Place this directive once in the document (typically in an appendix
     page).  During the write phase it is replaced by sections grouped by
-    command tag, containing the full content of each referenced feature file.
+    the first non-excluded tag, sorted alphabetically, containing the full
+    content of each referenced feature file.
 
     In HTML builds scenarios appear inline in the main text, so this
     directive emits an explanatory note instead.
@@ -332,18 +331,17 @@ class ScenarioAppendixDirective(Directive):
     def run(self) -> List[nodes.Node]:
         env = self.state.document.settings.env
         if env.app.builder.name not in ("latex", "rinoh"):
-            # HTML: scenarios are inline; provide a brief orientation note.
             note = nodes.note()
             para = nodes.paragraph()
             para += nodes.Text(
                 "In the HTML edition, feature scenarios appear as expandable "
                 "examples directly within each guide section. "
-                "In the PDF edition they are collected here, grouped by command."
+                "In the PDF edition they are collected here, grouped by tag."
             )
             note += para
             return [note]
 
-        node = scenario_appendix_placeholder()
+        node = ScenarioAppendixPlaceholder()
         return [node]
 
 
@@ -351,34 +349,22 @@ class ScenarioAppendixDirective(Directive):
 # Event: replace placeholder with actual appendix content
 # ---------------------------------------------------------------------------
 
-def _build_appendix_nodes(
-    entries: Dict,
-) -> List[nodes.Node]:
+
+def _build_appendix_nodes(entries: Dict) -> List[nodes.Node]:
     """Build docutils section nodes for every collected appendix entry."""
-    # Group by command tag
     by_tag: Dict[str, List] = {}
     for entry in entries.values():
-        by_tag.setdefault(entry["command_tag"], []).append(entry)
-
-    # Determine display order
-    ordered_tags = sorted(
-        by_tag.keys(),
-        key=lambda t: (
-            _TAG_ORDER.index(t) if t in _TAG_ORDER else len(_TAG_ORDER),
-            t,
-        ),
-    )
+        by_tag.setdefault(entry["group_tag"], []).append(entry)
 
     result: List[nodes.Node] = []
-    for tag in ordered_tags:
+    for tag in sorted(by_tag):
         tag_entries = sorted(by_tag[tag], key=lambda e: e["feature_title"])
         label = f"appendix-{tag}"
-        section_title = _TAG_LABELS.get(tag, f"``dfetch {tag}`` scenarios")
 
         tag_section = nodes.section()
         tag_section["ids"] = [label]
         tag_section["names"] = [label]
-        tag_section += nodes.title(text=section_title)
+        tag_section += nodes.title(text=_tag_section_title(tag))
 
         for entry in tag_entries:
             feat_section = nodes.section()
@@ -386,7 +372,9 @@ def _build_appendix_nodes(
             feat_section["names"] = [entry["label"]]
             feat_section += nodes.title(text=entry["feature_title"])
 
-            content = _full_feature_content(entry["feature_abs"])
+            content = _selected_scenarios_content(
+                entry["feature_abs"], entry["scenarios"]
+            )
             code = nodes.literal_block(content, content)
             code["language"] = "gherkin"
             feat_section += code
@@ -398,11 +386,9 @@ def _build_appendix_nodes(
     return result
 
 
-def process_scenario_appendix(
-    app, doctree: nodes.document, fromdocname: str
-) -> None:
-    """Replace scenario_appendix_placeholder nodes with generated content."""
-    placeholders = list(doctree.traverse(scenario_appendix_placeholder))
+def process_scenario_appendix(app, doctree: nodes.document, _fromdocname: str) -> None:
+    """Replace ScenarioAppendixPlaceholder nodes with generated content."""
+    placeholders = list(doctree.traverse(ScenarioAppendixPlaceholder))
     if not placeholders:
         return
 
@@ -413,18 +399,20 @@ def process_scenario_appendix(
         placeholder.replace_self(appendix_nodes)
 
 
-def purge_scenario_appendix(app, env, docname: str) -> None:
+def purge_scenario_appendix(_app, env, docname: str) -> None:
     """Remove appendix entries that originated from a re-read document."""
     if not hasattr(env, "scenario_appendix_entries"):
         return
-    env.scenario_appendix_entries = {
-        k: v
-        for k, v in env.scenario_appendix_entries.items()
-        if v.get("source_doc") != docname
-    }
+    to_delete = []
+    for k, v in env.scenario_appendix_entries.items():
+        v["source_docs"].discard(docname)
+        if not v["source_docs"]:
+            to_delete.append(k)
+    for k in to_delete:
+        del env.scenario_appendix_entries[k]
 
 
-def merge_scenario_appendix(app, env, docnames, other) -> None:
+def merge_scenario_appendix(_app, env, _docnames, other) -> None:
     """Merge appendix entries from a parallel read worker."""
     if not hasattr(env, "scenario_appendix_entries"):
         env.scenario_appendix_entries = {}
@@ -433,6 +421,7 @@ def merge_scenario_appendix(app, env, docnames, other) -> None:
             env.scenario_appendix_entries[key] = entry
         else:
             existing = env.scenario_appendix_entries[key]
+            existing["source_docs"].update(entry["source_docs"])
             for scenario in entry["scenarios"]:
                 if scenario not in existing["scenarios"]:
                     existing["scenarios"].append(scenario)
@@ -445,15 +434,16 @@ def merge_scenario_appendix(app, env, docnames, other) -> None:
 
 def setup(app):
     """Register directives, nodes, and event hooks."""
+    app.add_config_value("scenario_non_command_tags", [], "env")
     app.add_directive("scenario-include", ScenarioIncludeDirective)
     app.add_directive("scenario-appendix", ScenarioAppendixDirective)
-    app.add_node(scenario_appendix_placeholder)
+    app.add_node(ScenarioAppendixPlaceholder)
     app.connect("doctree-resolved", process_scenario_appendix)
     app.connect("env-purge-doc", purge_scenario_appendix)
     app.connect("env-merge-info", merge_scenario_appendix)
 
     return {
-        "version": "0.2",
+        "version": "0.3",
         "parallel_read_safe": True,
         "parallel_write_safe": True,
     }

--- a/doc/appendix/scenarios.rst
+++ b/doc/appendix/scenarios.rst
@@ -6,9 +6,6 @@ Appendix: Feature scenarios
 This appendix collects all the Gherkin feature scenarios that illustrate
 dfetch's behaviour. In the HTML documentation each scenario appears inline,
 folded inside an expandable *Example* block. In the PDF edition the scenarios
-are moved here to keep the main text readable; each location in the guide
-carries a cross-reference back to the relevant section below.
-
-The sections are grouped by the dfetch command they exercise.
+are moved here, grouped alphabetically by tag.
 
 .. scenario-appendix::

--- a/doc/appendix/scenarios.rst
+++ b/doc/appendix/scenarios.rst
@@ -1,11 +1,14 @@
 .. _scenario-appendix:
 
-Appendix: Feature scenarios
+Appendix: Feature Examples
 ============================
 
-This appendix collects all the Gherkin feature scenarios that illustrate
-dfetch's behaviour. In the HTML documentation each scenario appears inline,
-folded inside an expandable *Example* block. In the PDF edition the scenarios
-are moved here, grouped alphabetically by tag.
+This appendix collects all the feature test examples that demonstrate dfetch's
+behaviour. Each example is an actual test that runs as part of dfetch's test
+suite, showing exactly how dfetch behaves in a given situation.
+
+In the HTML documentation each example appears inline, folded inside an
+expandable block directly within the relevant guide section. In the PDF
+edition they are collected here, grouped by command.
 
 .. scenario-appendix::

--- a/doc/appendix/scenarios.rst
+++ b/doc/appendix/scenarios.rst
@@ -1,0 +1,14 @@
+.. _scenario-appendix:
+
+Appendix: Feature scenarios
+============================
+
+This appendix collects all the Gherkin feature scenarios that illustrate
+dfetch's behaviour. In the HTML documentation each scenario appears inline,
+folded inside an expandable *Example* block. In the PDF edition the scenarios
+are moved here to keep the main text readable; each location in the guide
+carries a cross-reference back to the relevant section below.
+
+The sections are grouped by the dfetch command they exercise.
+
+.. scenario-appendix::

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -41,6 +41,7 @@ extensions = [
     "sphinx_design",
     "plantweb.directive",
     "scenario_directive",
+    "latex_tabs",
     "unique_section_ids",
     "sphinx.ext.autodoc",
     "sphinx.ext.autosectionlabel",

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -61,6 +61,11 @@ extensions = [
 copybutton_prompt_text = r"\$ |>>> |\.\.\. "
 copybutton_prompt_is_regexp = True
 
+# scenario_directive: tags that are not group keys (environment markers, etc.)
+# The first tag on a feature file that is not in this list determines which
+# appendix section the file ends up in.
+scenario_non_command_tags = ["remote-svn"]
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 

--- a/doc/howto/contributing.rst
+++ b/doc/howto/contributing.rst
@@ -83,19 +83,27 @@ Feature tests
 ~~~~~~~~~~~~~
 Feature tests are used for higher-level integration testing of functionality.
 For this `behave <https://behave.readthedocs.io/en/latest/>`_ is used as testing framework.
-Features are specified in *Gherkin* in so-called feature files in the ``features`` folder.
-The sentences in the feature files, map to steps in the ``features/steps`` folder.
+Feature files in the ``features`` folder contain plain-language examples that
+demonstrate dfetch's behaviour. The sentences in the feature files map to step
+definitions in the ``features/steps`` folder.
 
-Test can be run directly from the command-line
+Tests can be run directly from the command-line:
 
 .. code-block:: bash
 
     behave features
 
+Feature files are tagged with the command they exercise (e.g. ``@update``,
+``@check``). You can run just the examples for a specific command using its tag:
+
+.. code-block:: bash
+
+    behave features --tags=update
+
 Alternatively in VSCode run the ``Run all feature tests`` task from the command palette.
 
 To debug these tests, mark the ``Feature:`` or ``Scenario:`` to debug with the ``@wip`` tag
-and add run the ``Feature tests (wip)`` debug configuration in VSCode.
+and run the ``Feature tests (wip)`` debug configuration in VSCode.
 
 
 Creating documentation

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -76,3 +76,9 @@ upstream. See :ref:`vendoring` for background on the problem this solves.
    explanation/vendoring
    explanation/alternatives
    explanation/architecture
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Appendix
+
+   appendix/scenarios

--- a/features/add-project-through-cli.feature
+++ b/features/add-project-through-cli.feature
@@ -1,3 +1,4 @@
+@add
 Feature: Add a project to the manifest via the CLI
 
     *DFetch* can add a new project entry to the manifest without requiring

--- a/features/check-archive.feature
+++ b/features/check-archive.feature
@@ -1,3 +1,4 @@
+@check
 Feature: Checking dependencies from an archive
 
     DFetch can check if archive-based projects are up-to-date.

--- a/features/check-git-repo.feature
+++ b/features/check-git-repo.feature
@@ -1,3 +1,4 @@
+@check
 Feature: Checking dependencies from a git repository
 
     *DFetch* can check if there are new versions.

--- a/features/check-report-code-climate.feature
+++ b/features/check-report-code-climate.feature
@@ -1,3 +1,4 @@
+@check
 Feature: Let check report to code climate
 
     *DFetch* can check if there are new versions available. Since this is an action a developer

--- a/features/check-report-jenkins.feature
+++ b/features/check-report-jenkins.feature
@@ -1,3 +1,4 @@
+@check
 Feature: Let check report to jenkins
 
     *DFetch* can check if there are new versions available. Since this is an action a developer

--- a/features/check-report-sarif.feature
+++ b/features/check-report-sarif.feature
@@ -1,3 +1,4 @@
+@check
 Feature: Let check report to sarif
 
     *DFetch* can check if there are new versions available. Since this is an action a developer

--- a/features/check-specific-projects.feature
+++ b/features/check-specific-projects.feature
@@ -1,3 +1,4 @@
+@check
 Feature: Checking specific projects
 
     *DFetch* can check specific projects, this is useful when you have a lot

--- a/features/check-svn-repo.feature
+++ b/features/check-svn-repo.feature
@@ -1,4 +1,4 @@
-@remote-svn
+@remote-svn @check
 Feature: Checking dependencies from a svn repository
 
     *DFetch* can check if there are new versions in a SVN repository.

--- a/features/checked-project-has-dependencies.feature
+++ b/features/checked-project-has-dependencies.feature
@@ -1,3 +1,4 @@
+@check
 Feature: Check for dependencies in projects
 
     When a project has dependencies of its own, it can list them using its own

--- a/features/diff-in-git.feature
+++ b/features/diff-in-git.feature
@@ -1,3 +1,4 @@
+@diff
 Feature: Diff in git
 
     If a project contains issues that need to be fixed, the user can work with the *Dfetch'ed* project as

--- a/features/diff-in-svn.feature
+++ b/features/diff-in-svn.feature
@@ -1,3 +1,4 @@
+@diff
 Feature: Diff in svn
 
     If a project contains issues that need to be fixed, the user can work with the *Dfetch'ed* project as

--- a/features/fetch-archive.feature
+++ b/features/fetch-archive.feature
@@ -1,3 +1,4 @@
+@update
 Feature: Fetching dependencies from an archive (tar/zip)
 
     Some projects are distributed as tar or zip archives, for example as

--- a/features/fetch-checks-destination.feature
+++ b/features/fetch-checks-destination.feature
@@ -1,3 +1,4 @@
+@update
 Feature: Fetch checks destinations
 
     Destinations marked with the 'dst:' attribute can be misused and lead to

--- a/features/fetch-file-pattern-git.feature
+++ b/features/fetch-file-pattern-git.feature
@@ -1,3 +1,4 @@
+@update
 Feature: Fetch file pattern from git repo
 
     Sometimes all files matching a pattern can be useful.

--- a/features/fetch-file-pattern-svn.feature
+++ b/features/fetch-file-pattern-svn.feature
@@ -1,3 +1,4 @@
+@update
 Feature: Fetch file pattern from svn repo
 
     Sometimes all files matching a pattern can be useful.

--- a/features/fetch-git-repo-with-submodule.feature
+++ b/features/fetch-git-repo-with-submodule.feature
@@ -1,4 +1,4 @@
-@update
+@update @report
 Feature: Fetch projects with nested VCS dependencies
 
     Some projects include nested version control dependencies

--- a/features/fetch-git-repo-with-submodule.feature
+++ b/features/fetch-git-repo-with-submodule.feature
@@ -1,3 +1,4 @@
+@update
 Feature: Fetch projects with nested VCS dependencies
 
     Some projects include nested version control dependencies

--- a/features/fetch-git-repo.feature
+++ b/features/fetch-git-repo.feature
@@ -1,3 +1,4 @@
+@update
 Feature: Fetching dependencies from a git repository
 
     The main functionality of *DFetch* is fetching remote dependencies.

--- a/features/fetch-single-file-git.feature
+++ b/features/fetch-single-file-git.feature
@@ -1,3 +1,4 @@
+@update
 Feature: Fetch single file from git repo
 
     Sometimes only one file is enough. *DFetch* makes it possible to specify

--- a/features/fetch-single-file-svn.feature
+++ b/features/fetch-single-file-svn.feature
@@ -1,3 +1,4 @@
+@update
 Feature: Fetch single file from svn repo
 
     Sometimes only one file is enough. *DFetch* makes it possible to specify

--- a/features/fetch-specific-project.feature
+++ b/features/fetch-specific-project.feature
@@ -1,3 +1,4 @@
+@update
 Feature: Fetching specific dependencies
 
     *DFetch* can update specific projects, this is useful when you have a lot

--- a/features/fetch-svn-repo.feature
+++ b/features/fetch-svn-repo.feature
@@ -1,4 +1,4 @@
-@remote-svn
+@remote-svn @update
 Feature: Fetching dependencies from a svn repository
 
     The main functionality of *DFetch* is fetching remote dependencies.

--- a/features/fetch-with-ignore-git.feature
+++ b/features/fetch-with-ignore-git.feature
@@ -1,3 +1,4 @@
+@update
 Feature: Fetch with ignore in git
 
     Sometimes you want to ignore files from a project

--- a/features/fetch-with-ignore-svn.feature
+++ b/features/fetch-with-ignore-svn.feature
@@ -1,3 +1,4 @@
+@update
 Feature: Fetch with ignore in svn
 
     Sometimes you want to ignore files from a project

--- a/features/format-patch-in-git.feature
+++ b/features/format-patch-in-git.feature
@@ -1,3 +1,4 @@
+@format-patch
 Feature: Formatting a patch for git repositories
 
     If a project is fetched from a git repository, and changes are made to

--- a/features/format-patch-in-svn.feature
+++ b/features/format-patch-in-svn.feature
@@ -1,3 +1,4 @@
+@format-patch
 Feature: Formatting a patch for svn repositories
 
     If a project is fetched from a svn repository, and changes are made to

--- a/features/freeze-archive.feature
+++ b/features/freeze-archive.feature
@@ -1,3 +1,4 @@
+@freeze
 Feature: Freeze archive dependencies
 
     For archive projects, 'dfetch freeze' adds a sha256 hash to the manifest

--- a/features/freeze-inplace.feature
+++ b/features/freeze-inplace.feature
@@ -1,3 +1,4 @@
+@freeze
 Feature: Freeze manifest in-place inside a version-controlled superproject
 
     When the manifest lives inside a git or SVN superproject, ``dfetch freeze``

--- a/features/freeze-projects.feature
+++ b/features/freeze-projects.feature
@@ -1,3 +1,4 @@
+@freeze
 Feature: Freeze dependencies
 
     If a user didn't use a revision or branch in his manifest, he can add these automatically with `dfetch freeze`.

--- a/features/freeze-specific-projects.feature
+++ b/features/freeze-specific-projects.feature
@@ -1,3 +1,4 @@
+@freeze
 Feature: Freeze specific projects
 
     *DFetch* can freeze specific projects by name, leaving other projects untouched.

--- a/features/guard-against-overwriting-git.feature
+++ b/features/guard-against-overwriting-git.feature
@@ -1,3 +1,4 @@
+@update
 Feature: Guard against overwriting in git
 
     Accidentally overwriting local changes could lead to introducing regressions.

--- a/features/guard-against-overwriting-svn.feature
+++ b/features/guard-against-overwriting-svn.feature
@@ -1,4 +1,4 @@
-@update
+@remote-svn @update
 Feature: Guard against overwriting in svn
 
     Accidentally overwriting local changes could lead to introducing regressions.

--- a/features/guard-against-overwriting-svn.feature
+++ b/features/guard-against-overwriting-svn.feature
@@ -1,3 +1,4 @@
+@update
 Feature: Guard against overwriting in svn
 
     Accidentally overwriting local changes could lead to introducing regressions.

--- a/features/handle-invalid-metadata.feature
+++ b/features/handle-invalid-metadata.feature
@@ -1,3 +1,4 @@
+@update
 Feature: Handle invalid metadata files
 
     *Dfetch* will keep metadata about the fetched project locally to prevent re-fetching unchanged projects

--- a/features/import-from-git.feature
+++ b/features/import-from-git.feature
@@ -1,3 +1,4 @@
+@import
 Feature: Importing submodules from an existing git repository
 
     One alternative to *Dfetch* is git submodules. To make the transition

--- a/features/import-from-svn.feature
+++ b/features/import-from-svn.feature
@@ -1,3 +1,4 @@
+@import
 Feature: Importing externals from an existing svn repository
 
     One alternative to *Dfetch* is svn externals. To make the transition

--- a/features/interactive-add.feature
+++ b/features/interactive-add.feature
@@ -1,3 +1,4 @@
+@add
 Feature: Add a project interactively via the CLI
 
     Pass ``--interactive`` / ``-i`` to ``dfetch add`` to be guided step-by-step

--- a/features/journey-basic-patching.feature
+++ b/features/journey-basic-patching.feature
@@ -1,3 +1,4 @@
+@update @diff
 Feature: Basic patch journey
 
     The main user journey for patching is:

--- a/features/journey-basic-usage.feature
+++ b/features/journey-basic-usage.feature
@@ -1,3 +1,4 @@
+@update @check
 Feature: Basic usage journey
 
     The main user journey is:

--- a/features/keep-license-in-project.feature
+++ b/features/keep-license-in-project.feature
@@ -1,3 +1,4 @@
+@update
 Feature: Keep license in project
 
     Lots of people in the world do a lot of hard work to create software

--- a/features/list-projects.feature
+++ b/features/list-projects.feature
@@ -1,3 +1,4 @@
+@report
 Feature: List dependencies
 
     The report command lists the current state of the projects. It will aggregate the metadata for each project

--- a/features/patch-after-fetch-git.feature
+++ b/features/patch-after-fetch-git.feature
@@ -1,3 +1,4 @@
+@update
 Feature: Patch after fetching from git repo
 
     Sometimes a patch needs to be applied after fetching. *DFetch* makes it

--- a/features/patch-after-fetch-svn.feature
+++ b/features/patch-after-fetch-svn.feature
@@ -1,4 +1,4 @@
-@remote-svn
+@remote-svn @update
 Feature: Patch after fetching from svn repo
 
     Sometimes a patch needs to be applied after fetching. *DFetch* makes it

--- a/features/patch-fuzzy-matching-git.feature
+++ b/features/patch-fuzzy-matching-git.feature
@@ -1,3 +1,4 @@
+@update
 Feature: Patch application tolerates small upstream changes
 
     If an upstream git repository changes slightly after a patch was created,

--- a/features/remove-project.feature
+++ b/features/remove-project.feature
@@ -1,3 +1,4 @@
+@remove
 Feature: Remove a project from the manifest
 
     During the lifetime of a project, dependencies come and go. When a vendored

--- a/features/report-sbom-archive.feature
+++ b/features/report-sbom-archive.feature
@@ -1,3 +1,4 @@
+@report
 Feature: Create a CycloneDX SBOM for archive dependencies
 
     *Dfetch* can generate a software Bill-of-Materials (SBOM) that includes

--- a/features/report-sbom-license.feature
+++ b/features/report-sbom-license.feature
@@ -1,3 +1,4 @@
+@report
 Feature: SBOM license transparency
 
     When *dfetch* scans a fetched component for license information it records

--- a/features/report-sbom.feature
+++ b/features/report-sbom.feature
@@ -1,3 +1,4 @@
+@report
 Feature: Create an CycloneDX sbom
 
     *Dfetch* can generate a software Bill-of-Materials (SBOM).

--- a/features/suggest-project-name.feature
+++ b/features/suggest-project-name.feature
@@ -1,3 +1,4 @@
+@check
 Feature: Suggest a project name
 
     Users sometimes mistype project names, this lead to blaming *DFetch* of wrong behavior.

--- a/features/update-patch-in-git.feature
+++ b/features/update-patch-in-git.feature
@@ -1,3 +1,4 @@
+@update-patch
 Feature: Update an existing patch in git
 
     If working with external projects, local changes can be tracked using

--- a/features/update-patch-in-svn.feature
+++ b/features/update-patch-in-svn.feature
@@ -1,3 +1,4 @@
+@update-patch
 Feature: Update an existing patch in svn
 
     If working with external projects, local changes can be tracked using

--- a/features/updated-project-has-dependencies.feature
+++ b/features/updated-project-has-dependencies.feature
@@ -1,3 +1,4 @@
+@update
 Feature: Updated project has dependencies
 
     When a project has dependencies of its own, it can list them using its own

--- a/features/validate-manifest.feature
+++ b/features/validate-manifest.feature
@@ -1,3 +1,4 @@
+@validate
 Feature: Validate a manifest
 
     *DFetch* can check if the manifest is valid.


### PR DESCRIPTION
Each feature file now carries a tag identifying the dfetch command it
exercises (e.g. @update, @check, @diff, @add, @remove, @report,
@freeze, @import, @validate, @format-patch, @update-patch).

Journey features that exercise multiple commands receive all relevant
tags (e.g. @update @check for journey-basic-usage.feature).

Files that already had @remote-svn retain it and gain the new command
tag on the same line (e.g. @remote-svn @update).

This makes it possible to run only the scenarios for a specific
command, for example:

    behave features/ --tags=update

https://claude.ai/code/session_01BvyikyxX9c3sDXev8HdP4f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an appendix that collects and groups real feature scenarios into a “Feature Examples” appendix; HTML shows inline expandable examples while PDF collects grouped appendices.
  * Added configuration and docs describing how scenarios are classified and included in each build format.

* **Chores**
  * Standardized feature-file tags (e.g., @update, @check, @report, @freeze, @add, @remove, @import, @diff, @format-patch, @update-patch) for consistent test selection and filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->