### PR TITLE
Update C4 diagrams to match current codebase

### DIFF
--- a/doc/static/uml/c3_dfetch_components_commands.puml
+++ b/doc/static/uml/c3_dfetch_components_commands.puml
@@ -10,6 +10,7 @@ System_Boundary(DFetch, "Dfetch") {
         Component(compCommon, "Common", "python", "Common actions for commands")
         Component(compCommand, "Command", "python", "Base class for commands")
 
+        Component(compAdd, "Add", "python", "Adds a new project to the manifest")
         Component(compCheck, "Check", "python", "Checks for updates")
         Component(compDiff, "Diff", "python", "Creates patch of local changes")
         Component(compEnv, "Environment", "python", "Shows local tools")
@@ -17,11 +18,13 @@ System_Boundary(DFetch, "Dfetch") {
         Component(compFreeze, "Freeze", "python", "Pins all projects")
         Component(compImport, "Import", "python", "Imports from VCS")
         Component(compInit, "Init", "python", "Initializes a manifest")
+        Component(compRemove, "Remove", "python", "Removes a project from the manifest")
         Component(compReport, "Report", "python", "Reports status")
         Component(compUpdate, "Update", "python", "Updates all projects")
         Component(compUpdatePatch, "UpdatePatch", "python", "Updates patch")
         Component(compValidate, "Validate", "python", "Validates manifest")
 
+        Rel_U(compAdd, compCommand, "Extends")
         Rel_U(compCheck, compCommand, "Extends")
         Rel_U(compDiff, compCommand, "Extends")
         Rel_U(compEnv, compCommand, "Extends")
@@ -29,6 +32,7 @@ System_Boundary(DFetch, "Dfetch") {
         Rel_U(compFreeze, compCommand, "Extends")
         Rel_U(compImport, compCommand, "Extends")
         Rel_U(compInit, compCommand, "Extends")
+        Rel_U(compRemove, compCommand, "Extends")
         Rel_U(compReport, compCommand, "Extends")
         Rel_U(compUpdate, compCommand, "Extends")
         Rel_U(compUpdatePatch, compCommand, "Extends")
@@ -42,6 +46,9 @@ System_Boundary(DFetch, "Dfetch") {
     Container(contProject, "Project", "python", "Main project that has a manifest.")
     Container(contVcs, "Vcs", "python", "Abstraction of various Version Control Systems.")
     Container(contReporting, "Reporting", "python", "Output formatters for various reporting formats.")
+
+    Rel(compAdd, contManifest, "Uses")
+    Rel(compAdd, contProject, "Uses")
 
     Rel(compCheck, contManifest, "Uses")
     Rel(compCheck, contProject, "Uses")
@@ -62,6 +69,9 @@ System_Boundary(DFetch, "Dfetch") {
     Rel(compImport, contManifest, "Uses")
     Rel(compImport, contProject, "Uses")
     Rel(compImport, contVcs, "Uses")
+
+    Rel(compRemove, contManifest, "Uses")
+    Rel(compRemove, contProject, "Uses")
 
     Rel(compReport, contManifest, "Uses")
     Rel(compReport, contProject, "Uses")

--- a/doc/static/uml/c3_dfetch_components_manifest.puml
+++ b/doc/static/uml/c3_dfetch_components_manifest.puml
@@ -10,16 +10,18 @@ System_Boundary(DFetch, "Dfetch") {
 
     Boundary(DFetchManifest, "Manifest") {
         Component(compManifest, "Manifest", "python", "Main configuration file describing all projects.")
+        Component(compParse, "Parse", "python", "Utilities for finding manifest files.")
         Component(compProject, "Project", "python", "A single project requirement with optionally specific version")
         Component(compRemote, "Remote", "python", "A remote source that contains one or more projects.")
-        Component(compValidate, "Validate", "python", "Validate a manifest.")
+        Component(compSchema, "Schema", "python", "StrictYAML schema for the manifest.")
         Component(compVersion, "Version", "python", "Check and compare versions.")
 
         Rel(compManifest, compProject, "Uses")
+        Rel(compManifest, compRemote, "Uses")
+        Rel(compManifest, compSchema, "Uses")
+        Rel(compParse, compManifest, "Uses")
         Rel(compProject, compVersion, "Uses")
         Rel_L(compProject, compRemote, "Uses")
-        Rel(compManifest, compValidate, "Uses")
-        Rel(compManifest, compRemote, "Uses")
     }
 
     Container(contProject, "Project", "python", "Main project that has a manifest.")

--- a/doc/static/uml/c3_dfetch_components_project.puml
+++ b/doc/static/uml/c3_dfetch_components_project.puml
@@ -12,6 +12,7 @@ System_Boundary(DFetch, "Dfetch") {
     Boundary(DfetchProject, "Project", "python", "Main project that has a manifest.") {
 
         Component(compAbstractCheckReporter, "AbstractCheckReporter", "python", "Abstract interface for generating a check report.")
+        Component(compArchiveSub, "ArchiveSubProject", "python", "A subproject based on an archive.")
         Component(compGitSub, "GitSubproject", "python", "A subproject based on git.")
         Component(compMetadata, "Metadata", "python", "A file containing metadata about a project.")
         Component(compSvnSub, "SvnSubproject", "python", "A subproject based on svn.")
@@ -21,6 +22,7 @@ System_Boundary(DFetch, "Dfetch") {
         Component(compSvnSuper, "SvnSuperProject", "python", "A superproject based on svn.")
         Component(compNoVcsSuper, "NoVcsSuperProject", "python", "A superproject without VCS.")
 
+        Rel_U(compArchiveSub, compSubProject, "Implements")
         Rel_U(compGitSub, compSubProject, "Implements")
         Rel_U(compSvnSub, compSubProject, "Implements")
         Rel(compSubProject, compAbstractCheckReporter, "Uses")
@@ -41,6 +43,7 @@ System_Boundary(DFetch, "Dfetch") {
     Rel_U(compMetadata, contManifest, "Has")
     Rel(compSuperProject, contManifest, "Has")
     Rel_U(contReporting, contManifest, "Uses")
+    Rel(compArchiveSub, contVcs, "Uses")
     Rel(compGitSub, contVcs, "Uses")
     Rel(compSvnSub, contVcs, "Uses")
     Rel(compGitSuper, contVcs, "Uses")


### PR DESCRIPTION
- Commands C3: add missing Add and Remove components with their Manifest/Project relationships
- Manifest C3: rename Validate→Schema (file is schema.py) and add Parse component (parse.py)
- Project C3: add missing ArchiveSubProject component with its VCS relationship

https://claude.ai/code/session_0177mNSCND9qFDXRuGo7xNQG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architectural component diagrams documenting command processing structure, hierarchy, and inter-component relationships.
  * Enhanced manifest processing pipeline documentation with reorganized component structure and updated processing flow.
  * Extended project architecture documentation to support additional subproject implementation types and system integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->