### PR TITLE
Fix off-by-one dropping a remote in dfetch import

### DIFF
--- a/dfetch/commands/import_.py
+++ b/dfetch/commands/import_.py
@@ -126,7 +126,7 @@ def _determine_best_remotes(projects_urls: set[str]) -> tuple[str, ...]:
 
     # For each permutation of any length, calculate the solution score
     solutions: list[tuple[int, tuple[str, ...]]] = []
-    for i in range(min(len(potential_remotes), max_remotes)):
+    for i in range(min(len(potential_remotes), max_remotes) + 1):
         for solution in combinations(potential_remotes, i):
             score = _calculate_solution_score(solution, projects_urls)
             solutions += [(score, solution)]

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 import pytest
 import yaml
 
-from dfetch.commands.import_ import Import
+from dfetch.commands.import_ import Import, _determine_best_remotes
 from dfetch.vcs.git import Submodule
 from dfetch.vcs.svn import External
 
@@ -79,6 +79,30 @@ def test_git_import(name, submodules):
 
                         # Manifest should have been dumped
                         mocked_manifest.from_yaml.return_value.dump.assert_called()
+
+
+def test_determine_best_remotes_covers_all_urls_at_max_remotes():
+    """Every project URL must be covered, even when each needs its own remote.
+
+    Reproduces the off-by-one in the combination-size loop: when the optimal
+    solution needs the maximum number of distinct remotes (one per host), the
+    largest combination was never evaluated, leaving one URL uncovered with its
+    full-length URL retained in the manifest.
+    """
+    urls = {
+        "https://github.com/a/x.git",
+        "https://gitlab.com/b/y.git",
+        "https://bitbucket.org/c/z.git",
+        "https://example.com/d/w.git",
+        "https://sourceforge.net/e/v.git",
+    }
+
+    remotes = _determine_best_remotes(urls)
+
+    uncovered = [
+        url for url in urls if not any(url.startswith(remote) for remote in remotes)
+    ]
+    assert not uncovered, f"URLs left without a matching remote: {uncovered}"
 
 
 FIRST_EXTERNAL = External(


### PR DESCRIPTION
The combination-size loop in _determine_best_remotes stopped one short of
the maximum, so a solution using the maximum number of remotes (one per
host) was never evaluated, leaving a project's URL uncovered in the
generated manifest. Add a regression test covering full remote coverage.

https://claude.ai/code/session_01KKvrvnVvsBChohuxbRRmzA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced remote-selection search in the import command to consider all viable combinations of remotes up to the maximum limit, rather than stopping short, enabling more comprehensive manifest generation.

* **Tests**
  * Added test coverage verifying that remote-selection successfully matches all provided URLs, including edge cases where each URL requires its own remote host.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dfetch-org/dfetch/pull/1233?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->