### PR TITLE
fix: use rolling cache key for clcache on Windows to get cache hits

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,15 +71,15 @@ jobs:
           verbose: 1
           create-symlink: true
 
-      - name: Setup cache for clcache
+      - name: Restore cache for clcache
+        id: clcache-restore
         if: ${{ matrix.platform == 'windows-latest' }}
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ github.workspace }}\.clcache
           key: ${{ github.job }}-${{ matrix.platform }}-${{ github.sha }}
           restore-keys: |
             ${{ github.job }}-${{ matrix.platform }}-
-          save-always: true
 
       - name: Create sbom, binary & package
         env:
@@ -93,6 +93,13 @@ jobs:
           python script/create_sbom.py
           python script/build.py
           python script/package.py
+
+      - name: Save cache for clcache
+        if: ${{ always() && matrix.platform == 'windows-latest' && steps.clcache-restore.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ github.workspace }}\.clcache
+          key: ${{ steps.clcache-restore.outputs.cache-primary-key }}
 
       - name: Store the distribution packages
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,10 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ github.workspace }}\.clcache
-          key: ${{ github.job }}-${{ matrix.platform }}
+          key: ${{ github.job }}-${{ matrix.platform }}-${{ github.sha }}
+          restore-keys: |
+            ${{ github.job }}-${{ matrix.platform }}-
+          save-always: true
 
       - name: Create sbom, binary & package
         env:


### PR DESCRIPTION
The static key caused clcache to restore a stale entry after every MSVC
runner update, resulting in 0 hits / 701 misses on every build run. A
sha-based key with a prefix restore-keys fallback and save-always mirrors
the rolling strategy used by ccache-action on Linux/macOS.

https://claude.ai/code/session_01XTvMZtPH8WpuiRBZkqWiHk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Windows build caching configuration to enhance cache retrieval efficiency and consistency across commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->