### PR TITLE
Allow release-assets.githubusercontent.com in source-provenance egress policy

### DIFF
--- a/.github/workflows/source-provenance.yml
+++ b/.github/workflows/source-provenance.yml
@@ -27,6 +27,7 @@ jobs:
           allowed-endpoints: >+
             github.com:443
             api.github.com:443
+            release-assets.githubusercontent.com:443
             uploads.github.com:443
             fulcio.sigstore.dev:443
             rekor.sigstore.dev:443


### PR DESCRIPTION
The slsa_with_provenance action downloads the slsa-source-corroborator
binary from GitHub releases, which redirects through
release-assets.githubusercontent.com. This endpoint was missing from
the harden-runner allowed list for the attest-source-governance job,
causing the egress block and failing the main build.

https://claude.ai/code/session_01FzXNiF3f5iEnRPX3SWfd2A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow network configuration to support release operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dfetch-org/dfetch/pull/1212?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->