### PR TITLE
Block outbound calls from ci runners to unallowed endpoints

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,10 +22,26 @@ jobs:
       security-events: write
 
     steps:
-      - name: Harden the runner (Audit all outbound calls)
+      - name: "Harden the runner (Block egress traffic: Only allow calls to allowed endpoints)"
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >+
+            github.com:443
+            api.github.com:443
+            release-assets.githubusercontent.com:443
+            uploads.github.com:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            packages.microsoft.com:443
+            azure.archive.ubuntu.com:80
+            esm.ubuntu.com:443
+            index.rubygems.org:443
+            rubygems.org:443
+            community.chocolatey.org:443
+            community.chocolatey.org:80
+            packages.chocolatey.org:443
+            api.nuget.org:443
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -207,10 +223,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Harden the runner (Audit all outbound calls)
+    - name: "Harden the runner (Block egress traffic: Only allow calls to allowed endpoints)"
       uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
       with:
-        egress-policy: audit
+        egress-policy: block
+        allowed-endpoints: >+
+          github.com:443
+          api.github.com:443
+          release-assets.githubusercontent.com:443
+          pypi.org:443
+          files.pythonhosted.org:443
+
 
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -34,10 +34,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Harden the runner (Audit all outbound calls)
+    - name: "Harden the runner (Block egress traffic: Only allow calls to allowed endpoints)"
       uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
       with:
-        egress-policy: audit
+        egress-policy: block
+        allowed-endpoints: >+
+          github.com:443
+          api.github.com:443
+          release-assets.githubusercontent.com:443
 
     - name: Checkout repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -16,10 +16,13 @@ jobs:
   dependency-review:
     runs-on: ubuntu-latest
     steps:
-      - name: Harden the runner (Audit all outbound calls)
+      - name: "Harden the runner (Block egress traffic: Only allow calls to allowed endpoints)"
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >+
+            api.github.com:443
+            github.com:443
 
       - name: 'Checkout Repository'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -15,10 +15,37 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Harden the runner (Audit all outbound calls)
+      - name: "Harden the runner (Block egress traffic: Only allow calls to allowed endpoints)"
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >+
+            _http._tcp.deb.debian.org:443
+            *.data.mcr.microsoft.com:443
+            api.github.com:443
+            auth.docker.io:443
+            containers.dev:443
+            deb.debian.org:443
+            deb.debian.org:80
+            debian.map.fastlydns.net:443
+            debian.map.fastlydns.net:80
+            dl.google.com:443
+            files.pythonhosted.org:443
+            github.com:443
+            go.dev:443
+            index.rubygems.org:443
+            mcr.microsoft.com:443
+            nodejs.org:443
+            www.plantuml.com:443
+            plantuml.com:443
+            plantuml.com:80
+            production.cloudflare.docker.com:443
+            proxy.golang.org:443
+            pypi.org:443
+            registry-1.docker.io:443
+            registry.npmjs.org:443
+            rubygems.org:443
+            storage.googleapis.com:443
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,10 +16,17 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-    - name: Harden the runner (Audit all outbound calls)
+    - name: "Harden the runner (Block egress traffic: Only allow calls to allowed endpoints)"
       uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
       with:
-        egress-policy: audit
+        egress-policy: block
+        allowed-endpoints: >+
+          github.com:443
+          pypi.org:443
+          files.pythonhosted.org:443
+          plantuml.com:80
+          plantuml.com:443
+          www.plantuml.com:80
 
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
@@ -41,10 +48,18 @@ jobs:
     name: Landing page
     runs-on: ubuntu-latest
     steps:
-      - name: Harden the runner (Audit all outbound calls)
+      - name: "Harden the runner (Block egress traffic: Only allow calls to allowed endpoints)"
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >+
+            github.com:443
+            github.com:22
+            pypi.org:443
+            files.pythonhosted.org:443
+            plantuml.com:80
+            plantuml.com:443
+            www.plantuml.com:80
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -75,10 +90,26 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Harden the runner (Audit all outbound calls)
+      - name: "Harden the runner (Block egress traffic: Only allow calls to allowed endpoints)"
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >+
+            _http._tcp.azure.archive.ubuntu.com:443
+            _https._tcp.archive.ubuntu.com:443
+            _https._tcp.security.ubuntu.com:443
+            archive.ubuntu.com:443
+            azure.archive.ubuntu.com:443
+            azure.archive.ubuntu.com:80
+            files.pythonhosted.org:443
+            github.com:443
+            api.github.com:443
+            uploads.github.com:443
+            plantuml.com:443
+            plantuml.com:80
+            pypi.org:443
+            security.ubuntu.com:443
+            www.plantuml.com:80
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -20,10 +20,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Harden the runner (Audit all outbound calls)
+    - name: "Harden the runner (Block egress traffic: Only allow calls to allowed endpoints)"
       uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
       with:
-        egress-policy: audit
+        egress-policy: block
+        allowed-endpoints: >+
+          github.com:443
+          api.github.com:443
+          release-assets.githubusercontent.com:443
+          pypi.org:443
+          files.pythonhosted.org:443
 
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,12 @@ jobs:
     steps:
       - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >+
+            github.com:443
+            api.github.com:443
+            release-assets.githubusercontent.com:443
+            uploads.github.com:443
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -15,10 +15,19 @@ jobs:
       security-events: write
 
     steps:
-      - name: Harden the runner (Audit all outbound calls)
+      - name: "Harden the runner (Block egress traffic: Only allow calls to allowed endpoints)"
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >+
+            github.com:443
+            api.github.com:443
+            release-assets.githubusercontent.com:443
+            pypi.org:443
+            files.pythonhosted.org:443
+            community.chocolatey.org:443
+            community.chocolatey.org:80
+            packages.chocolatey.org:443
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -67,16 +76,81 @@ jobs:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        include:
+          - platform: ubuntu-latest
+            allowed-endpoints: >+
+              _http._tcp.azure.archive.ubuntu.com:443
+              _https._tcp.archive.ubuntu.com:443
+              _https._tcp.dl.google.com:443
+              _https._tcp.esm.ubuntu.com:443
+              _https._tcp.motd.ubuntu.com:443
+              _https._tcp.security.ubuntu.com:443
+              0.pool.ntp.org:443
+              api.github.com:443
+              archive.ubuntu.com:443
+              azure.archive.ubuntu.com:443
+              azure.archive.ubuntu.com:80
+              cfhcable.dl.sourceforge.net:443
+              cytranet-dal.dl.sourceforge.net:443
+              dl.google.com:443
+              downloads.sourceforge.net:443
+              esm.ubuntu.com:443
+              files.pythonhosted.org:443
+              gigenet.dl.sourceforge.net:443
+              github.com:443
+              motd.ubuntu.com:443
+              netactuate.dl.sourceforge.net:443
+              pilotfiber.dl.sourceforge.net:443
+              psychz.dl.sourceforge.net:443
+              pypi.org:443
+              release-assets.githubusercontent.com:443
+              security.ubuntu.com:443
+              sourceforge.net:443
+          - platform: macos-latest
+            allowed-endpoints: >+
+              api.apple-cloudkit.com:443
+              api.github.com:443
+              files.pythonhosted.org:443
+              formulae.brew.sh:443
+              gdmf.apple.com:443
+              ghcr.io:443
+              github.com:443
+              init.itunes.apple.com:443
+              mask.icloud.com:443
+              mesu.apple.com:443
+              mirrors.ctan.org:443
+              ocsp.sectigo.com:80
+              ocsp2.apple.com:443
+              pkg-containers.githubusercontent.com:443
+              pypi.org:443
+              release-assets.githubusercontent.com:443
+          - platform: windows-latest
+            allowed-endpoints: >+
+              _https._tcp.packages.microsoft.com:443
+              api.github.com:443
+              community.chocolatey.org:443
+              community.chocolatey.org:80
+              dc.services.visualstudio.com:443
+              fe2cr.update.microsoft.com:443
+              files.pythonhosted.org:443
+              github.com:443
+              mobile.events.data.microsoft.com:443
+              packages.chocolatey.org:443
+              packages.microsoft.com:443
+              pypi.org:443
+              release-assets.githubusercontent.com:443
+              ziglang.org:443
     runs-on: ${{ matrix.platform }}
     permissions:
       contents: read
       security-events: write
 
     steps:
-      - name: Harden the runner (Audit all outbound calls)
+      - name: "Harden the runner (Block egress traffic: Only allow calls to allowed endpoints)"
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: ${{ matrix.allowed-endpoints }}
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -26,10 +26,21 @@ jobs:
       id-token: write
 
     steps:
-      - name: Harden the runner (Audit all outbound calls)
+      - name: "Harden the runner (Block egress traffic: Only allow calls to allowed endpoints)"
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >+
+            github.com:443
+            api.github.com:443
+            raw.githubusercontent.com:443
+            codeload.github.com:443
+            uploads.github.com:443
+            api.osv.dev:443
+            www.bestpractices.dev:443
+            api.securityscorecards.dev:443
+            rekor.sigstore.dev:443
+            fulcio.sigstore.dev:443
 
       - name: "Checkout code"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,41 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - name: Harden the runner (Audit all outbound calls)
+      - name: "Harden the runner (Block egress traffic: Only allow calls to allowed endpoints)"
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          # dfetch.invalid and giiiiiidhub.com are intentionally invalid test
+          # domains used to verify network blocking/allowlist behaviour in the
+          # feature tests; they are never reachable from the runner.
+          allowed-endpoints: >+
+            _http._tcp.azure.archive.ubuntu.com:443
+            _https._tcp.archive.ubuntu.com:443
+            _https._tcp.dl.google.com:443
+            _https._tcp.esm.ubuntu.com:443
+            _https._tcp.motd.ubuntu.com:443
+            _https._tcp.packages.microsoft.com:443
+            _https._tcp.security.ubuntu.com:443
+            api.codacy.com:443
+            archive.ubuntu.com:443
+            artifacts.codacy.com:443
+            azure.archive.ubuntu.com:443
+            azure.archive.ubuntu.com:80
+            coverage.codacy.com:443
+            dfetch.invalid:443
+            dl.google.com:443
+            esm.ubuntu.com:443
+            files.pythonhosted.org:443
+            giiiiiidhub.com:443
+            github.com:22
+            github.com:443
+            motd.ubuntu.com:443
+            packages.microsoft.com:443
+            pypi.org:443
+            release-assets.githubusercontent.com:443
+            security.ubuntu.com:443
+            svn.code.sf.net:3690
+            svn.code.sf.net:443
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflows now block outbound network egress by default instead of only auditing it; hardening steps renamed to reflect blocking behavior.
  * Per-job allowlists introduced so each pipeline can only reach explicitly permitted external endpoints (allowlists vary by job), tightening and standardizing network access across automated builds and tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->