### PR TITLE
Report externals in svn subprojects

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Release 0.14.0 (unreleased)
 ===========================
 
+* Report SVN externals fetched during update (#1220)
 * Use ``.cdx.json`` as the default extension for CycloneDX SBOM reports (#1118)
 * Embed base64-encoded license text in SBOM ``licenses[].text`` when a license is successfully identified (#1112)
 * Set SBOM ``licenses`` to the SPDX expression ``NOASSERTION`` when a license file is not found or cannot be classified (#1112)

--- a/dfetch/project/svnsubproject.py
+++ b/dfetch/project/svnsubproject.py
@@ -152,7 +152,32 @@ class SvnSubProject(SubProject):
         if self.ignore:
             self._remove_ignored_files()
 
-        return Version(tag=version.tag, branch=branch, revision=revision), []
+        return (
+            Version(tag=version.tag, branch=branch, revision=revision),
+            self._fetch_externals(complete_path, revision),
+        )
+
+    def _fetch_externals(self, complete_path: str, revision: str) -> list[Dependency]:
+        """Detect and log SVN externals that were exported with the project."""
+        vcs_deps = []
+        for external in SvnRepo.externals_from_url(complete_path, revision):
+            path_display = "./" + external.path.lstrip("./")
+            display_branch = external.branch or SvnRepo.DEFAULT_BRANCH
+            self._log_project(
+                f'Found & fetched external "{path_display}" '
+                f"({external.url} @ {Version(tag=external.tag, branch=display_branch, revision=external.revision)})",
+            )
+            vcs_deps.append(
+                Dependency(
+                    remote_url=external.url,
+                    destination=external.path,
+                    branch=external.branch,
+                    tag=external.tag,
+                    revision=external.revision,
+                    source_type="svn-external",
+                )
+            )
+        return vcs_deps
 
     @staticmethod
     def _parse_file_pattern(complete_path: str) -> tuple[str, str]:

--- a/dfetch/vcs/svn.py
+++ b/dfetch/vcs/svn.py
@@ -164,48 +164,97 @@ class SvnRepo:
                     "-R",
                 ],
             )
-
             repo_root = SvnRepo.get_info_from_target()["Repository Root"]
+            return SvnRepo._parse_externals(
+                result.stdout.decode(), repo_root, toplevel=self._path
+            )
 
-            externals: list[External] = []
-            # Pattern matches: "path - ..." where path is the local directory
-            path_pattern = r"([^\s^-]+)\s+-"
-            for entry in result.stdout.decode().split(os.linesep * 2):
-                match: re.Match[str] | None = None
-                local_path: str = ""
-                for match in re.finditer(path_pattern, entry):
-                    pass
-                if match:
-                    local_path = match.group(1)
-                    entry = re.sub(path_pattern, "", entry)
+    @staticmethod
+    def externals_from_url(url: str, revision: str = "") -> list[External]:
+        """Get list of externals from a remote SVN URL."""
+        cmd = ["svn", "--non-interactive", "propget", "svn:externals", "-R"]
+        if revision:
+            cmd += ["--revision", revision]
+        cmd += [url]
+        result = run_on_cmdline(logger, cmd)
+        repo_root = SvnRepo.get_info_from_target(url)["Repository Root"]
+        normalized = SvnRepo._normalize_url_prefix(result.stdout.decode(), url)
+        return SvnRepo._parse_externals(normalized, repo_root)
 
-                # Pattern matches either:
-                # - url@revision name (pinned)
-                # - url name (unpinned)
-                for match in re.finditer(
-                    r"([^-\s\d][^\s]+)(?:@)(\d+)\s+([^\s]+)|([^-\s\d][^\s]+)\s+([^\s]+)",
-                    entry,
-                ):
-                    url = match.group(1) or match.group(4)
-                    name = match.group(3) or match.group(5)
-                    rev = "" if not match.group(2) else match.group(2).strip()
+    @staticmethod
+    def _normalize_url_prefix(output: str, base_url: str) -> str:
+        """Convert URL-mode ``svn propget -R`` output to relative-path format.
 
-                    url, branch, tag, src = SvnRepo._split_url(url, repo_root)
+        When querying a remote URL, each entry is prefixed with the full SVN URL
+        of the directory that owns the property instead of a relative path.
+        Strip the base_url so the standard parser receives familiar relative paths.
+        """
+        base = base_url.rstrip("/")
+        entries = []
+        for entry in output.split(os.linesep * 2):
+            if entry.startswith(base + "/"):
+                after = entry[len(base) + 1 :]
+                sep = after.find(" -")
+                if sep >= 0:
+                    rel = after[:sep] or "."
+                    entry = rel + after[sep:]
+            elif entry.startswith(base + " -"):
+                entry = "." + entry[len(base) :]
+            entries.append(entry)
+        return (os.linesep * 2).join(entries)
 
-                    externals += [
-                        External(
-                            name=name,
-                            toplevel=self._path,
-                            path="/".join(os.path.join(local_path, name).split(os.sep)),
-                            revision=rev,
-                            url=url,
-                            branch=branch,
-                            tag=tag,
-                            src=src,
-                        )
-                    ]
+    @staticmethod
+    def _parse_externals(
+        output: str, repo_root: str, toplevel: str = ""
+    ) -> list[External]:
+        """Parse svn propget svn:externals output into External objects.
 
-            return externals
+        Args:
+            output: Raw stdout from ``svn propget svn:externals -R``.
+            repo_root: Repository root URL (used to resolve ``^/`` relative URLs).
+            toplevel: Local working-copy root to record in each External.
+        """
+        externals: list[External] = []
+        path_pattern = r"(.+?)\s+-"
+        for entry in output.split(os.linesep * 2):
+            match: re.Match[str] | None = None
+            local_path: str = ""
+            for match in re.finditer(path_pattern, entry):
+                pass
+            if match:
+                local_path = match.group(1)
+                entry = re.sub(path_pattern, "", entry)
+
+            for match in re.finditer(
+                r"-r\s+(\d+)\s+(\S+?)(?:@\d+)?\s+(\S+)|([^@\s-][^@\s]*)(?:@(\d+))?\s+([^\s]+)",
+                entry,
+            ):
+                if match.group(1):
+                    rev = match.group(1)
+                    url = match.group(2)
+                    name = match.group(3)
+                else:
+                    url = match.group(4)
+                    rev = match.group(5) or ""
+                    name = match.group(6)
+
+                url, branch, tag, src = SvnRepo._split_url(url, repo_root)
+
+                raw_path = "/".join(os.path.join(local_path, name).split(os.sep))
+                externals += [
+                    External(
+                        name=name,
+                        toplevel=toplevel,
+                        path=raw_path[2:] if raw_path.startswith("./") else raw_path,
+                        revision=rev,
+                        url=url,
+                        branch=branch,
+                        tag=tag,
+                        src=src,
+                    )
+                ]
+
+        return externals
 
     @staticmethod
     def _split_url(url: str, repo_root: str) -> tuple[str, str, str, str]:

--- a/features/fetch-svn-repo-with-external.feature
+++ b/features/fetch-svn-repo-with-external.feature
@@ -1,0 +1,79 @@
+@update @report
+Feature: Fetch projects with nested SVN dependencies
+
+    When fetching an SVN project that defines svn:externals,
+    the exported content already includes the external directories.
+    DFetch should detect and report these externals so they are
+    visible in the project report, mirroring the behaviour for
+    Git submodules.
+
+    Background:
+        Given a svn-server "ExternalLib" with the files
+            | path      |
+            | README.md |
+        And a svn-server "ParentProject" with the files
+            | path      |
+            | README.md |
+        And svn-server "ParentProject" has an external at "ext" from svn-server "ExternalLib"
+
+    Scenario: A project with an SVN external is fetched and the external is reported
+        Given the manifest 'dfetch.yaml' in MyProject
+            """
+            manifest:
+                version: 0.0
+                projects:
+                    - name: svn-project-with-external
+                      url: some-remote-server/ParentProject
+                      vcs: svn
+            """
+        When I run "dfetch update" in MyProject
+        Then the output shows
+            """
+            Dfetch (0.13.0)
+              svn-project-with-external:
+              > Found & fetched external "./ext" (some-remote-server/ExternalLib @ trunk)
+              > Fetched trunk - 2
+            """
+        And 'MyProject' looks like:
+            """
+            MyProject/
+                dfetch.yaml
+                svn-project-with-external/
+                    .dfetch_data.yaml
+                    README.md
+                    ext/
+                        README.md
+            """
+
+    Scenario: External changes are reported in the project report
+        Given a fetched and committed MyProject with the manifest
+            """
+            manifest:
+                version: 0.0
+                projects:
+                    - name: svn-project-with-external
+                      url: some-remote-server/ParentProject
+                      vcs: svn
+            """
+        When I run "dfetch report" in MyProject
+        Then the output shows
+            """
+            Dfetch (0.13.0)
+              svn-project-with-external:
+              - remote            : <none>
+                remote url        : some-remote-server/ParentProject
+                branch            : trunk
+                tag               : <none>
+                last fetch        :
+                revision          : 2
+                patch             : <none>
+                licenses          : <none>
+
+                dependencies      :
+                - path            : ext
+                  url             : some-remote-server/ExternalLib
+                  branch          : <none>
+                  tag             : <none>
+                  revision        : <none>
+                  source-type     : svn-external
+            """

--- a/features/fetch-svn-repo-with-nonstd-external.feature
+++ b/features/fetch-svn-repo-with-nonstd-external.feature
@@ -1,0 +1,78 @@
+@update @report
+Feature: Fetch projects with non-standard-layout SVN externals
+
+    SVN externals can point to a repository root that has no trunk/branches/tags
+    layout.  DFetch should detect and report these with an empty branch value
+    (represented internally as a single space) rather than treating them as a
+    standard branch.
+
+    Background:
+        Given a non-standard svn-server "NonstdLib" with the files
+            | path      |
+            | README.md |
+        And a svn-server "ParentProject" with the files
+            | path      |
+            | README.md |
+        And svn-server "ParentProject" has an external at "nonstd-ext" from non-standard svn-server "NonstdLib"
+
+    Scenario: A project with a non-standard-layout SVN external is fetched and the external is reported
+        Given the manifest 'dfetch.yaml' in MyProject
+            """
+            manifest:
+                version: 0.0
+                projects:
+                    - name: svn-project-with-nonstd-external
+                      url: some-remote-server/ParentProject
+                      vcs: svn
+            """
+        When I run "dfetch update" in MyProject
+        Then the output shows
+            """
+            Dfetch (0.13.0)
+              svn-project-with-nonstd-external:
+              > Found & fetched external "./nonstd-ext" (some-remote-server/NonstdLib @ )
+              > Fetched trunk - 2
+            """
+        And 'MyProject' looks like:
+            """
+            MyProject/
+                dfetch.yaml
+                svn-project-with-nonstd-external/
+                    .dfetch_data.yaml
+                    README.md
+                    nonstd-ext/
+                        README.md
+            """
+
+    Scenario: Non-standard external is shown in the project report with no branch
+        Given a fetched and committed MyProject with the manifest
+            """
+            manifest:
+                version: 0.0
+                projects:
+                    - name: svn-project-with-nonstd-external
+                      url: some-remote-server/ParentProject
+                      vcs: svn
+            """
+        When I run "dfetch report" in MyProject
+        Then the output shows
+            """
+            Dfetch (0.13.0)
+              svn-project-with-nonstd-external:
+              - remote            : <none>
+                remote url        : some-remote-server/ParentProject
+                branch            : trunk
+                tag               : <none>
+                last fetch        :
+                revision          : 2
+                patch             : <none>
+                licenses          : <none>
+
+                dependencies      :
+                - path            : nonstd-ext
+                  url             : some-remote-server/NonstdLib
+                  branch          :
+                  tag             : <none>
+                  revision        : <none>
+                  source-type     : svn-external
+            """

--- a/features/import-from-svn.feature
+++ b/features/import-from-svn.feature
@@ -26,18 +26,15 @@ Feature: Importing externals from an existing svn repository
               - name: ext/cunit1
                 revision: '176'
                 src: Man
-                dst: ./ext/cunit1
                 repo-path: code
 
               - name: ext/cunit2
                 revision: '150'
                 src: Man
-                dst: ./ext/cunit2
                 branch: mingw64
                 repo-path: code
 
               - name: ext/cunit3
-                dst: ./ext/cunit3
                 branch: ' '
                 repo-path: code
 

--- a/features/steps/svn_steps.py
+++ b/features/steps/svn_steps.py
@@ -143,3 +143,25 @@ def step_impl(_, pattern, directory):
     with in_directory(directory):
         subprocess.check_call(["svn", "propset", "svn:ignore", pattern, "."])
         commit_all(f"Ignore {pattern} files")
+
+
+@given(
+    'svn-server "{name}" has an external at "{ext_path}" from svn-server "{source_name}"'
+)
+def step_impl(context, name, ext_path, source_name):
+    source_url = (
+        pathlib.Path(context.remotes_dir_path).joinpath(source_name, "trunk").as_uri()
+    )
+    with in_directory(name):
+        with in_directory("trunk"):
+            add_externals([{"url": source_url, "path": ext_path, "revision": ""}])
+
+
+@given(
+    'svn-server "{name}" has an external at "{ext_path}" from non-standard svn-server "{source_name}"'
+)
+def step_impl(context, name, ext_path, source_name):
+    source_url = pathlib.Path(context.remotes_dir_path).joinpath(source_name).as_uri()
+    with in_directory(name):
+        with in_directory("trunk"):
+            add_externals([{"url": source_url, "path": ext_path, "revision": ""}])

--- a/tests/test_svn.py
+++ b/tests/test_svn.py
@@ -37,7 +37,7 @@ UNPINNED_NONSTD_EXPECTATION = [
     External(
         name="Database",
         toplevel=CWD,
-        path="./Database",
+        path="Database",
         revision="",
         url="http://svn.mycompany.eu/MYCOMPANY/SomeModule/Core/Modules/Database",
         branch=" ",
@@ -100,6 +100,84 @@ PINNED_MODULE_NO_SUBFOLDER_EXPECTATION = [
     )
 ]
 
+# -r REV URL NAME without a peg revision (@rev) in the URL.
+EXPLICIT_REV_NO_PEG = (
+    "lib - -r 500 http://svn.mycompany.eu/MYCOMPANY/SomeLib/trunk SomeLib"
+)
+EXPLICIT_REV_NO_PEG_EXPECTATION = [
+    External(
+        name="SomeLib",
+        toplevel=CWD,
+        path="lib/SomeLib",
+        revision="500",
+        url="http://svn.mycompany.eu/MYCOMPANY/SomeLib",
+        branch="",
+        tag="",
+        src="",
+    )
+]
+
+# Same -r form but with a subdirectory inside trunk, so src is also populated.
+EXPLICIT_REV_NO_PEG_SUBFOLDER = (
+    "vendor - -r 123 http://svn.mycompany.eu/MYCOMPANY/Framework/trunk/include Utils"
+)
+EXPLICIT_REV_NO_PEG_SUBFOLDER_EXPECTATION = [
+    External(
+        name="Utils",
+        toplevel=CWD,
+        path="vendor/Utils",
+        revision="123",
+        url="http://svn.mycompany.eu/MYCOMPANY/Framework",
+        branch="",
+        tag="",
+        src="include",
+    )
+]
+
+HYPHENATED_PATH = "libs/ui-kit - http://svn.mycompany.eu/MYCOMPANY/UIKit/trunk UIKit"
+HYPHENATED_PATH_EXPECTATION = [
+    External(
+        name="UIKit",
+        toplevel=CWD,
+        path="libs/ui-kit/UIKit",
+        revision="",
+        url="http://svn.mycompany.eu/MYCOMPANY/UIKit",
+        branch="",
+        tag="",
+        src="",
+    )
+]
+
+AUTHENTICATED_URL_WITH_REV = (
+    "lib - -r 100 svn+ssh://user@host/MYCOMPANY/SomeLib/trunk SomeLib"
+)
+AUTHENTICATED_URL_WITH_REV_EXPECTATION = [
+    External(
+        name="SomeLib",
+        toplevel=CWD,
+        path="lib/SomeLib",
+        revision="100",
+        url="svn+ssh://user@host/MYCOMPANY/SomeLib",
+        branch="",
+        tag="",
+        src="",
+    )
+]
+
+ROOT_LEVEL_EXTERNAL = ". - http://svn.mycompany.eu/MYCOMPANY/SomeLib/trunk SomeLib"
+ROOT_LEVEL_EXTERNAL_EXPECTATION = [
+    External(
+        name="SomeLib",
+        toplevel=CWD,
+        path="SomeLib",
+        revision="",
+        url="http://svn.mycompany.eu/MYCOMPANY/SomeLib",
+        branch="",
+        tag="",
+        src="",
+    )
+]
+
 
 @pytest.mark.parametrize(
     "name, externals, expectations",
@@ -113,6 +191,31 @@ PINNED_MODULE_NO_SUBFOLDER_EXPECTATION = [
             "pinned_module_no_subfolder",
             [PINNED_MODULE_NO_SUBFOLDER],
             PINNED_MODULE_NO_SUBFOLDER_EXPECTATION,
+        ),
+        (
+            "explicit_rev_no_peg",
+            [EXPLICIT_REV_NO_PEG],
+            EXPLICIT_REV_NO_PEG_EXPECTATION,
+        ),
+        (
+            "explicit_rev_no_peg_subfolder",
+            [EXPLICIT_REV_NO_PEG_SUBFOLDER],
+            EXPLICIT_REV_NO_PEG_SUBFOLDER_EXPECTATION,
+        ),
+        (
+            "hyphenated_path",
+            [HYPHENATED_PATH],
+            HYPHENATED_PATH_EXPECTATION,
+        ),
+        (
+            "authenticated_url_with_rev",
+            [AUTHENTICATED_URL_WITH_REV],
+            AUTHENTICATED_URL_WITH_REV_EXPECTATION,
+        ),
+        (
+            "root_level_external",
+            [ROOT_LEVEL_EXTERNAL],
+            ROOT_LEVEL_EXTERNAL_EXPECTATION,
         ),
         (
             "multiple",
@@ -271,3 +374,149 @@ def test_svn_repo_split_url(svn_repo):
     assert branch == ""
     assert tag == "v1.0"
     assert src == "src"
+
+
+# ---------------------------------------------------------------------------
+# _normalize_url_prefix
+# ---------------------------------------------------------------------------
+
+_BASE_URL = "http://svn.example.com/repos/myproject"
+_OTHER_LIB = "http://svn.other.com/repos/otherlib/trunk MyLib"
+
+
+@pytest.mark.parametrize(
+    "name, output, base_url, expected",
+    [
+        (
+            "subdirectory",
+            f"{_BASE_URL}/lib - {os.linesep}{_OTHER_LIB}",
+            _BASE_URL,
+            f"lib - {os.linesep}{_OTHER_LIB}",
+        ),
+        (
+            "root_level",
+            f"{_BASE_URL} - {os.linesep}{_OTHER_LIB}",
+            _BASE_URL,
+            f". - {os.linesep}{_OTHER_LIB}",
+        ),
+        (
+            "trailing_slash_on_base_url",
+            f"{_BASE_URL}/lib - {os.linesep}{_OTHER_LIB}",
+            _BASE_URL + "/",
+            f"lib - {os.linesep}{_OTHER_LIB}",
+        ),
+        (
+            "unrelated_url_unchanged",
+            f"http://other.com/repo - {os.linesep}{_OTHER_LIB}",
+            _BASE_URL,
+            f"http://other.com/repo - {os.linesep}{_OTHER_LIB}",
+        ),
+        (
+            "multiple_entries",
+            f"{_BASE_URL}/lib - {os.linesep}{_OTHER_LIB}"
+            + os.linesep * 2
+            + f"{_BASE_URL} - {os.linesep}http://svn.other.com/repos/framework/trunk Framework",
+            _BASE_URL,
+            f"lib - {os.linesep}{_OTHER_LIB}"
+            + os.linesep * 2
+            + f". - {os.linesep}http://svn.other.com/repos/framework/trunk Framework",
+        ),
+    ],
+)
+def test_normalize_url_prefix(name, output, base_url, expected):
+    assert SvnRepo._normalize_url_prefix(output, base_url) == expected
+
+
+# ---------------------------------------------------------------------------
+# externals_from_url
+# ---------------------------------------------------------------------------
+
+
+def test_externals_from_url_omits_revision_when_not_given():
+    with (
+        patch("dfetch.vcs.svn.run_on_cmdline") as mock_run,
+        patch("dfetch.vcs.svn.SvnRepo.get_info_from_target") as mock_info,
+    ):
+        mock_run.return_value.stdout = b""
+        mock_info.return_value = {"Repository Root": REPO_ROOT}
+
+        SvnRepo.externals_from_url(REPO_ROOT + "/trunk")
+
+        cmd = mock_run.call_args[0][1]
+        assert "--revision" not in cmd
+
+
+def test_externals_from_url_adds_revision_flag_when_given():
+    with (
+        patch("dfetch.vcs.svn.run_on_cmdline") as mock_run,
+        patch("dfetch.vcs.svn.SvnRepo.get_info_from_target") as mock_info,
+    ):
+        mock_run.return_value.stdout = b""
+        mock_info.return_value = {"Repository Root": REPO_ROOT}
+
+        SvnRepo.externals_from_url(REPO_ROOT + "/trunk", "42")
+
+        cmd = mock_run.call_args[0][1]
+        assert "--revision" in cmd
+        assert "42" in cmd
+
+
+@pytest.mark.parametrize(
+    "name, error",
+    [
+        ("subprocess_error", SubprocessCommandError([""], "", "", -1)),
+        ("runtime_error", RuntimeError("not an SVN repo")),
+    ],
+)
+def test_externals_from_url_propagates_error(name, error):
+    with patch("dfetch.vcs.svn.run_on_cmdline") as mock_run:
+        mock_run.side_effect = error
+        with pytest.raises(type(error)):
+            SvnRepo.externals_from_url(REPO_ROOT + "/trunk")
+
+
+def test_externals_from_url_normalizes_url_prefix_and_parses():
+    base = "http://svn.example.com/repos/myproject/trunk"
+    raw = (
+        f"{base}/vendor - "
+        + os.linesep
+        + "http://svn.example.com/repos/libs/trunk@100 mylib"
+    )
+    with (
+        patch("dfetch.vcs.svn.run_on_cmdline") as mock_run,
+        patch("dfetch.vcs.svn.SvnRepo.get_info_from_target") as mock_info,
+    ):
+        mock_run.return_value.stdout = raw.encode()
+        mock_info.return_value = {"Repository Root": "http://svn.example.com/repos"}
+
+        result = SvnRepo.externals_from_url(base)
+
+        assert len(result) == 1
+        assert result[0].name == "mylib"
+        assert result[0].revision == "100"
+        assert result[0].path == "vendor/mylib"
+        assert result[0].url == "http://svn.example.com/repos/libs"
+
+
+def test_externals_from_url_nonstd_layout_branch_is_space():
+    # When the external URL has no /trunk/, /branches/, or /tags/ segment,
+    # _split_url returns branch=" " (non-standard layout sentinel).  Confirm
+    # this flows through the full externals_from_url pipeline.
+    base = "http://svn.example.com/repos/myproject/trunk"
+    nonstd_url = "http://svn.mycompany.eu/MYCOMPANY/SomeModule/Core/Modules/Database"
+    raw = f"{base} - {os.linesep}{nonstd_url} Database"
+    with (
+        patch("dfetch.vcs.svn.run_on_cmdline") as mock_run,
+        patch("dfetch.vcs.svn.SvnRepo.get_info_from_target") as mock_info,
+    ):
+        mock_run.return_value.stdout = raw.encode()
+        mock_info.return_value = {"Repository Root": "http://svn.example.com/repos"}
+
+        result = SvnRepo.externals_from_url(base)
+
+        assert len(result) == 1
+        assert result[0].name == "Database"
+        assert result[0].branch == " "
+        assert result[0].url == nonstd_url
+        assert result[0].revision == ""
+        assert result[0].path == "Database"

--- a/tests/test_svnsubproject.py
+++ b/tests/test_svnsubproject.py
@@ -1,0 +1,128 @@
+"""Tests for dfetch.project.svnsubproject.SvnSubProject._fetch_externals."""
+
+# mypy: ignore-errors
+# flake8: noqa
+
+from unittest.mock import patch
+
+from dfetch.manifest.project import ProjectEntry
+from dfetch.project.svnsubproject import SvnSubProject
+from dfetch.vcs.svn import External
+
+REPO_ROOT = "repo-root"
+
+
+def test_fetch_externals_returns_empty_when_no_externals():
+    with patch("dfetch.project.svnsubproject.SvnRepo.externals_from_url") as mock_ext:
+        mock_ext.return_value = []
+        subproject = SvnSubProject(
+            ProjectEntry({"name": "myproject", "url": REPO_ROOT})
+        )
+        assert subproject._fetch_externals(REPO_ROOT + "/trunk", "42") == []
+
+
+def test_fetch_externals_forwards_path_and_revision():
+    with patch("dfetch.project.svnsubproject.SvnRepo.externals_from_url") as mock_ext:
+        mock_ext.return_value = []
+        subproject = SvnSubProject(
+            ProjectEntry({"name": "myproject", "url": REPO_ROOT})
+        )
+        complete_path = REPO_ROOT + "/trunk"
+        subproject._fetch_externals(complete_path, "77")
+        mock_ext.assert_called_once_with(complete_path, "77")
+
+
+def test_fetch_externals_maps_externals_to_dependencies():
+    externals_list = [
+        External(
+            name="mylib",
+            toplevel="",
+            path="vendor/mylib",
+            revision="100",
+            url=REPO_ROOT + "/libs",
+            branch="",
+            tag="",
+            src="",
+        ),
+        External(
+            name="utils",
+            toplevel="",
+            path="vendor/utils",
+            revision="200",
+            url=REPO_ROOT + "/utils",
+            branch="devel",
+            tag="",
+            src="",
+        ),
+    ]
+    with patch("dfetch.project.svnsubproject.SvnRepo.externals_from_url") as mock_ext:
+        mock_ext.return_value = externals_list
+        subproject = SvnSubProject(
+            ProjectEntry({"name": "myproject", "url": REPO_ROOT})
+        )
+        result = subproject._fetch_externals(REPO_ROOT + "/trunk", "100")
+
+        assert len(result) == 2
+
+        assert result[0]["remote_url"] == REPO_ROOT + "/libs"
+        assert result[0]["destination"] == "vendor/mylib"
+        assert result[0]["branch"] == ""
+        assert result[0]["tag"] == ""
+        assert result[0]["revision"] == "100"
+        assert result[0]["source_type"] == "svn-external"
+
+        assert result[1]["remote_url"] == REPO_ROOT + "/utils"
+        assert result[1]["destination"] == "vendor/utils"
+        assert result[1]["branch"] == "devel"
+        assert result[1]["revision"] == "200"
+        assert result[1]["source_type"] == "svn-external"
+
+
+def test_fetch_externals_preserves_tag_in_dependency():
+    external = External(
+        name="mylib",
+        toplevel="",
+        path="vendor/mylib",
+        revision="300",
+        url=REPO_ROOT + "/libs",
+        branch="",
+        tag="v2.0",
+        src="",
+    )
+    with patch("dfetch.project.svnsubproject.SvnRepo.externals_from_url") as mock_ext:
+        mock_ext.return_value = [external]
+        subproject = SvnSubProject(
+            ProjectEntry({"name": "myproject", "url": REPO_ROOT})
+        )
+        result = subproject._fetch_externals(REPO_ROOT + "/trunk", "300")
+
+        assert result[0]["tag"] == "v2.0"
+        assert result[0]["source_type"] == "svn-external"
+
+
+def test_fetch_externals_nonstd_layout_preserves_space_branch():
+    # A non-standard-layout external (URL contains no /trunk/, /branches/, or
+    # /tags/) is represented with branch=" " by _split_url.  That sentinel must
+    # reach the Dependency unchanged — it must NOT be collapsed to "" or "trunk"
+    # by the display_branch substitution that only applies to the log line.
+    external = External(
+        name="Database",
+        toplevel="",
+        path="./Database",
+        revision="",
+        url="http://svn.mycompany.eu/MYCOMPANY/SomeModule/Core/Modules/Database",
+        branch=" ",
+        tag="",
+        src="",
+    )
+    with patch("dfetch.project.svnsubproject.SvnRepo.externals_from_url") as mock_ext:
+        mock_ext.return_value = [external]
+        subproject = SvnSubProject(
+            ProjectEntry({"name": "myproject", "url": REPO_ROOT})
+        )
+        result = subproject._fetch_externals(REPO_ROOT + "/trunk", "")
+
+        assert result[0]["branch"] == " "
+        assert result[0]["remote_url"] == (
+            "http://svn.mycompany.eu/MYCOMPANY/SomeModule/Core/Modules/Database"
+        )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects and fetches SVN externals during update; externals are reported with source-type, URL, display path, revision, branch and tag metadata.

* **Tests**
  * Added end-to-end and unit tests covering externals detection, parsing/normalization (including non-standard layouts), reporting, and error cases.

* **Documentation**
  * Changelog updated to note externals are now reported.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dfetch-org/dfetch/pull/1220?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->