### PR TITLE
Fix CI build: upgrade actions/download-artifact from v5 to v7.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Download canonical source archive
         id: download-source
         if: github.event_name != 'pull_request'
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v5
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: source-archive
       - name: Verify source provenance
@@ -262,7 +262,7 @@ jobs:
 
     steps:
     - name: Download the binary artifact
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v5
+      uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
       with:
         name: binary-distribution-${{ matrix.platform }}
         path: .
@@ -429,7 +429,7 @@ jobs:
       security-events: write
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v5
+      uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
       with:
         name: python-package-distributions
         path: dist/

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -89,7 +89,7 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v5
+      uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
       with:
         name: python-package-distributions
         path: dist/
@@ -118,7 +118,7 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v5
+      uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
       with:
         name: python-package-distributions
         path: dist/
@@ -127,7 +127,7 @@ jobs:
       with:
         skip-existing: true
     - name: Download SBOM
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v5
+      uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
       with:
         name: python-sbom
         path: dist-sbom/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,7 +113,7 @@ jobs:
       - name: Download canonical source archive
         id: download-source
         if: github.event_name != 'pull_request'
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v5
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: source-archive
 


### PR DESCRIPTION
Upload steps use actions/upload-artifact@v7.0.1 but download steps were
pinned to v5, which is incompatible with the v7 artifact format and
Node.js 24 runtime. Updated all 7 download-artifact references in
build.yml, test.yml, and python-publish.yml to v7.0.0.

https://claude.ai/code/session_01X2pZH7YaVm55kpxGnN9uxH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow dependencies to use the latest download artifact action versions across build, test, and publishing pipelines for improved CI/CD stability and compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dfetch-org/dfetch/pull/1219?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->