### PR TITLE
Fix main build: add missing egress endpoints to harden-runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ jobs:
             api.github.com:443
             release-assets.githubusercontent.com:443
             uploads.github.com:443
+            timestamp.githubapp.com:443
             pypi.org:443
             files.pythonhosted.org:443
             packages.microsoft.com:443
@@ -341,6 +342,8 @@ jobs:
           github.com:443
           api.github.com:443
           release-assets.githubusercontent.com:443
+          uploads.github.com:443
+          timestamp.githubapp.com:443
           pypi.org:443
           files.pythonhosted.org:443
           fulcio.sigstore.dev:443

--- a/.github/workflows/source-provenance.yml
+++ b/.github/workflows/source-provenance.yml
@@ -29,6 +29,7 @@ jobs:
             api.github.com:443
             release-assets.githubusercontent.com:443
             uploads.github.com:443
+            timestamp.githubapp.com:443
             fulcio.sigstore.dev:443
             rekor.sigstore.dev:443
             tuf-repo-cdn.sigstore.dev:443
@@ -61,6 +62,7 @@ jobs:
             github.com:443
             api.github.com:443
             uploads.github.com:443
+            timestamp.githubapp.com:443
             fulcio.sigstore.dev:443
             rekor.sigstore.dev:443
             tuf-repo-cdn.sigstore.dev:443

--- a/.github/workflows/source-provenance.yml
+++ b/.github/workflows/source-provenance.yml
@@ -27,6 +27,7 @@ jobs:
           allowed-endpoints: >+
             github.com:443
             api.github.com:443
+            release-assets.githubusercontent.com:443
             uploads.github.com:443
             fulcio.sigstore.dev:443
             rekor.sigstore.dev:443

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,7 @@ jobs:
             svn.code.sf.net:443
             api.github.com:443
             uploads.github.com:443
+            timestamp.githubapp.com:443
             fulcio.sigstore.dev:443
             rekor.sigstore.dev:443
             tuf-repo-cdn.sigstore.dev:443


### PR DESCRIPTION
## Summary

- Add `release-assets.githubusercontent.com:443` to `source-provenance.yml` — needed by `slsa_with_provenance` to download the `slsa-source-corroborator` binary from GitHub releases
- Add `timestamp.githubapp.com:443` to `source-provenance.yml`, `build.yml`, and `test.yml` — needed by `actions/attest` and `actions/attest-build-provenance` when signing DSSE attestation wrappers
- Add `uploads.github.com:443` to the `build-whl` job in `build.yml` — needed for artifact upload

All three endpoints were blocked by the harden-runner egress policy, cascading into build and test failures on main.

## Test plan

- [ ] `source-provenance` workflow passes on main (both `attest-source-governance` and `attest-source` jobs)
- [ ] `build` workflow passes (binary and wheel jobs complete attestation steps)
- [ ] `test` workflow passes attestation step

https://claude.ai/code/session_01FzXNiF3f5iEnRPX3SWfd2A

---
_Generated by [Claude Code](https://claude.ai/code/session_01FzXNiF3f5iEnRPX3SWfd2A)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline security configurations across build, testing, and attestation workflows to improve overall system reliability and security posture during the release process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dfetch-org/dfetch/pull/1213?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->