### PR TITLE
Collapse threat-model tables to one curated row per threat

### DIFF
--- a/doc/explanation/threat_model_supply_chain.rst
+++ b/doc/explanation/threat_model_supply_chain.rst
@@ -632,70 +632,14 @@ Threats
      - Target
      - Analysis
      - Controls / Notes
-   * - DFT-03
-     - Path traversal in archive or patch extraction
-     - A-04: Release Gate / Code Review
-     - | **Sev:** 🔴VH
-       | **Risk:** 🟡M
-       | **STRIDE:** T E
-       | **Status:** Mitigate
-     - C-015, C-017
-   * - DFT-07
-     - CI/CD secret exfiltration via supply-chain attack on build environment
-     - A-04: Release Gate / Code Review
-     - | **Sev:** 🟠H
-       | **Risk:** 🟠H
-       | **STRIDE:** S T I E
-       | **Status:** Mitigate
-     - C-009, C-010, C-011, C-012, C-013, C-024
-   * - DFT-09
-     - Archive decompression bomb causes resource exhaustion
-     - A-04: Release Gate / Code Review
-     - | **Sev:** 🟡M
-       | **Risk:** 🟡M
-       | **STRIDE:** D
-       | **Status:** Accept
-     - Decompression-bomb protection is a runtime concern (C-002 in usage model), not a supply-chain pipeline control.  Accepted based on the **CI runner posture** assumption: GitHub Actions environments run on ephemeral, isolated runners; any denial-of-service impact from a decompression bomb is bounded to the affected job and does not persist beyond it.
-   * - DFT-11
-     - Privileged account compromise enables unauthorised merge or release
-     - A-04: Release Gate / Code Review
-     - | **Sev:** 🟠H
-       | **Risk:** 🟠H
-       | **STRIDE:** S E
-       | **Status:** Accept
-     - No hardware-token MFA or mandatory second-approver enforced for accounts with merge or release-trigger rights.  Accepted based on the **Trusted workstation** assumption: developer workstations and accounts are trusted at development and commit time; a compromised maintainer account is outside the scope of this model.
-   * - DFT-27
-     - Build or release triggered from unofficial source fork or unprotected branch
-     - A-04: Release Gate / Code Review
+   * - DFT-02
+     - Supply-chain content substitution via server-side compromise
+     - A-03: PyPI / TestPyPI
      - | **Sev:** 🟠H
        | **Risk:** 🟠H
        | **STRIDE:** T S
        | **Status:** Mitigate
-     - C-032
-   * - DFT-29
-     - Signing key or short-lived publish credential exfiltrated from build environment
-     - A-04: Release Gate / Code Review
-     - | **Sev:** 🔴VH
-       | **Risk:** 🟠H
-       | **STRIDE:** I T
-       | **Status:** Mitigate
-     - C-013
-   * - DFT-03
-     - Path traversal in archive or patch extraction
-     - A-06: GitHub Actions Workflow
-     - | **Sev:** 🔴VH
-       | **Risk:** 🟡M
-       | **STRIDE:** T E
-       | **Status:** Mitigate
-     - C-015, C-017
-   * - DFT-09
-     - Archive decompression bomb causes resource exhaustion
-     - A-06: GitHub Actions Workflow
-     - | **Sev:** 🟡M
-       | **Risk:** 🟡M
-       | **STRIDE:** D
-       | **Status:** Accept
-     - Decompression-bomb protection is a runtime concern (C-002 in usage model), not a supply-chain pipeline control.  Accepted based on the **CI runner posture** assumption: GitHub Actions environments run on ephemeral, isolated runners; any denial-of-service impact from a decompression bomb is bounded to the affected job and does not persist beyond it.
+     - C-022
    * - DFT-03
      - Path traversal in archive or patch extraction
      - A-08: Python Build (wheel / sdist)
@@ -704,6 +648,14 @@ Threats
        | **STRIDE:** T E
        | **Status:** Mitigate
      - C-015, C-017
+   * - DFT-05
+     - Mutable VCS reference enables silent content substitution
+     - DF-16: CI fetches build/dev deps from PyPI
+     - | **Sev:** 🟡M
+       | **Risk:** 🟡M
+       | **STRIDE:** T S
+       | **Status:** Mitigate
+     - C-021
    * - DFT-07
      - CI/CD secret exfiltration via supply-chain attack on build environment
      - A-08: Python Build (wheel / sdist)
@@ -712,6 +664,14 @@ Threats
        | **STRIDE:** S T I E
        | **Status:** Mitigate
      - C-009, C-010, C-011, C-012, C-013, C-024
+   * - DFT-08
+     - Tampered secondary artifact suppresses or bypasses security checks
+     - A-08b: GitHub Actions Build Cache
+     - | **Sev:** 🟡M
+       | **Risk:** 🟠H
+       | **STRIDE:** T
+       | **Status:** Accept
+     - Secondary artifacts are not independently verified in the supply-chain pipeline.  Accepted based on the **CI runner posture** assumption: GitHub Actions environments run on ephemeral, GitHub-hosted runners whose isolation is provided by GitHub, so secondary artifacts written and consumed within a single job are considered adequately protected by that isolation.
    * - DFT-09
      - Archive decompression bomb causes resource exhaustion
      - A-08: Python Build (wheel / sdist)
@@ -720,22 +680,6 @@ Threats
        | **STRIDE:** D
        | **Status:** Accept
      - Decompression-bomb protection is a runtime concern (C-002 in usage model), not a supply-chain pipeline control.  Accepted based on the **CI runner posture** assumption: GitHub Actions environments run on ephemeral, isolated runners; any denial-of-service impact from a decompression bomb is bounded to the affected job and does not persist beyond it.
-   * - DFT-27
-     - Build or release triggered from unofficial source fork or unprotected branch
-     - A-08: Python Build (wheel / sdist)
-     - | **Sev:** 🟠H
-       | **Risk:** 🟠H
-       | **STRIDE:** T S
-       | **Status:** Mitigate
-     - C-032
-   * - DFT-29
-     - Signing key or short-lived publish credential exfiltrated from build environment
-     - A-08: Python Build (wheel / sdist)
-     - | **Sev:** 🔴VH
-       | **Risk:** 🟠H
-       | **STRIDE:** I T
-       | **Status:** Mitigate
-     - C-013
    * - DFT-10
      - Build or development dependency substitution via compromised registry
      - A-07: dfetch Build / Dev Dependencies
@@ -744,6 +688,22 @@ Threats
        | **STRIDE:** T
        | **Status:** Mitigate
      - C-016 checks known-vulnerable deps on PRs; build deps lack ``--require-hashes`` pinning.
+   * - DFT-11
+     - Privileged account compromise enables unauthorised merge or release
+     - A-04: Release Gate / Code Review
+     - | **Sev:** 🟠H
+       | **Risk:** 🟠H
+       | **STRIDE:** S E
+       | **Status:** Accept
+     - No hardware-token MFA or mandatory second-approver enforced for accounts with merge or release-trigger rights.  Accepted based on the **Trusted workstation** assumption: developer workstations and accounts are trusted at development and commit time; a compromised maintainer account is outside the scope of this model.
+   * - DFT-17
+     - Typosquatting or unverified source identity on an unauthenticated channel
+     - A-03: PyPI / TestPyPI
+     - | **Sev:** 🟠H
+       | **Risk:** 🟡M
+       | **STRIDE:** S
+       | **Status:** Mitigate
+     - C-026
    * - DFT-18
      - Dependency confusion - public registry package shadows private internal package
      - A-07: dfetch Build / Dev Dependencies
@@ -760,14 +720,14 @@ Threats
        | **STRIDE:** S T
        | **Status:** Accept
      - Abandoned namespace reclaim is a registry-level concern outside dfetch's control.  Accepted based on the **CI runner posture** assumption: GitHub Actions environments inherit the security posture of the GitHub-hosted runner, including its access to the public PyPI registry; registry-level namespace integrity is outside the scope of this model.
-   * - DFT-08
-     - Tampered secondary artifact suppresses or bypasses security checks
-     - A-08b: GitHub Actions Build Cache
+   * - DFT-23
+     - Replay or freeze attack delivers stale content to suppress security updates
+     - DF-16: CI fetches build/dev deps from PyPI
      - | **Sev:** 🟡M
-       | **Risk:** 🟠H
+       | **Risk:** 🟡M
        | **STRIDE:** T
        | **Status:** Accept
-     - Secondary artifacts are not independently verified in the supply-chain pipeline.  Accepted based on the **CI runner posture** assumption: GitHub Actions environments run on ephemeral, GitHub-hosted runners whose isolation is provided by GitHub, so secondary artifacts written and consumed within a single job are considered adequately protected by that isolation.
+     - No version-pinning or update-freshness check in the supply-chain pipeline.  Accepted based on the **CI runner posture** assumption: GitHub Actions environments inherit the security posture of the GitHub-hosted runner; freshness enforcement for registry dependencies is a registry-level concern outside the scope of this model.
    * - DFT-24
      - Local dependency cache or metadata store poisoned to suppress integrity alerts
      - A-08b: GitHub Actions Build Cache
@@ -784,6 +744,14 @@ Threats
        | **STRIDE:** S T R
        | **Status:** Mitigate
      - C-026, C-039
+   * - DFT-27
+     - Build or release triggered from unofficial source fork or unprotected branch
+     - A-04: Release Gate / Code Review
+     - | **Sev:** 🟠H
+       | **Risk:** 🟠H
+       | **STRIDE:** T S
+       | **Status:** Mitigate
+     - C-032
    * - DFT-28
      - CI/CD build cache poisoned to silently substitute a malicious compiled artifact
      - A-08b: GitHub Actions Build Cache
@@ -792,134 +760,14 @@ Threats
        | **STRIDE:** T
        | **Status:** Mitigate
      - C-033
-   * - DFT-02
-     - Supply-chain content substitution via server-side compromise
-     - DF-16: CI fetches build/dev deps from PyPI
-     - | **Sev:** 🟠H
+   * - DFT-29
+     - Signing key or short-lived publish credential exfiltrated from build environment
+     - A-08: Python Build (wheel / sdist)
+     - | **Sev:** 🔴VH
        | **Risk:** 🟠H
-       | **STRIDE:** T S
+       | **STRIDE:** I T
        | **Status:** Mitigate
-     - C-022
-   * - DFT-05
-     - Mutable VCS reference enables silent content substitution
-     - DF-16: CI fetches build/dev deps from PyPI
-     - | **Sev:** 🟡M
-       | **Risk:** 🟡M
-       | **STRIDE:** T S
-       | **Status:** Mitigate
-     - C-021
-   * - DFT-17
-     - Typosquatting or unverified source identity on an unauthenticated channel
-     - DF-16: CI fetches build/dev deps from PyPI
-     - | **Sev:** 🟠H
-       | **Risk:** 🟡M
-       | **STRIDE:** S
-       | **Status:** Mitigate
-     - C-026
-   * - DFT-23
-     - Replay or freeze attack delivers stale content to suppress security updates
-     - DF-16: CI fetches build/dev deps from PyPI
-     - | **Sev:** 🟡M
-       | **Risk:** 🟡M
-       | **STRIDE:** T
-       | **Status:** Accept
-     - No version-pinning or update-freshness check in the supply-chain pipeline.  Accepted based on the **CI runner posture** assumption: GitHub Actions environments inherit the security posture of the GitHub-hosted runner; freshness enforcement for registry dependencies is a registry-level concern outside the scope of this model.
-   * - DFT-31
-     - Upstream source publishes no SLSA Source provenance attestation — consumer cannot verify upstream security controls
-     - DF-16: CI fetches build/dev deps from PyPI
-     - | **Sev:** 🟡M
-       | **Risk:** 🟢L
-       | **STRIDE:** R S
-       | **Status:** Mitigate
-     - C-037, C-039, C-040
-   * - DFT-33
-     - Upstream default-branch history rewritten — ancestry broken, pinned SHA orphaned or made unreachable
-     - DF-16: CI fetches build/dev deps from PyPI
-     - | **Sev:** 🟡M
-       | **Risk:** 🟢L
-       | **STRIDE:** T
-       | **Status:** Mitigate
-     - C-038
-   * - DFT-02
-     - Supply-chain content substitution via server-side compromise
-     - DF-25: pip install dfetch
-     - | **Sev:** 🟠H
-       | **Risk:** 🟠H
-       | **STRIDE:** T S
-       | **Status:** Mitigate
-     - C-022
-   * - DFT-05
-     - Mutable VCS reference enables silent content substitution
-     - DF-25: pip install dfetch
-     - | **Sev:** 🟡M
-       | **Risk:** 🟡M
-       | **STRIDE:** T S
-       | **Status:** Mitigate
-     - C-021
-   * - DFT-17
-     - Typosquatting or unverified source identity on an unauthenticated channel
-     - DF-25: pip install dfetch
-     - | **Sev:** 🟠H
-       | **Risk:** 🟡M
-       | **STRIDE:** S
-       | **Status:** Mitigate
-     - C-026
-   * - DFT-23
-     - Replay or freeze attack delivers stale content to suppress security updates
-     - DF-25: pip install dfetch
-     - | **Sev:** 🟡M
-       | **Risk:** 🟡M
-       | **STRIDE:** T
-       | **Status:** Accept
-     - No version-pinning or update-freshness check in the supply-chain pipeline.  Accepted based on the **CI runner posture** assumption: GitHub Actions environments inherit the security posture of the GitHub-hosted runner; freshness enforcement for registry dependencies is a registry-level concern outside the scope of this model.
-   * - DFT-31
-     - Upstream source publishes no SLSA Source provenance attestation — consumer cannot verify upstream security controls
-     - DF-25: pip install dfetch
-     - | **Sev:** 🟡M
-       | **Risk:** 🟢L
-       | **STRIDE:** R S
-       | **Status:** Mitigate
-     - C-037, C-039, C-040
-   * - DFT-33
-     - Upstream default-branch history rewritten — ancestry broken, pinned SHA orphaned or made unreachable
-     - DF-25: pip install dfetch
-     - | **Sev:** 🟡M
-       | **Risk:** 🟢L
-       | **STRIDE:** T
-       | **Status:** Mitigate
-     - C-038
-   * - DFT-02
-     - Supply-chain content substitution via server-side compromise
-     - DF-26: Consumer downloads dfetch from PyPI
-     - | **Sev:** 🟠H
-       | **Risk:** 🟠H
-       | **STRIDE:** T S
-       | **Status:** Mitigate
-     - C-022
-   * - DFT-05
-     - Mutable VCS reference enables silent content substitution
-     - DF-26: Consumer downloads dfetch from PyPI
-     - | **Sev:** 🟡M
-       | **Risk:** 🟡M
-       | **STRIDE:** T S
-       | **Status:** Mitigate
-     - C-021
-   * - DFT-17
-     - Typosquatting or unverified source identity on an unauthenticated channel
-     - DF-26: Consumer downloads dfetch from PyPI
-     - | **Sev:** 🟠H
-       | **Risk:** 🟡M
-       | **STRIDE:** S
-       | **Status:** Mitigate
-     - C-026
-   * - DFT-23
-     - Replay or freeze attack delivers stale content to suppress security updates
-     - DF-26: Consumer downloads dfetch from PyPI
-     - | **Sev:** 🟡M
-       | **Risk:** 🟡M
-       | **STRIDE:** T
-       | **Status:** Accept
-     - No version-pinning or update-freshness check in the supply-chain pipeline.  Accepted based on the **CI runner posture** assumption: GitHub Actions environments inherit the security posture of the GitHub-hosted runner; freshness enforcement for registry dependencies is a registry-level concern outside the scope of this model.
+     - C-013
    * - DFT-31
      - Upstream source publishes no SLSA Source provenance attestation — consumer cannot verify upstream security controls
      - DF-26: Consumer downloads dfetch from PyPI

--- a/doc/explanation/threat_model_usage.rst
+++ b/doc/explanation/threat_model_usage.rst
@@ -910,46 +910,22 @@ Threats
      - Target
      - Analysis
      - Controls / Notes
-   * - DFT-10
-     - Build or development dependency substitution via compromised registry
-     - A-23: Upstream Source Attestation (VSA)
+   * - DFT-01
+     - Unencrypted transport interception (MITM)
+     - DF-06b: Archive bytes - HTTP (plaintext risk)
      - | **Sev:** 🟠H
-       | **Risk:** 🟠H
-       | **STRIDE:** T
-       | **Status:** Accept
-     - dfetch's runtime dependency supply-chain is the supply-chain model's scope; use a verified dfetch installation.  Accepted based on the **dfetch scope boundary** assumption: dfetch is responsible only for its own security posture; the integrity of dfetch's own runtime dependencies is out of scope for this usage model and is addressed by the supply-chain threat model.
-   * - DFT-18
-     - Dependency confusion - public registry package shadows private internal package
-     - A-23: Upstream Source Attestation (VSA)
-     - | **Sev:** 🟠H
-       | **Risk:** 🟠H
+       | **Risk:** 🔴C
        | **STRIDE:** T S
-       | **Status:** Accept
-     - Not applicable to dfetch's fetch-by-explicit-URL model; relevant only if using package-registry shorthand.  Accepted based on the **dfetch scope boundary** assumption: dfetch fetches by explicit URL declared in the manifest rather than by package name resolved against a registry; dependency confusion via registry namespace shadowing cannot occur within dfetch's fetch model.
-   * - DFT-20
-     - Abandoned package namespace reclaimed by malicious actor
-     - A-23: Upstream Source Attestation (VSA)
-     - | **Sev:** 🟠H
-       | **Risk:** 🟡M
-       | **STRIDE:** S T
-       | **Status:** Accept
-     - Not applicable to direct-URL fetches; relevant only if using Git-hosting shorthand with inferred registry lookup.  Accepted based on the **dfetch scope boundary** assumption: dfetch fetches by explicit URL declared in the manifest rather than resolving package names against a registry; abandoned-namespace reclaim attacks require a registry lookup step that does not exist in dfetch's fetch model.
-   * - DFT-16
-     - Configured destination path allows writes to security-sensitive project directories
-     - A-22: dfetch Process
-     - | **Sev:** 🔴VH
-       | **Risk:** 🟠H
-       | **STRIDE:** T E
-       | **Status:** Accept
-     - C-001 prevents writes outside the project root; no denylist blocks writes to sensitive within-root paths such as ``.github/workflows/``.  Defense-in-depth: CI pipelines should run ``dfetch update`` in a step that does not have write access to ``.github/workflows/`` (e.g. by restricting permissions or running in a directory sandbox).  Accepted based on the **Manifest under code review** assumption: the ``dst:`` path for every dependency is declared in ``dfetch.yaml`` and subject to code review; any change pointing a destination at a sensitive directory would be rejected at the review boundary.
-   * - DFT-30
-     - Weak or deprecated hash algorithm allows collision-based integrity bypass
-     - A-22: dfetch Process
+       | **Status:** Mitigate
+     - C-005 mitigates only when ``integrity.hash`` is present; plain HTTP without a hash has no transport or content protection.
+   * - DFT-02
+     - Supply-chain content substitution via server-side compromise
+     - DF-04a: VCS content inbound - HTTPS/SSH
      - | **Sev:** 🟠H
        | **Risk:** 🟠H
        | **STRIDE:** T S
        | **Status:** Mitigate
-     - C-005, C-034
+     - Archives: C-005 mitigates when hash is present. Git/SVN refs have no equivalent integrity mechanism; pinning to a commit SHA is the strongest available mitigation.
    * - DFT-03
      - Path traversal in archive or patch extraction
      - A-25: Patch Application (patch-ng)
@@ -958,30 +934,6 @@ Threats
        | **STRIDE:** T E
        | **Status:** Mitigate
      - Archive and VCS extraction mitigated by C-001, C-003, C-004. Patch files carry no integrity hash and are not independently verified.
-   * - DFT-07
-     - CI/CD secret exfiltration via supply-chain attack on build environment
-     - A-25: Patch Application (patch-ng)
-     - | **Sev:** 🟠H
-       | **Risk:** 🟠H
-       | **STRIDE:** I
-       | **Status:** Accept
-     - dfetch uses ``shell=False`` throughout (C-007); residual supply-chain compromise of dfetch itself is the supply-chain model's scope.  Accepted based on the **dfetch scope boundary** assumption: dfetch is responsible only for its own security posture; a compromised dfetch installation is addressed by the supply-chain threat model, not the runtime-usage model.
-   * - DFT-09
-     - Archive decompression bomb causes resource exhaustion
-     - A-25: Patch Application (patch-ng)
-     - | **Sev:** 🟡M
-       | **Risk:** 🟡M
-       | **STRIDE:** D
-       | **Status:** Mitigate
-     - C-002
-   * - DFT-28
-     - CI/CD build cache poisoned to silently substitute a malicious compiled artifact
-     - A-12: dfetch Manifest
-     - | **Sev:** 🟠H
-       | **Risk:** 🟠H
-       | **STRIDE:** T
-       | **Status:** Accept
-     - Build-cache poisoning (SLSA E6) is a CI/CD supply-chain concern that applies to the dfetch build pipeline, not to runtime usage.  dfetch does not maintain a persistent compiled artifact cache; fetched source files are written directly to the vendor directory.  See the supply-chain threat model for the mitigating control (C-033).  Accepted based on the **dfetch scope boundary** assumption: dfetch is responsible only for its own security posture; the CI/CD build pipeline for dfetch itself is outside the scope of the runtime-usage model.
    * - DFT-04
      - Sensitive datastore write without content integrity verification
      - A-13: Fetched Source Code
@@ -990,62 +942,22 @@ Threats
        | **STRIDE:** T
        | **Status:** Mitigate
      - C-008
-   * - DFT-19
-     - Malicious upstream update or intentional maintainer sabotage (protestware)
-     - A-13: Fetched Source Code
-     - | **Sev:** 🔴VH
-       | **Risk:** 🟠H
-       | **STRIDE:** T
-       | **Status:** Accept
-     - Upstream maintainer trust; pinning to an immutable commit SHA is the strongest available mitigation but is not enforced by dfetch.  Accepted based on the **dfetch scope boundary** assumption: the security of fetched third-party source code is the responsibility of the manifest author who selects and pins each dependency; intentional maintainer sabotage of an upstream is outside dfetch's control.
-   * - DFT-22
-     - Vendored content contains submodule or nested external reference triggering undeclared fetch
-     - A-13: Fetched Source Code
-     - | **Sev:** 🟡M
-       | **Risk:** 🟡M
-       | **STRIDE:** T
-       | **Status:** Accept
-     - dfetch does not parse or execute embedded build manifests (CMakeLists.txt, package.json, etc.); undeclared fetches via build-system externals cannot occur.  However, Git dependencies with submodules and SVN dependencies with ``svn:externals`` do trigger undeclared fetches — see DFT-15 for details and mitigations.  Accepted based on the **dfetch scope boundary** assumption: the security of fetched third-party source code and any nested dependencies it carries is the responsibility of the manifest author who selects and pins each dependency.
-   * - DFT-32
-     - Upstream source enforces no mandatory two-party review — single contributor can introduce changes without independent verification
-     - A-13: Fetched Source Code
-     - | **Sev:** 🟡M
-       | **Risk:** 🟢L
-       | **STRIDE:** T
-       | **Status:** Accept
-     - Upstream repositories are outside dfetch's control; no mechanism exists to require mandatory two-party review on upstream changes.  Accepted based on the **dfetch scope boundary** assumption: the security of fetched third-party source code is the responsibility of the manifest author who selects and pins each dependency; requiring upstream review policies is outside dfetch's own security posture.
-   * - DFT-08
-     - Tampered secondary artifact suppresses or bypasses security checks
-     - A-15: SBOM Output (CycloneDX)
+   * - DFT-05
+     - Mutable VCS reference enables silent content substitution
+     - DF-04a: VCS content inbound - HTTPS/SSH
      - | **Sev:** 🟡M
        | **Risk:** 🟠H
-       | **STRIDE:** T
+       | **STRIDE:** T S
        | **Status:** Mitigate
-     - Manifest schema (C-008) validates all string fields; patch files carry no integrity hash and are not verified before application.
-   * - DFT-24
-     - Local dependency cache or metadata store poisoned to suppress integrity alerts
-     - A-15: SBOM Output (CycloneDX)
-     - | **Sev:** 🟠H
-       | **Risk:** 🟡M
-       | **STRIDE:** T
-       | **Status:** Accept
-     - ``.dfetch_data.yaml`` metadata is not integrity-protected; tampering could suppress update notifications from ``dfetch check``.  Accepted based on the **Trusted workstation** assumption: developer workstations are trusted at dfetch invocation time; local filesystem write access sufficient to tamper with ``.dfetch_data.yaml`` implies a compromised workstation, which is outside the scope of this model.
-   * - DFT-25
-     - Forged or unverifiable provenance attestation conceals malicious build output
-     - A-15: SBOM Output (CycloneDX)
+     - C-005 mitigates archive deps when hash present. Git/SVN: no integrity mechanism; pinning to an immutable commit SHA is recommended but not enforced by dfetch.
+   * - DFT-07
+     - CI/CD secret exfiltration via supply-chain attack on build environment
+     - A-25: Patch Application (patch-ng)
      - | **Sev:** 🟠H
        | **Risk:** 🟠H
-       | **STRIDE:** S T R
+       | **STRIDE:** I
        | **Status:** Accept
-     - dfetch does not verify upstream SLSA provenance of fetched sources; provenance verification is the consumer's responsibility.  Accepted based on the **dfetch scope boundary** assumption: the security of fetched third-party source code is the responsibility of the manifest author who selects and pins each dependency; upstream provenance attestation is outside dfetch's own security posture.
-   * - DFT-28
-     - CI/CD build cache poisoned to silently substitute a malicious compiled artifact
-     - A-15: SBOM Output (CycloneDX)
-     - | **Sev:** 🟠H
-       | **Risk:** 🟠H
-       | **STRIDE:** T
-       | **Status:** Accept
-     - Build-cache poisoning (SLSA E6) is a CI/CD supply-chain concern that applies to the dfetch build pipeline, not to runtime usage.  dfetch does not maintain a persistent compiled artifact cache; fetched source files are written directly to the vendor directory.  See the supply-chain threat model for the mitigating control (C-033).  Accepted based on the **dfetch scope boundary** assumption: dfetch is responsible only for its own security posture; the CI/CD build pipeline for dfetch itself is outside the scope of the runtime-usage model.
+     - dfetch uses ``shell=False`` throughout (C-007); residual supply-chain compromise of dfetch itself is the supply-chain model's scope.  Accepted based on the **dfetch scope boundary** assumption: dfetch is responsible only for its own security posture; a compromised dfetch installation is addressed by the supply-chain threat model, not the runtime-usage model.
    * - DFT-08
      - Tampered secondary artifact suppresses or bypasses security checks
      - A-18: Dependency Metadata
@@ -1054,6 +966,30 @@ Threats
        | **STRIDE:** T
        | **Status:** Mitigate
      - Manifest schema (C-008) validates all string fields; patch files carry no integrity hash and are not verified before application.
+   * - DFT-09
+     - Archive decompression bomb causes resource exhaustion
+     - A-24: Archive Extraction (tarfile / zipfile)
+     - | **Sev:** 🟡M
+       | **Risk:** 🟡M
+       | **STRIDE:** D
+       | **Status:** Mitigate
+     - C-002
+   * - DFT-10
+     - Build or development dependency substitution via compromised registry
+     - A-22: dfetch Process
+     - | **Sev:** 🟠H
+       | **Risk:** 🟠H
+       | **STRIDE:** T
+       | **Status:** Accept
+     - dfetch's runtime dependency supply-chain is the supply-chain model's scope; use a verified dfetch installation.  Accepted based on the **dfetch scope boundary** assumption: dfetch is responsible only for its own security posture; the integrity of dfetch's own runtime dependencies is out of scope for this usage model and is addressed by the supply-chain threat model.
+   * - DFT-12
+     - SSRF via unvalidated HTTP redirect chain
+     - DF-05a: Archive download request - HTTPS
+     - | **Sev:** 🟠H
+       | **Risk:** 🟠H
+       | **STRIDE:** I
+       | **Status:** Accept
+     - Archive downloads follow up to 10 HTTP redirects without validating the destination against RFC-1918, loopback, or link-local ranges; SSRF to internal metadata endpoints is possible.  Accepted based on the **No HTTPS enforcement** assumption: HTTPS enforcement and safe URL selection are the manifest author's responsibility; the manifest is under code review, and URLs that could expose internal services should be rejected at the review boundary.
    * - DFT-13
      - Credential embedded in source URL persisted to unencrypted metadata
      - A-18: Dependency Metadata
@@ -1062,446 +998,6 @@ Threats
        | **STRIDE:** I
        | **Status:** Accept
      - dfetch persists the configured URL to ``.dfetch_data.yaml``; credentials embedded in URLs appear in that file in plaintext.  Accepted based on the **No persisted secrets** assumption: no runtime secrets are persisted to disk by dfetch itself — VCS credentials are expected to be managed by the OS keychain, SSH agent, or CI secret store rather than embedded in source URLs.
-   * - DFT-24
-     - Local dependency cache or metadata store poisoned to suppress integrity alerts
-     - A-18: Dependency Metadata
-     - | **Sev:** 🟠H
-       | **Risk:** 🟡M
-       | **STRIDE:** T
-       | **Status:** Accept
-     - ``.dfetch_data.yaml`` metadata is not integrity-protected; tampering could suppress update notifications from ``dfetch check``.  Accepted based on the **Trusted workstation** assumption: developer workstations are trusted at dfetch invocation time; local filesystem write access sufficient to tamper with ``.dfetch_data.yaml`` implies a compromised workstation, which is outside the scope of this model.
-   * - DFT-25
-     - Forged or unverifiable provenance attestation conceals malicious build output
-     - A-18: Dependency Metadata
-     - | **Sev:** 🟠H
-       | **Risk:** 🟠H
-       | **STRIDE:** S T R
-       | **Status:** Accept
-     - dfetch does not verify upstream SLSA provenance of fetched sources; provenance verification is the consumer's responsibility.  Accepted based on the **dfetch scope boundary** assumption: the security of fetched third-party source code is the responsibility of the manifest author who selects and pins each dependency; upstream provenance attestation is outside dfetch's own security posture.
-   * - DFT-28
-     - CI/CD build cache poisoned to silently substitute a malicious compiled artifact
-     - A-18: Dependency Metadata
-     - | **Sev:** 🟠H
-       | **Risk:** 🟠H
-       | **STRIDE:** T
-       | **Status:** Accept
-     - Build-cache poisoning (SLSA E6) is a CI/CD supply-chain concern that applies to the dfetch build pipeline, not to runtime usage.  dfetch does not maintain a persistent compiled artifact cache; fetched source files are written directly to the vendor directory.  See the supply-chain threat model for the mitigating control (C-033).  Accepted based on the **dfetch scope boundary** assumption: dfetch is responsible only for its own security posture; the CI/CD build pipeline for dfetch itself is outside the scope of the runtime-usage model.
-   * - DFT-08
-     - Tampered secondary artifact suppresses or bypasses security checks
-     - A-19: Patch Files
-     - | **Sev:** 🟡M
-       | **Risk:** 🟠H
-       | **STRIDE:** T
-       | **Status:** Mitigate
-     - Manifest schema (C-008) validates all string fields; patch files carry no integrity hash and are not verified before application.
-   * - DFT-24
-     - Local dependency cache or metadata store poisoned to suppress integrity alerts
-     - A-19: Patch Files
-     - | **Sev:** 🟠H
-       | **Risk:** 🟡M
-       | **STRIDE:** T
-       | **Status:** Accept
-     - ``.dfetch_data.yaml`` metadata is not integrity-protected; tampering could suppress update notifications from ``dfetch check``.  Accepted based on the **Trusted workstation** assumption: developer workstations are trusted at dfetch invocation time; local filesystem write access sufficient to tamper with ``.dfetch_data.yaml`` implies a compromised workstation, which is outside the scope of this model.
-   * - DFT-25
-     - Forged or unverifiable provenance attestation conceals malicious build output
-     - A-19: Patch Files
-     - | **Sev:** 🟠H
-       | **Risk:** 🟠H
-       | **STRIDE:** S T R
-       | **Status:** Accept
-     - dfetch does not verify upstream SLSA provenance of fetched sources; provenance verification is the consumer's responsibility.  Accepted based on the **dfetch scope boundary** assumption: the security of fetched third-party source code is the responsibility of the manifest author who selects and pins each dependency; upstream provenance attestation is outside dfetch's own security posture.
-   * - DFT-28
-     - CI/CD build cache poisoned to silently substitute a malicious compiled artifact
-     - A-19: Patch Files
-     - | **Sev:** 🟠H
-       | **Risk:** 🟠H
-       | **STRIDE:** T
-       | **Status:** Accept
-     - Build-cache poisoning (SLSA E6) is a CI/CD supply-chain concern that applies to the dfetch build pipeline, not to runtime usage.  dfetch does not maintain a persistent compiled artifact cache; fetched source files are written directly to the vendor directory.  See the supply-chain threat model for the mitigating control (C-033).  Accepted based on the **dfetch scope boundary** assumption: dfetch is responsible only for its own security posture; the CI/CD build pipeline for dfetch itself is outside the scope of the runtime-usage model.
-   * - DFT-01
-     - Unencrypted transport interception (MITM)
-     - DF-03b: Fetch VCS content - svn:// / http://
-     - | **Sev:** 🟠H
-       | **Risk:** 🔴C
-       | **STRIDE:** T S
-       | **Status:** Mitigate
-     - C-005 mitigates only when ``integrity.hash`` is present; plain HTTP without a hash has no transport or content protection.
-   * - DFT-02
-     - Supply-chain content substitution via server-side compromise
-     - DF-03b: Fetch VCS content - svn:// / http://
-     - | **Sev:** 🟠H
-       | **Risk:** 🟠H
-       | **STRIDE:** T S
-       | **Status:** Mitigate
-     - Archives: C-005 mitigates when hash is present. Git/SVN refs have no equivalent integrity mechanism; pinning to a commit SHA is the strongest available mitigation.
-   * - DFT-05
-     - Mutable VCS reference enables silent content substitution
-     - DF-03b: Fetch VCS content - svn:// / http://
-     - | **Sev:** 🟡M
-       | **Risk:** 🟠H
-       | **STRIDE:** T S
-       | **Status:** Mitigate
-     - C-005 mitigates archive deps when hash present. Git/SVN: no integrity mechanism; pinning to an immutable commit SHA is recommended but not enforced by dfetch.
-   * - DFT-17
-     - Typosquatting or unverified source identity on an unauthenticated channel
-     - DF-03b: Fetch VCS content - svn:// / http://
-     - | **Sev:** 🟠H
-       | **Risk:** 🟡M
-       | **STRIDE:** S
-       | **Status:** Accept
-     - Manifest author responsibility; the manifest is under code review.  Accepted based on the **Manifest under code review** assumption: ``dfetch.yaml`` is under version control and subject to code review; an adversary who introduces a typosquatted or unverified URL must do so through a manifest change that passes the review boundary.
-   * - DFT-23
-     - Replay or freeze attack delivers stale content to suppress security updates
-     - DF-03b: Fetch VCS content - svn:// / http://
-     - | **Sev:** 🟡M
-       | **Risk:** 🟡M
-       | **STRIDE:** T
-       | **Status:** Accept
-     - No freshness check; ``dfetch check`` detects version drift but does not enforce a minimum version or reject stale content.  Accepted based on the **Mutable VCS references** assumption: branch- and tag-pinned dependencies are mutable references whose content can be changed by upstream force-pushes; stale-content delivery is an acknowledged consequence of using mutable pins without a freshness enforcement mechanism.
-   * - DFT-31
-     - Upstream source publishes no SLSA Source provenance attestation — consumer cannot verify upstream security controls
-     - DF-03b: Fetch VCS content - svn:// / http://
-     - | **Sev:** 🟡M
-       | **Risk:** 🟢L
-       | **STRIDE:** R
-       | **Status:** Accept
-     - Upstream repositories are outside dfetch's control; no mechanism exists to require or verify upstream SLSA source level.  Accepted based on the **dfetch scope boundary** assumption: the security of fetched third-party source code is the responsibility of the manifest author who selects and pins each dependency; verifying upstream governance controls is outside dfetch's own security posture.
-   * - DFT-33
-     - Upstream default-branch history rewritten — ancestry broken, pinned SHA orphaned or made unreachable
-     - DF-03b: Fetch VCS content - svn:// / http://
-     - | **Sev:** 🟡M
-       | **Risk:** 🟢L
-       | **STRIDE:** T
-       | **Status:** Accept
-     - Upstream repositories are outside dfetch's control; dfetch cannot prevent or detect upstream force-pushes.  Accepted based on the **Mutable VCS references** assumption: branch- and tag-pinned Git dependencies are mutable references; upstream force-pushes silently change what is fetched without triggering a manifest diff, and dfetch has no mechanism to verify that a pinned SHA remains reachable after a history rewrite.
-   * - DFT-02
-     - Supply-chain content substitution via server-side compromise
-     - DF-04a: VCS content inbound - HTTPS/SSH
-     - | **Sev:** 🟠H
-       | **Risk:** 🟠H
-       | **STRIDE:** T S
-       | **Status:** Mitigate
-     - Archives: C-005 mitigates when hash is present. Git/SVN refs have no equivalent integrity mechanism; pinning to a commit SHA is the strongest available mitigation.
-   * - DFT-05
-     - Mutable VCS reference enables silent content substitution
-     - DF-04a: VCS content inbound - HTTPS/SSH
-     - | **Sev:** 🟡M
-       | **Risk:** 🟠H
-       | **STRIDE:** T S
-       | **Status:** Mitigate
-     - C-005 mitigates archive deps when hash present. Git/SVN: no integrity mechanism; pinning to an immutable commit SHA is recommended but not enforced by dfetch.
-   * - DFT-21
-     - Unsigned or forged VCS tag accepted as a trusted version pin
-     - DF-04a: VCS content inbound - HTTPS/SSH
-     - | **Sev:** 🟠H
-       | **Risk:** 🟡M
-       | **STRIDE:** S T
-       | **Status:** Accept
-     - dfetch does not verify VCS tag signatures; pinning to an immutable commit SHA is recommended.  Accepted based on the **Mutable VCS references** assumption: branch- and tag-pinned Git dependencies are mutable references; upstream force-pushes can silently change the commit a tag resolves to without triggering a manifest diff, and tag-signature verification is not enforced by dfetch.
-   * - DFT-31
-     - Upstream source publishes no SLSA Source provenance attestation — consumer cannot verify upstream security controls
-     - DF-04a: VCS content inbound - HTTPS/SSH
-     - | **Sev:** 🟡M
-       | **Risk:** 🟢L
-       | **STRIDE:** R
-       | **Status:** Accept
-     - Upstream repositories are outside dfetch's control; no mechanism exists to require or verify upstream SLSA source level.  Accepted based on the **dfetch scope boundary** assumption: the security of fetched third-party source code is the responsibility of the manifest author who selects and pins each dependency; verifying upstream governance controls is outside dfetch's own security posture.
-   * - DFT-33
-     - Upstream default-branch history rewritten — ancestry broken, pinned SHA orphaned or made unreachable
-     - DF-04a: VCS content inbound - HTTPS/SSH
-     - | **Sev:** 🟡M
-       | **Risk:** 🟢L
-       | **STRIDE:** T
-       | **Status:** Accept
-     - Upstream repositories are outside dfetch's control; dfetch cannot prevent or detect upstream force-pushes.  Accepted based on the **Mutable VCS references** assumption: branch- and tag-pinned Git dependencies are mutable references; upstream force-pushes silently change what is fetched without triggering a manifest diff, and dfetch has no mechanism to verify that a pinned SHA remains reachable after a history rewrite.
-   * - DFT-01
-     - Unencrypted transport interception (MITM)
-     - DF-04b: VCS content inbound - svn:// / http://
-     - | **Sev:** 🟠H
-       | **Risk:** 🔴C
-       | **STRIDE:** T S
-       | **Status:** Mitigate
-     - C-005 mitigates only when ``integrity.hash`` is present; plain HTTP without a hash has no transport or content protection.
-   * - DFT-02
-     - Supply-chain content substitution via server-side compromise
-     - DF-04b: VCS content inbound - svn:// / http://
-     - | **Sev:** 🟠H
-       | **Risk:** 🟠H
-       | **STRIDE:** T S
-       | **Status:** Mitigate
-     - Archives: C-005 mitigates when hash is present. Git/SVN refs have no equivalent integrity mechanism; pinning to a commit SHA is the strongest available mitigation.
-   * - DFT-05
-     - Mutable VCS reference enables silent content substitution
-     - DF-04b: VCS content inbound - svn:// / http://
-     - | **Sev:** 🟡M
-       | **Risk:** 🟠H
-       | **STRIDE:** T S
-       | **Status:** Mitigate
-     - C-005 mitigates archive deps when hash present. Git/SVN: no integrity mechanism; pinning to an immutable commit SHA is recommended but not enforced by dfetch.
-   * - DFT-17
-     - Typosquatting or unverified source identity on an unauthenticated channel
-     - DF-04b: VCS content inbound - svn:// / http://
-     - | **Sev:** 🟠H
-       | **Risk:** 🟡M
-       | **STRIDE:** S
-       | **Status:** Accept
-     - Manifest author responsibility; the manifest is under code review.  Accepted based on the **Manifest under code review** assumption: ``dfetch.yaml`` is under version control and subject to code review; an adversary who introduces a typosquatted or unverified URL must do so through a manifest change that passes the review boundary.
-   * - DFT-23
-     - Replay or freeze attack delivers stale content to suppress security updates
-     - DF-04b: VCS content inbound - svn:// / http://
-     - | **Sev:** 🟡M
-       | **Risk:** 🟡M
-       | **STRIDE:** T
-       | **Status:** Accept
-     - No freshness check; ``dfetch check`` detects version drift but does not enforce a minimum version or reject stale content.  Accepted based on the **Mutable VCS references** assumption: branch- and tag-pinned dependencies are mutable references whose content can be changed by upstream force-pushes; stale-content delivery is an acknowledged consequence of using mutable pins without a freshness enforcement mechanism.
-   * - DFT-31
-     - Upstream source publishes no SLSA Source provenance attestation — consumer cannot verify upstream security controls
-     - DF-04b: VCS content inbound - svn:// / http://
-     - | **Sev:** 🟡M
-       | **Risk:** 🟢L
-       | **STRIDE:** R
-       | **Status:** Accept
-     - Upstream repositories are outside dfetch's control; no mechanism exists to require or verify upstream SLSA source level.  Accepted based on the **dfetch scope boundary** assumption: the security of fetched third-party source code is the responsibility of the manifest author who selects and pins each dependency; verifying upstream governance controls is outside dfetch's own security posture.
-   * - DFT-33
-     - Upstream default-branch history rewritten — ancestry broken, pinned SHA orphaned or made unreachable
-     - DF-04b: VCS content inbound - svn:// / http://
-     - | **Sev:** 🟡M
-       | **Risk:** 🟢L
-       | **STRIDE:** T
-       | **Status:** Accept
-     - Upstream repositories are outside dfetch's control; dfetch cannot prevent or detect upstream force-pushes.  Accepted based on the **Mutable VCS references** assumption: branch- and tag-pinned Git dependencies are mutable references; upstream force-pushes silently change what is fetched without triggering a manifest diff, and dfetch has no mechanism to verify that a pinned SHA remains reachable after a history rewrite.
-   * - DFT-02
-     - Supply-chain content substitution via server-side compromise
-     - DF-05a: Archive download request - HTTPS
-     - | **Sev:** 🟠H
-       | **Risk:** 🟠H
-       | **STRIDE:** T S
-       | **Status:** Mitigate
-     - Archives: C-005 mitigates when hash is present. Git/SVN refs have no equivalent integrity mechanism; pinning to a commit SHA is the strongest available mitigation.
-   * - DFT-05
-     - Mutable VCS reference enables silent content substitution
-     - DF-05a: Archive download request - HTTPS
-     - | **Sev:** 🟡M
-       | **Risk:** 🟠H
-       | **STRIDE:** T S
-       | **Status:** Mitigate
-     - C-005 mitigates archive deps when hash present. Git/SVN: no integrity mechanism; pinning to an immutable commit SHA is recommended but not enforced by dfetch.
-   * - DFT-12
-     - SSRF via unvalidated HTTP redirect chain
-     - DF-05a: Archive download request - HTTPS
-     - | **Sev:** 🟠H
-       | **Risk:** 🟠H
-       | **STRIDE:** I
-       | **Status:** Accept
-     - Archive downloads follow up to 10 HTTP redirects without validating the destination against RFC-1918, loopback, or link-local ranges; SSRF to internal metadata endpoints is possible.  Accepted based on the **No HTTPS enforcement** assumption: HTTPS enforcement and safe URL selection are the manifest author's responsibility; the manifest is under code review, and URLs that could expose internal services should be rejected at the review boundary.
-   * - DFT-17
-     - Typosquatting or unverified source identity on an unauthenticated channel
-     - DF-05a: Archive download request - HTTPS
-     - | **Sev:** 🟠H
-       | **Risk:** 🟡M
-       | **STRIDE:** S
-       | **Status:** Accept
-     - Manifest author responsibility; the manifest is under code review.  Accepted based on the **Manifest under code review** assumption: ``dfetch.yaml`` is under version control and subject to code review; an adversary who introduces a typosquatted or unverified URL must do so through a manifest change that passes the review boundary.
-   * - DFT-23
-     - Replay or freeze attack delivers stale content to suppress security updates
-     - DF-05a: Archive download request - HTTPS
-     - | **Sev:** 🟡M
-       | **Risk:** 🟡M
-       | **STRIDE:** T
-       | **Status:** Accept
-     - No freshness check; ``dfetch check`` detects version drift but does not enforce a minimum version or reject stale content.  Accepted based on the **Mutable VCS references** assumption: branch- and tag-pinned dependencies are mutable references whose content can be changed by upstream force-pushes; stale-content delivery is an acknowledged consequence of using mutable pins without a freshness enforcement mechanism.
-   * - DFT-31
-     - Upstream source publishes no SLSA Source provenance attestation — consumer cannot verify upstream security controls
-     - DF-05a: Archive download request - HTTPS
-     - | **Sev:** 🟡M
-       | **Risk:** 🟢L
-       | **STRIDE:** R
-       | **Status:** Accept
-     - Upstream repositories are outside dfetch's control; no mechanism exists to require or verify upstream SLSA source level.  Accepted based on the **dfetch scope boundary** assumption: the security of fetched third-party source code is the responsibility of the manifest author who selects and pins each dependency; verifying upstream governance controls is outside dfetch's own security posture.
-   * - DFT-33
-     - Upstream default-branch history rewritten — ancestry broken, pinned SHA orphaned or made unreachable
-     - DF-05a: Archive download request - HTTPS
-     - | **Sev:** 🟡M
-       | **Risk:** 🟢L
-       | **STRIDE:** T
-       | **Status:** Accept
-     - Upstream repositories are outside dfetch's control; dfetch cannot prevent or detect upstream force-pushes.  Accepted based on the **Mutable VCS references** assumption: branch- and tag-pinned Git dependencies are mutable references; upstream force-pushes silently change what is fetched without triggering a manifest diff, and dfetch has no mechanism to verify that a pinned SHA remains reachable after a history rewrite.
-   * - DFT-01
-     - Unencrypted transport interception (MITM)
-     - DF-05b: Archive download request - HTTP
-     - | **Sev:** 🟠H
-       | **Risk:** 🔴C
-       | **STRIDE:** T S
-       | **Status:** Mitigate
-     - C-005 mitigates only when ``integrity.hash`` is present; plain HTTP without a hash has no transport or content protection.
-   * - DFT-02
-     - Supply-chain content substitution via server-side compromise
-     - DF-05b: Archive download request - HTTP
-     - | **Sev:** 🟠H
-       | **Risk:** 🟠H
-       | **STRIDE:** T S
-       | **Status:** Mitigate
-     - Archives: C-005 mitigates when hash is present. Git/SVN refs have no equivalent integrity mechanism; pinning to a commit SHA is the strongest available mitigation.
-   * - DFT-05
-     - Mutable VCS reference enables silent content substitution
-     - DF-05b: Archive download request - HTTP
-     - | **Sev:** 🟡M
-       | **Risk:** 🟠H
-       | **STRIDE:** T S
-       | **Status:** Mitigate
-     - C-005 mitigates archive deps when hash present. Git/SVN: no integrity mechanism; pinning to an immutable commit SHA is recommended but not enforced by dfetch.
-   * - DFT-12
-     - SSRF via unvalidated HTTP redirect chain
-     - DF-05b: Archive download request - HTTP
-     - | **Sev:** 🟠H
-       | **Risk:** 🟠H
-       | **STRIDE:** I
-       | **Status:** Accept
-     - Archive downloads follow up to 10 HTTP redirects without validating the destination against RFC-1918, loopback, or link-local ranges; SSRF to internal metadata endpoints is possible.  Accepted based on the **No HTTPS enforcement** assumption: HTTPS enforcement and safe URL selection are the manifest author's responsibility; the manifest is under code review, and URLs that could expose internal services should be rejected at the review boundary.
-   * - DFT-17
-     - Typosquatting or unverified source identity on an unauthenticated channel
-     - DF-05b: Archive download request - HTTP
-     - | **Sev:** 🟠H
-       | **Risk:** 🟡M
-       | **STRIDE:** S
-       | **Status:** Accept
-     - Manifest author responsibility; the manifest is under code review.  Accepted based on the **Manifest under code review** assumption: ``dfetch.yaml`` is under version control and subject to code review; an adversary who introduces a typosquatted or unverified URL must do so through a manifest change that passes the review boundary.
-   * - DFT-23
-     - Replay or freeze attack delivers stale content to suppress security updates
-     - DF-05b: Archive download request - HTTP
-     - | **Sev:** 🟡M
-       | **Risk:** 🟡M
-       | **STRIDE:** T
-       | **Status:** Accept
-     - No freshness check; ``dfetch check`` detects version drift but does not enforce a minimum version or reject stale content.  Accepted based on the **Mutable VCS references** assumption: branch- and tag-pinned dependencies are mutable references whose content can be changed by upstream force-pushes; stale-content delivery is an acknowledged consequence of using mutable pins without a freshness enforcement mechanism.
-   * - DFT-31
-     - Upstream source publishes no SLSA Source provenance attestation — consumer cannot verify upstream security controls
-     - DF-05b: Archive download request - HTTP
-     - | **Sev:** 🟡M
-       | **Risk:** 🟢L
-       | **STRIDE:** R
-       | **Status:** Accept
-     - Upstream repositories are outside dfetch's control; no mechanism exists to require or verify upstream SLSA source level.  Accepted based on the **dfetch scope boundary** assumption: the security of fetched third-party source code is the responsibility of the manifest author who selects and pins each dependency; verifying upstream governance controls is outside dfetch's own security posture.
-   * - DFT-33
-     - Upstream default-branch history rewritten — ancestry broken, pinned SHA orphaned or made unreachable
-     - DF-05b: Archive download request - HTTP
-     - | **Sev:** 🟡M
-       | **Risk:** 🟢L
-       | **STRIDE:** T
-       | **Status:** Accept
-     - Upstream repositories are outside dfetch's control; dfetch cannot prevent or detect upstream force-pushes.  Accepted based on the **Mutable VCS references** assumption: branch- and tag-pinned Git dependencies are mutable references; upstream force-pushes silently change what is fetched without triggering a manifest diff, and dfetch has no mechanism to verify that a pinned SHA remains reachable after a history rewrite.
-   * - DFT-02
-     - Supply-chain content substitution via server-side compromise
-     - DF-06a: Archive bytes - HTTPS
-     - | **Sev:** 🟠H
-       | **Risk:** 🟠H
-       | **STRIDE:** T S
-       | **Status:** Mitigate
-     - Archives: C-005 mitigates when hash is present. Git/SVN refs have no equivalent integrity mechanism; pinning to a commit SHA is the strongest available mitigation.
-   * - DFT-05
-     - Mutable VCS reference enables silent content substitution
-     - DF-06a: Archive bytes - HTTPS
-     - | **Sev:** 🟡M
-       | **Risk:** 🟠H
-       | **STRIDE:** T S
-       | **Status:** Mitigate
-     - C-005 mitigates archive deps when hash present. Git/SVN: no integrity mechanism; pinning to an immutable commit SHA is recommended but not enforced by dfetch.
-   * - DFT-17
-     - Typosquatting or unverified source identity on an unauthenticated channel
-     - DF-06a: Archive bytes - HTTPS
-     - | **Sev:** 🟠H
-       | **Risk:** 🟡M
-       | **STRIDE:** S
-       | **Status:** Accept
-     - Manifest author responsibility; the manifest is under code review.  Accepted based on the **Manifest under code review** assumption: ``dfetch.yaml`` is under version control and subject to code review; an adversary who introduces a typosquatted or unverified URL must do so through a manifest change that passes the review boundary.
-   * - DFT-23
-     - Replay or freeze attack delivers stale content to suppress security updates
-     - DF-06a: Archive bytes - HTTPS
-     - | **Sev:** 🟡M
-       | **Risk:** 🟡M
-       | **STRIDE:** T
-       | **Status:** Accept
-     - No freshness check; ``dfetch check`` detects version drift but does not enforce a minimum version or reject stale content.  Accepted based on the **Mutable VCS references** assumption: branch- and tag-pinned dependencies are mutable references whose content can be changed by upstream force-pushes; stale-content delivery is an acknowledged consequence of using mutable pins without a freshness enforcement mechanism.
-   * - DFT-31
-     - Upstream source publishes no SLSA Source provenance attestation — consumer cannot verify upstream security controls
-     - DF-06a: Archive bytes - HTTPS
-     - | **Sev:** 🟡M
-       | **Risk:** 🟢L
-       | **STRIDE:** R
-       | **Status:** Accept
-     - Upstream repositories are outside dfetch's control; no mechanism exists to require or verify upstream SLSA source level.  Accepted based on the **dfetch scope boundary** assumption: the security of fetched third-party source code is the responsibility of the manifest author who selects and pins each dependency; verifying upstream governance controls is outside dfetch's own security posture.
-   * - DFT-33
-     - Upstream default-branch history rewritten — ancestry broken, pinned SHA orphaned or made unreachable
-     - DF-06a: Archive bytes - HTTPS
-     - | **Sev:** 🟡M
-       | **Risk:** 🟢L
-       | **STRIDE:** T
-       | **Status:** Accept
-     - Upstream repositories are outside dfetch's control; dfetch cannot prevent or detect upstream force-pushes.  Accepted based on the **Mutable VCS references** assumption: branch- and tag-pinned Git dependencies are mutable references; upstream force-pushes silently change what is fetched without triggering a manifest diff, and dfetch has no mechanism to verify that a pinned SHA remains reachable after a history rewrite.
-   * - DFT-01
-     - Unencrypted transport interception (MITM)
-     - DF-06b: Archive bytes - HTTP (plaintext risk)
-     - | **Sev:** 🟠H
-       | **Risk:** 🔴C
-       | **STRIDE:** T S
-       | **Status:** Mitigate
-     - C-005 mitigates only when ``integrity.hash`` is present; plain HTTP without a hash has no transport or content protection.
-   * - DFT-02
-     - Supply-chain content substitution via server-side compromise
-     - DF-06b: Archive bytes - HTTP (plaintext risk)
-     - | **Sev:** 🟠H
-       | **Risk:** 🟠H
-       | **STRIDE:** T S
-       | **Status:** Mitigate
-     - Archives: C-005 mitigates when hash is present. Git/SVN refs have no equivalent integrity mechanism; pinning to a commit SHA is the strongest available mitigation.
-   * - DFT-05
-     - Mutable VCS reference enables silent content substitution
-     - DF-06b: Archive bytes - HTTP (plaintext risk)
-     - | **Sev:** 🟡M
-       | **Risk:** 🟠H
-       | **STRIDE:** T S
-       | **Status:** Mitigate
-     - C-005 mitigates archive deps when hash present. Git/SVN: no integrity mechanism; pinning to an immutable commit SHA is recommended but not enforced by dfetch.
-   * - DFT-17
-     - Typosquatting or unverified source identity on an unauthenticated channel
-     - DF-06b: Archive bytes - HTTP (plaintext risk)
-     - | **Sev:** 🟠H
-       | **Risk:** 🟡M
-       | **STRIDE:** S
-       | **Status:** Accept
-     - Manifest author responsibility; the manifest is under code review.  Accepted based on the **Manifest under code review** assumption: ``dfetch.yaml`` is under version control and subject to code review; an adversary who introduces a typosquatted or unverified URL must do so through a manifest change that passes the review boundary.
-   * - DFT-23
-     - Replay or freeze attack delivers stale content to suppress security updates
-     - DF-06b: Archive bytes - HTTP (plaintext risk)
-     - | **Sev:** 🟡M
-       | **Risk:** 🟡M
-       | **STRIDE:** T
-       | **Status:** Accept
-     - No freshness check; ``dfetch check`` detects version drift but does not enforce a minimum version or reject stale content.  Accepted based on the **Mutable VCS references** assumption: branch- and tag-pinned dependencies are mutable references whose content can be changed by upstream force-pushes; stale-content delivery is an acknowledged consequence of using mutable pins without a freshness enforcement mechanism.
-   * - DFT-31
-     - Upstream source publishes no SLSA Source provenance attestation — consumer cannot verify upstream security controls
-     - DF-06b: Archive bytes - HTTP (plaintext risk)
-     - | **Sev:** 🟡M
-       | **Risk:** 🟢L
-       | **STRIDE:** R
-       | **Status:** Accept
-     - Upstream repositories are outside dfetch's control; no mechanism exists to require or verify upstream SLSA source level.  Accepted based on the **dfetch scope boundary** assumption: the security of fetched third-party source code is the responsibility of the manifest author who selects and pins each dependency; verifying upstream governance controls is outside dfetch's own security posture.
-   * - DFT-33
-     - Upstream default-branch history rewritten — ancestry broken, pinned SHA orphaned or made unreachable
-     - DF-06b: Archive bytes - HTTP (plaintext risk)
-     - | **Sev:** 🟡M
-       | **Risk:** 🟢L
-       | **STRIDE:** T
-       | **Status:** Accept
-     - Upstream repositories are outside dfetch's control; dfetch cannot prevent or detect upstream force-pushes.  Accepted based on the **Mutable VCS references** assumption: branch- and tag-pinned Git dependencies are mutable references; upstream force-pushes silently change what is fetched without triggering a manifest diff, and dfetch has no mechanism to verify that a pinned SHA remains reachable after a history rewrite.
-   * - DFT-07
-     - CI/CD secret exfiltration via supply-chain attack on build environment
-     - A-24: Archive Extraction (tarfile / zipfile)
-     - | **Sev:** 🟠H
-       | **Risk:** 🟠H
-       | **STRIDE:** I
-       | **Status:** Accept
-     - dfetch uses ``shell=False`` throughout (C-007); residual supply-chain compromise of dfetch itself is the supply-chain model's scope.  Accepted based on the **dfetch scope boundary** assumption: dfetch is responsible only for its own security posture; a compromised dfetch installation is addressed by the supply-chain threat model, not the runtime-usage model.
    * - DFT-14
      - Dangerous file permission bits preserved during archive extraction
      - A-24: Archive Extraction (tarfile / zipfile)
@@ -1510,25 +1006,81 @@ Threats
        | **STRIDE:** T
        | **Status:** Accept
      - dfetch does not strip executable or setuid/setgid bits from extracted archive members; on Python < 3.11.4, TAR extraction preserves such bits.  dfetch supports Python ≥ 3.10 (``requires-python = '>=3.10'`` in ``pyproject.toml``), so this is a live concern for users on Python 3.10.x or Python 3.11.0–3.11.3.  Mitigation: pin dfetch to archives from trusted, reviewed sources only, or run on Python ≥ 3.11.4 where the TAR extraction filter strips these bits.  Accepted based on the **Trusted workstation** assumption: developer workstations are trusted at dfetch invocation time; setuid bits on extracted files in the vendor directory are a local concern within that trusted environment, and a compromised workstation is outside the scope of this model.
+   * - DFT-15
+     - VCS externals / submodules trigger undeclared third-party fetches
+     - A-27: Git Clone (git init / fetch / checkout)
+     - | **Sev:** 🟠H
+       | **Risk:** 🟠H
+       | **STRIDE:** T
+       | **Status:** Accept
+     - Git submodules are followed: ``git submodule update --init --recursive`` is called unconditionally during every Git fetch (``dfetch/vcs/git.py``), and each submodule is recorded as a ``Dependency`` with ``source_type='git-submodule'`` (``gitsubproject.py``).  SVN ``export`` is invoked without ``--ignore-externals``; each ``svn:externals`` entry triggers an additional fetch, and ``SvnSubProject._fetch_externals()`` records it as a ``Dependency`` with ``source_type='svn-external'`` (``svnsubproject.py``).  Both behaviours are intentional — dfetch vendors submodule and external trees and surfaces them in metadata — but the fetched URLs come from the upstream repository (``.gitmodules`` / ``svn:externals``), not from ``dfetch.yaml``, and therefore bypass manifest code review and carry no integrity hash.  Suppressing these fetches (e.g. passing ``--no-recurse-submodules`` or ``--ignore-externals``) would be a design change that removes intentional vendoring behaviour.  Accepted based on the **Manifest under code review** assumption: the choice to vendor an upstream that contains submodules or svn:externals is declared in ``dfetch.yaml`` and subject to code review; the decision to trust those nested URLs is made at the manifest-review boundary.
    * - DFT-16
      - Configured destination path allows writes to security-sensitive project directories
-     - A-24: Archive Extraction (tarfile / zipfile)
+     - A-22: dfetch Process
      - | **Sev:** 🔴VH
        | **Risk:** 🟠H
        | **STRIDE:** T E
        | **Status:** Accept
      - C-001 prevents writes outside the project root; no denylist blocks writes to sensitive within-root paths such as ``.github/workflows/``.  Defense-in-depth: CI pipelines should run ``dfetch update`` in a step that does not have write access to ``.github/workflows/`` (e.g. by restricting permissions or running in a directory sandbox).  Accepted based on the **Manifest under code review** assumption: the ``dst:`` path for every dependency is declared in ``dfetch.yaml`` and subject to code review; any change pointing a destination at a sensitive directory would be rejected at the review boundary.
-   * - DFT-08
-     - Tampered secondary artifact suppresses or bypasses security checks
-     - A-20: Local VCS Cache (temp)
-     - | **Sev:** 🟡M
+   * - DFT-17
+     - Typosquatting or unverified source identity on an unauthenticated channel
+     - DF-06a: Archive bytes - HTTPS
+     - | **Sev:** 🟠H
+       | **Risk:** 🟡M
+       | **STRIDE:** S
+       | **Status:** Accept
+     - Manifest author responsibility; the manifest is under code review.  Accepted based on the **Manifest under code review** assumption: ``dfetch.yaml`` is under version control and subject to code review; an adversary who introduces a typosquatted or unverified URL must do so through a manifest change that passes the review boundary.
+   * - DFT-18
+     - Dependency confusion - public registry package shadows private internal package
+     - A-12: dfetch Manifest
+     - | **Sev:** 🟠H
+       | **Risk:** 🟠H
+       | **STRIDE:** T S
+       | **Status:** Accept
+     - Not applicable to dfetch's fetch-by-explicit-URL model; relevant only if using package-registry shorthand.  Accepted based on the **dfetch scope boundary** assumption: dfetch fetches by explicit URL declared in the manifest rather than by package name resolved against a registry; dependency confusion via registry namespace shadowing cannot occur within dfetch's fetch model.
+   * - DFT-19
+     - Malicious upstream update or intentional maintainer sabotage (protestware)
+     - A-13: Fetched Source Code
+     - | **Sev:** 🔴VH
        | **Risk:** 🟠H
        | **STRIDE:** T
-       | **Status:** Mitigate
-     - Manifest schema (C-008) validates all string fields; patch files carry no integrity hash and are not verified before application.
+       | **Status:** Accept
+     - Upstream maintainer trust; pinning to an immutable commit SHA is the strongest available mitigation but is not enforced by dfetch.  Accepted based on the **dfetch scope boundary** assumption: the security of fetched third-party source code is the responsibility of the manifest author who selects and pins each dependency; intentional maintainer sabotage of an upstream is outside dfetch's control.
+   * - DFT-20
+     - Abandoned package namespace reclaimed by malicious actor
+     - A-12: dfetch Manifest
+     - | **Sev:** 🟠H
+       | **Risk:** 🟡M
+       | **STRIDE:** S T
+       | **Status:** Accept
+     - Not applicable to direct-URL fetches; relevant only if using Git-hosting shorthand with inferred registry lookup.  Accepted based on the **dfetch scope boundary** assumption: dfetch fetches by explicit URL declared in the manifest rather than resolving package names against a registry; abandoned-namespace reclaim attacks require a registry lookup step that does not exist in dfetch's fetch model.
+   * - DFT-21
+     - Unsigned or forged VCS tag accepted as a trusted version pin
+     - DF-04a: VCS content inbound - HTTPS/SSH
+     - | **Sev:** 🟠H
+       | **Risk:** 🟡M
+       | **STRIDE:** S T
+       | **Status:** Accept
+     - dfetch does not verify VCS tag signatures; pinning to an immutable commit SHA is recommended.  Accepted based on the **Mutable VCS references** assumption: branch- and tag-pinned Git dependencies are mutable references; upstream force-pushes can silently change the commit a tag resolves to without triggering a manifest diff, and tag-signature verification is not enforced by dfetch.
+   * - DFT-22
+     - Vendored content contains submodule or nested external reference triggering undeclared fetch
+     - A-13: Fetched Source Code
+     - | **Sev:** 🟡M
+       | **Risk:** 🟡M
+       | **STRIDE:** T
+       | **Status:** Accept
+     - dfetch does not parse or execute embedded build manifests (CMakeLists.txt, package.json, etc.); undeclared fetches via build-system externals cannot occur.  However, Git dependencies with submodules and SVN dependencies with ``svn:externals`` do trigger undeclared fetches — see DFT-15 for details and mitigations.  Accepted based on the **dfetch scope boundary** assumption: the security of fetched third-party source code and any nested dependencies it carries is the responsibility of the manifest author who selects and pins each dependency.
+   * - DFT-23
+     - Replay or freeze attack delivers stale content to suppress security updates
+     - DF-06a: Archive bytes - HTTPS
+     - | **Sev:** 🟡M
+       | **Risk:** 🟡M
+       | **STRIDE:** T
+       | **Status:** Accept
+     - No freshness check; ``dfetch check`` detects version drift but does not enforce a minimum version or reject stale content.  Accepted based on the **Mutable VCS references** assumption: branch- and tag-pinned dependencies are mutable references whose content can be changed by upstream force-pushes; stale-content delivery is an acknowledged consequence of using mutable pins without a freshness enforcement mechanism.
    * - DFT-24
      - Local dependency cache or metadata store poisoned to suppress integrity alerts
-     - A-20: Local VCS Cache (temp)
+     - A-18: Dependency Metadata
      - | **Sev:** 🟠H
        | **Risk:** 🟡M
        | **STRIDE:** T
@@ -1536,12 +1088,20 @@ Threats
      - ``.dfetch_data.yaml`` metadata is not integrity-protected; tampering could suppress update notifications from ``dfetch check``.  Accepted based on the **Trusted workstation** assumption: developer workstations are trusted at dfetch invocation time; local filesystem write access sufficient to tamper with ``.dfetch_data.yaml`` implies a compromised workstation, which is outside the scope of this model.
    * - DFT-25
      - Forged or unverifiable provenance attestation conceals malicious build output
-     - A-20: Local VCS Cache (temp)
+     - A-15: SBOM Output (CycloneDX)
      - | **Sev:** 🟠H
        | **Risk:** 🟠H
        | **STRIDE:** S T R
        | **Status:** Accept
      - dfetch does not verify upstream SLSA provenance of fetched sources; provenance verification is the consumer's responsibility.  Accepted based on the **dfetch scope boundary** assumption: the security of fetched third-party source code is the responsibility of the manifest author who selects and pins each dependency; upstream provenance attestation is outside dfetch's own security posture.
+   * - DFT-26
+     - Protocol or transport downgrade forces connection over insecure channel
+     - A-27: Git Clone (git init / fetch / checkout)
+     - | **Sev:** 🟠H
+       | **Risk:** 🟠H
+       | **STRIDE:** T I
+       | **Status:** Mitigate
+     - C-009 emits a visible warning immediately before the VCS command when a plaintext scheme (``http://``, ``git://``, ``svn://``) is detected, with credentials redacted and ``https://`` / ``svn+ssh://`` recommended.  Detection only — dfetch does not reject or upgrade plaintext URLs; scheme selection remains the manifest author's responsibility.
    * - DFT-28
      - CI/CD build cache poisoned to silently substitute a malicious compiled artifact
      - A-20: Local VCS Cache (temp)
@@ -1550,118 +1110,38 @@ Threats
        | **STRIDE:** T
        | **Status:** Accept
      - Build-cache poisoning (SLSA E6) is a CI/CD supply-chain concern that applies to the dfetch build pipeline, not to runtime usage.  dfetch does not maintain a persistent compiled artifact cache; fetched source files are written directly to the vendor directory.  See the supply-chain threat model for the mitigating control (C-033).  Accepted based on the **dfetch scope boundary** assumption: dfetch is responsible only for its own security posture; the CI/CD build pipeline for dfetch itself is outside the scope of the runtime-usage model.
-   * - DFT-08
-     - Tampered secondary artifact suppresses or bypasses security checks
-     - A-21: Audit / Check Reports
+   * - DFT-30
+     - Weak or deprecated hash algorithm allows collision-based integrity bypass
+     - A-22: dfetch Process
+     - | **Sev:** 🟠H
+       | **Risk:** 🟠H
+       | **STRIDE:** T S
+       | **Status:** Mitigate
+     - C-005, C-034
+   * - DFT-31
+     - Upstream source publishes no SLSA Source provenance attestation — consumer cannot verify upstream security controls
+     - DF-04a: VCS content inbound - HTTPS/SSH
      - | **Sev:** 🟡M
-       | **Risk:** 🟠H
-       | **STRIDE:** T
-       | **Status:** Mitigate
-     - Manifest schema (C-008) validates all string fields; patch files carry no integrity hash and are not verified before application.
-   * - DFT-24
-     - Local dependency cache or metadata store poisoned to suppress integrity alerts
-     - A-21: Audit / Check Reports
-     - | **Sev:** 🟠H
-       | **Risk:** 🟡M
-       | **STRIDE:** T
+       | **Risk:** 🟢L
+       | **STRIDE:** R
        | **Status:** Accept
-     - ``.dfetch_data.yaml`` metadata is not integrity-protected; tampering could suppress update notifications from ``dfetch check``.  Accepted based on the **Trusted workstation** assumption: developer workstations are trusted at dfetch invocation time; local filesystem write access sufficient to tamper with ``.dfetch_data.yaml`` implies a compromised workstation, which is outside the scope of this model.
-   * - DFT-25
-     - Forged or unverifiable provenance attestation conceals malicious build output
-     - A-21: Audit / Check Reports
-     - | **Sev:** 🟠H
-       | **Risk:** 🟠H
-       | **STRIDE:** S T R
-       | **Status:** Accept
-     - dfetch does not verify upstream SLSA provenance of fetched sources; provenance verification is the consumer's responsibility.  Accepted based on the **dfetch scope boundary** assumption: the security of fetched third-party source code is the responsibility of the manifest author who selects and pins each dependency; upstream provenance attestation is outside dfetch's own security posture.
-   * - DFT-28
-     - CI/CD build cache poisoned to silently substitute a malicious compiled artifact
-     - A-21: Audit / Check Reports
-     - | **Sev:** 🟠H
-       | **Risk:** 🟠H
-       | **STRIDE:** T
-       | **Status:** Accept
-     - Build-cache poisoning (SLSA E6) is a CI/CD supply-chain concern that applies to the dfetch build pipeline, not to runtime usage.  dfetch does not maintain a persistent compiled artifact cache; fetched source files are written directly to the vendor directory.  See the supply-chain threat model for the mitigating control (C-033).  Accepted based on the **dfetch scope boundary** assumption: dfetch is responsible only for its own security posture; the CI/CD build pipeline for dfetch itself is outside the scope of the runtime-usage model.
-   * - DFT-03
-     - Path traversal in archive or patch extraction
-     - A-27: Git Clone (git init / fetch / checkout)
-     - | **Sev:** 🔴VH
-       | **Risk:** 🟠H
-       | **STRIDE:** T E
-       | **Status:** Mitigate
-     - Archive and VCS extraction mitigated by C-001, C-003, C-004. Patch files carry no integrity hash and are not independently verified.
-   * - DFT-07
-     - CI/CD secret exfiltration via supply-chain attack on build environment
-     - A-27: Git Clone (git init / fetch / checkout)
-     - | **Sev:** 🟠H
-       | **Risk:** 🟠H
-       | **STRIDE:** I
-       | **Status:** Accept
-     - dfetch uses ``shell=False`` throughout (C-007); residual supply-chain compromise of dfetch itself is the supply-chain model's scope.  Accepted based on the **dfetch scope boundary** assumption: dfetch is responsible only for its own security posture; a compromised dfetch installation is addressed by the supply-chain threat model, not the runtime-usage model.
-   * - DFT-09
-     - Archive decompression bomb causes resource exhaustion
-     - A-27: Git Clone (git init / fetch / checkout)
+     - Upstream repositories are outside dfetch's control; no mechanism exists to require or verify upstream SLSA source level.  Accepted based on the **dfetch scope boundary** assumption: the security of fetched third-party source code is the responsibility of the manifest author who selects and pins each dependency; verifying upstream governance controls is outside dfetch's own security posture.
+   * - DFT-32
+     - Upstream source enforces no mandatory two-party review — single contributor can introduce changes without independent verification
+     - A-13: Fetched Source Code
      - | **Sev:** 🟡M
-       | **Risk:** 🟡M
-       | **STRIDE:** D
-       | **Status:** Mitigate
-     - C-002
-   * - DFT-15
-     - VCS externals / submodules trigger undeclared third-party fetches
-     - A-27: Git Clone (git init / fetch / checkout)
-     - | **Sev:** 🟠H
-       | **Risk:** 🟠H
+       | **Risk:** 🟢L
        | **STRIDE:** T
        | **Status:** Accept
-     - Git submodules are followed: ``git submodule update --init --recursive`` is called unconditionally during every Git fetch (``dfetch/vcs/git.py``), and each submodule is recorded as a ``Dependency`` with ``source_type='git-submodule'`` (``gitsubproject.py``).  SVN ``export`` is invoked without ``--ignore-externals``; each ``svn:externals`` entry triggers an additional fetch, and ``SvnSubProject._fetch_externals()`` records it as a ``Dependency`` with ``source_type='svn-external'`` (``svnsubproject.py``).  Both behaviours are intentional — dfetch vendors submodule and external trees and surfaces them in metadata — but the fetched URLs come from the upstream repository (``.gitmodules`` / ``svn:externals``), not from ``dfetch.yaml``, and therefore bypass manifest code review and carry no integrity hash.  Suppressing these fetches (e.g. passing ``--no-recurse-submodules`` or ``--ignore-externals``) would be a design change that removes intentional vendoring behaviour.  Accepted based on the **Manifest under code review** assumption: the choice to vendor an upstream that contains submodules or svn:externals is declared in ``dfetch.yaml`` and subject to code review; the decision to trust those nested URLs is made at the manifest-review boundary.
-   * - DFT-26
-     - Protocol or transport downgrade forces connection over insecure channel
-     - A-27: Git Clone (git init / fetch / checkout)
-     - | **Sev:** 🟠H
-       | **Risk:** 🟠H
-       | **STRIDE:** T I
-       | **Status:** Accept
-     - dfetch accepts ``http://``, ``svn://``, and other non-TLS scheme URLs; HTTPS enforcement is the manifest author's responsibility.  Accepted based on the **No HTTPS enforcement** assumption: HTTPS enforcement is the responsibility of the manifest author; dfetch accepts non-TLS scheme URLs as written and does not upgrade or reject them.
-   * - DFT-03
-     - Path traversal in archive or patch extraction
-     - A-26: SVN Export (svn export)
-     - | **Sev:** 🔴VH
-       | **Risk:** 🟠H
-       | **STRIDE:** T E
-       | **Status:** Mitigate
-     - Archive and VCS extraction mitigated by C-001, C-003, C-004. Patch files carry no integrity hash and are not independently verified.
-   * - DFT-07
-     - CI/CD secret exfiltration via supply-chain attack on build environment
-     - A-26: SVN Export (svn export)
-     - | **Sev:** 🟠H
-       | **Risk:** 🟠H
-       | **STRIDE:** I
-       | **Status:** Accept
-     - dfetch uses ``shell=False`` throughout (C-007); residual supply-chain compromise of dfetch itself is the supply-chain model's scope.  Accepted based on the **dfetch scope boundary** assumption: dfetch is responsible only for its own security posture; a compromised dfetch installation is addressed by the supply-chain threat model, not the runtime-usage model.
-   * - DFT-09
-     - Archive decompression bomb causes resource exhaustion
-     - A-26: SVN Export (svn export)
+     - Upstream repositories are outside dfetch's control; no mechanism exists to require mandatory two-party review on upstream changes.  Accepted based on the **dfetch scope boundary** assumption: the security of fetched third-party source code is the responsibility of the manifest author who selects and pins each dependency; requiring upstream review policies is outside dfetch's own security posture.
+   * - DFT-33
+     - Upstream default-branch history rewritten — ancestry broken, pinned SHA orphaned or made unreachable
+     - DF-04a: VCS content inbound - HTTPS/SSH
      - | **Sev:** 🟡M
-       | **Risk:** 🟡M
-       | **STRIDE:** D
-       | **Status:** Mitigate
-     - C-002
-   * - DFT-15
-     - VCS externals / submodules trigger undeclared third-party fetches
-     - A-26: SVN Export (svn export)
-     - | **Sev:** 🟠H
-       | **Risk:** 🟠H
+       | **Risk:** 🟢L
        | **STRIDE:** T
        | **Status:** Accept
-     - Git submodules are followed: ``git submodule update --init --recursive`` is called unconditionally during every Git fetch (``dfetch/vcs/git.py``), and each submodule is recorded as a ``Dependency`` with ``source_type='git-submodule'`` (``gitsubproject.py``).  SVN ``export`` is invoked without ``--ignore-externals``; each ``svn:externals`` entry triggers an additional fetch, and ``SvnSubProject._fetch_externals()`` records it as a ``Dependency`` with ``source_type='svn-external'`` (``svnsubproject.py``).  Both behaviours are intentional — dfetch vendors submodule and external trees and surfaces them in metadata — but the fetched URLs come from the upstream repository (``.gitmodules`` / ``svn:externals``), not from ``dfetch.yaml``, and therefore bypass manifest code review and carry no integrity hash.  Suppressing these fetches (e.g. passing ``--no-recurse-submodules`` or ``--ignore-externals``) would be a design change that removes intentional vendoring behaviour.  Accepted based on the **Manifest under code review** assumption: the choice to vendor an upstream that contains submodules or svn:externals is declared in ``dfetch.yaml`` and subject to code review; the decision to trust those nested URLs is made at the manifest-review boundary.
-   * - DFT-26
-     - Protocol or transport downgrade forces connection over insecure channel
-     - A-26: SVN Export (svn export)
-     - | **Sev:** 🟠H
-       | **Risk:** 🟠H
-       | **STRIDE:** T I
-       | **Status:** Accept
-     - dfetch accepts ``http://``, ``svn://``, and other non-TLS scheme URLs; HTTPS enforcement is the manifest author's responsibility.  Accepted based on the **No HTTPS enforcement** assumption: HTTPS enforcement is the responsibility of the manifest author; dfetch accepts non-TLS scheme URLs as written and does not upgrade or reject them.
+     - Upstream repositories are outside dfetch's control; dfetch cannot prevent or detect upstream force-pushes.  Accepted based on the **Mutable VCS references** assumption: branch- and tag-pinned Git dependencies are mutable references; upstream force-pushes silently change what is fetched without triggering a manifest diff, and dfetch has no mechanism to verify that a pinned SHA remains reachable after a history rewrite.
 
 
 Controls
@@ -1708,6 +1188,10 @@ Controls
      - Manifest input validation
      - DFT-04, DFT-08
      - StrictYAML schema with ``SAFE_STR = Regex(r"^[^\x00-\x1F\x7F-\x9F]*$")`` rejects control characters in all string fields.  ``dfetch/manifest/schema.py``
+   * - C-009
+     - Plaintext transport detection
+     - DFT-26
+     - ``plaintext_warning()`` (``dfetch/manifest/project.py``) inspects the resolved remote URL immediately before each VCS command is issued (inside the ``check_for_update`` and ``update`` spinners in ``subproject.py``).  If the scheme is ``http://``, ``git://``, or ``svn://``, a visible warning is emitted naming the redacted URL (credentials stripped from the userinfo component) and recommending ``https://`` or ``svn+ssh://``.  Detection only — dfetch still proceeds with the plaintext connection; the control raises user awareness but does not enforce scheme selection.  ``dfetch/manifest/project.py, dfetch/project/subproject.py``
    * - C-034
      - Hash algorithm allowlist (SHA-256/384/512 only)
      - DFT-30

--- a/security/tm_elements.py
+++ b/security/tm_elements.py
@@ -16,13 +16,21 @@ THREATS_FILE = os.path.join(os.path.dirname(__file__), "threats.json")
 
 @dataclass
 class ThreatResponse:
-    """Per-threat handling decision: how this model responds to a specific threat."""
+    """Per-threat handling decision: how this model responds to a specific threat.
+
+    ``target`` names the single canonical element or dataflow the threat is
+    documented against.  pytm matches a threat to every element its condition
+    satisfies, so a threat that applies to many elements yields many identical
+    findings; the rendered report collapses these to one row and shows this
+    target.  Leave empty for threats that match a single element.
+    """
 
     threat_id: str
     status: Literal["avoid", "mitigate", "accept", "transfer"]
     risk: Literal["Critical", "High", "Medium", "Low"] = "Medium"
     stride: list[str] = field(default_factory=list)
     note: str = ""
+    target: str = ""
 
 
 @dataclass

--- a/security/tm_render.py
+++ b/security/tm_render.py
@@ -123,12 +123,22 @@ def _render_asset_rows(
 def _render_threat_rows(
     tm: Any, controls: list[Control], responses: list[ThreatResponse]
 ) -> str:
-    """Return RST list-table rows for all active findings."""
+    """Return RST list-table rows, one curated row per threat, sorted by ID.
+
+    pytm emits a finding for every element a threat's condition matches, so a
+    threat that applies to many elements produces many byte-identical rows.
+    Collapse them to a single row documented against the threat's canonical
+    target (``ThreatResponse.target`` when set, otherwise the matched element).
+    """
     findings = tm.findings
     if not findings:
         return ""
 
     resp_map: dict[str, ThreatResponse] = {r.threat_id: r for r in responses}
+
+    representative: dict[str, Any] = {}
+    for f in findings:
+        representative.setdefault(f.threat_id, f)
 
     def _row(f: Any) -> str:
         resp = resp_map.get(f.threat_id)
@@ -150,10 +160,11 @@ def _render_threat_rows(
             detail = resp.note if resp.note else ctrl_ids
         else:
             detail = resp.note if resp and resp.note else "—"
+        target = resp.target if resp and resp.target else str(f.target)
         return (
             f"   * - {f.threat_id}\n"
             f"     - {f.description}\n"
-            f"     - {f.target}\n"
+            f"     - {target}\n"
             f"     - | **Sev:** {sev}\n"
             f"       | **Risk:** {risk}\n"
             f"       | **STRIDE:** {stride}\n"
@@ -161,7 +172,7 @@ def _render_threat_rows(
             f"     - {detail}\n"
         )
 
-    return "".join(_row(f) for f in findings)
+    return "".join(_row(representative[tid]) for tid in sorted(representative))
 
 
 def _render_control_rows(controls: list[Control]) -> str:

--- a/security/tm_supply_chain.py
+++ b/security/tm_supply_chain.py
@@ -870,15 +870,26 @@ ASSET_CONTROLS: dict[str, list[Control]] = build_asset_controls_index(
 )
 
 RESPONSES: list[ThreatResponse] = [
-    ThreatResponse("DFT-02", "mitigate", risk="High", stride=["Tampering", "Spoofing"]),
+    ThreatResponse(
+        "DFT-02",
+        "mitigate",
+        risk="High",
+        stride=["Tampering", "Spoofing"],
+        target="A-03: PyPI / TestPyPI",
+    ),
     ThreatResponse(
         "DFT-03",
         "mitigate",
         risk="Medium",
         stride=["Tampering", "Elevation of Privilege"],
+        target="A-08: Python Build (wheel / sdist)",
     ),
     ThreatResponse(
-        "DFT-05", "mitigate", risk="Medium", stride=["Tampering", "Spoofing"]
+        "DFT-05",
+        "mitigate",
+        risk="Medium",
+        stride=["Tampering", "Spoofing"],
+        target="DF-16: CI fetches build/dev deps from PyPI",
     ),
     ThreatResponse(
         "DFT-06",
@@ -900,6 +911,7 @@ RESPONSES: list[ThreatResponse] = [
             "Information Disclosure",
             "Elevation of Privilege",
         ],
+        target="A-08: Python Build (wheel / sdist)",
     ),
     ThreatResponse(
         "DFT-08",
@@ -926,6 +938,7 @@ RESPONSES: list[ThreatResponse] = [
             "run on ephemeral, isolated runners; any denial-of-service impact from a "
             "decompression bomb is bounded to the affected job and does not persist beyond it."
         ),
+        target="A-08: Python Build (wheel / sdist)",
     ),
     ThreatResponse(
         "DFT-10",
@@ -947,7 +960,13 @@ RESPONSES: list[ThreatResponse] = [
             "a compromised maintainer account is outside the scope of this model."
         ),
     ),
-    ThreatResponse("DFT-17", "mitigate", risk="Medium", stride=["Spoofing"]),
+    ThreatResponse(
+        "DFT-17",
+        "mitigate",
+        risk="Medium",
+        stride=["Spoofing"],
+        target="A-03: PyPI / TestPyPI",
+    ),
     ThreatResponse(
         "DFT-18",
         "accept",
@@ -986,6 +1005,7 @@ RESPONSES: list[ThreatResponse] = [
             "for registry dependencies is a registry-level concern outside the scope of this "
             "model."
         ),
+        target="DF-16: CI fetches build/dev deps from PyPI",
     ),
     ThreatResponse(
         "DFT-24",
@@ -1006,18 +1026,35 @@ RESPONSES: list[ThreatResponse] = [
         risk="High",
         stride=["Spoofing", "Tampering", "Repudiation"],
     ),
-    ThreatResponse("DFT-27", "mitigate", risk="High", stride=["Tampering", "Spoofing"]),
+    ThreatResponse(
+        "DFT-27",
+        "mitigate",
+        risk="High",
+        stride=["Tampering", "Spoofing"],
+        target="A-04: Release Gate / Code Review",
+    ),
     ThreatResponse("DFT-28", "mitigate", risk="High", stride=["Tampering"]),
     ThreatResponse(
         "DFT-29",
         "mitigate",
         risk="High",
         stride=["Information Disclosure", "Tampering"],
+        target="A-08: Python Build (wheel / sdist)",
     ),
     ThreatResponse(
-        "DFT-31", "mitigate", risk="Low", stride=["Repudiation", "Spoofing"]
+        "DFT-31",
+        "mitigate",
+        risk="Low",
+        stride=["Repudiation", "Spoofing"],
+        target="DF-26: Consumer downloads dfetch from PyPI",
     ),
-    ThreatResponse("DFT-33", "mitigate", risk="Low", stride=["Tampering"]),
+    ThreatResponse(
+        "DFT-33",
+        "mitigate",
+        risk="Low",
+        stride=["Tampering"],
+        target="DF-26: Consumer downloads dfetch from PyPI",
+    ),
 ]
 
 if __name__ == "__main__":

--- a/security/tm_usage.py
+++ b/security/tm_usage.py
@@ -1003,6 +1003,7 @@ RESPONSES: list[ThreatResponse] = [
             "C-005 mitigates only when ``integrity.hash`` is present; "
             "plain HTTP without a hash has no transport or content protection."
         ),
+        target="DF-06b: Archive bytes - HTTP (plaintext risk)",
     ),
     ThreatResponse(
         "DFT-02",
@@ -1014,6 +1015,7 @@ RESPONSES: list[ThreatResponse] = [
             "Git/SVN refs have no equivalent integrity mechanism; "
             "pinning to a commit SHA is the strongest available mitigation."
         ),
+        target="DF-04a: VCS content inbound - HTTPS/SSH",
     ),
     ThreatResponse(
         "DFT-03",
@@ -1024,6 +1026,7 @@ RESPONSES: list[ThreatResponse] = [
             "Archive and VCS extraction mitigated by C-001, C-003, C-004. "
             "Patch files carry no integrity hash and are not independently verified."
         ),
+        target="A-25: Patch Application (patch-ng)",
     ),
     ThreatResponse("DFT-04", "mitigate", risk="High", stride=["Tampering"]),
     ThreatResponse(
@@ -1036,6 +1039,7 @@ RESPONSES: list[ThreatResponse] = [
             "Git/SVN: no integrity mechanism; pinning to an immutable commit SHA "
             "is recommended but not enforced by dfetch."
         ),
+        target="DF-04a: VCS content inbound - HTTPS/SSH",
     ),
     ThreatResponse(
         "DFT-06",
@@ -1060,6 +1064,7 @@ RESPONSES: list[ThreatResponse] = [
             "only for its own security posture; a compromised dfetch installation is addressed "
             "by the supply-chain threat model, not the runtime-usage model."
         ),
+        target="A-25: Patch Application (patch-ng)",
     ),
     ThreatResponse(
         "DFT-08",
@@ -1070,8 +1075,15 @@ RESPONSES: list[ThreatResponse] = [
             "Manifest schema (C-008) validates all string fields; "
             "patch files carry no integrity hash and are not verified before application."
         ),
+        target="A-18: Dependency Metadata",
     ),
-    ThreatResponse("DFT-09", "mitigate", risk="Medium", stride=["Denial of Service"]),
+    ThreatResponse(
+        "DFT-09",
+        "mitigate",
+        risk="Medium",
+        stride=["Denial of Service"],
+        target="A-24: Archive Extraction (tarfile / zipfile)",
+    ),
     ThreatResponse(
         "DFT-10",
         "accept",
@@ -1085,6 +1097,7 @@ RESPONSES: list[ThreatResponse] = [
             "dependencies is out of scope for this usage model and is addressed by the "
             "supply-chain threat model."
         ),
+        target="A-22: dfetch Process",
     ),
     ThreatResponse(
         "DFT-12",
@@ -1100,6 +1113,7 @@ RESPONSES: list[ThreatResponse] = [
             "is under code review, and URLs that could expose internal services should be "
             "rejected at the review boundary."
         ),
+        target="DF-05a: Archive download request - HTTPS",
     ),
     ThreatResponse(
         "DFT-13",
@@ -1160,6 +1174,7 @@ RESPONSES: list[ThreatResponse] = [
             "``dfetch.yaml`` and subject to code review; the decision to trust those "
             "nested URLs is made at the manifest-review boundary."
         ),
+        target="A-27: Git Clone (git init / fetch / checkout)",
     ),
     ThreatResponse(
         "DFT-16",
@@ -1178,6 +1193,7 @@ RESPONSES: list[ThreatResponse] = [
             "review; any change pointing a destination at a sensitive directory would be "
             "rejected at the review boundary."
         ),
+        target="A-22: dfetch Process",
     ),
     ThreatResponse(
         "DFT-17",
@@ -1191,6 +1207,7 @@ RESPONSES: list[ThreatResponse] = [
             "an adversary who introduces a typosquatted or unverified URL must do so "
             "through a manifest change that passes the review boundary."
         ),
+        target="DF-06a: Archive bytes - HTTPS",
     ),
     ThreatResponse(
         "DFT-18",
@@ -1205,6 +1222,7 @@ RESPONSES: list[ThreatResponse] = [
             "against a registry; dependency confusion via registry namespace shadowing "
             "cannot occur within dfetch's fetch model."
         ),
+        target="A-12: dfetch Manifest",
     ),
     ThreatResponse(
         "DFT-19",
@@ -1233,6 +1251,7 @@ RESPONSES: list[ThreatResponse] = [
             "against a registry; abandoned-namespace reclaim attacks require a registry "
             "lookup step that does not exist in dfetch's fetch model."
         ),
+        target="A-12: dfetch Manifest",
     ),
     ThreatResponse(
         "DFT-21",
@@ -1278,6 +1297,7 @@ RESPONSES: list[ThreatResponse] = [
             "by upstream force-pushes; stale-content delivery is an acknowledged "
             "consequence of using mutable pins without a freshness enforcement mechanism."
         ),
+        target="DF-06a: Archive bytes - HTTPS",
     ),
     ThreatResponse(
         "DFT-24",
@@ -1292,6 +1312,7 @@ RESPONSES: list[ThreatResponse] = [
             "write access sufficient to tamper with ``.dfetch_data.yaml`` implies "
             "a compromised workstation, which is outside the scope of this model."
         ),
+        target="A-18: Dependency Metadata",
     ),
     ThreatResponse(
         "DFT-25",
@@ -1306,6 +1327,7 @@ RESPONSES: list[ThreatResponse] = [
             "author who selects and pins each dependency; upstream provenance attestation "
             "is outside dfetch's own security posture."
         ),
+        target="A-15: SBOM Output (CycloneDX)",
     ),
     ThreatResponse(
         "DFT-26",
@@ -1319,6 +1341,7 @@ RESPONSES: list[ThreatResponse] = [
             "Detection only — dfetch does not reject or upgrade plaintext URLs; "
             "scheme selection remains the manifest author's responsibility."
         ),
+        target="A-27: Git Clone (git init / fetch / checkout)",
     ),
     ThreatResponse(
         "DFT-28",
@@ -1335,6 +1358,7 @@ RESPONSES: list[ThreatResponse] = [
             "responsible only for its own security posture; the CI/CD build pipeline "
             "for dfetch itself is outside the scope of the runtime-usage model."
         ),
+        target="A-20: Local VCS Cache (temp)",
     ),
     ThreatResponse("DFT-30", "mitigate", risk="High", stride=["Tampering", "Spoofing"]),
     ThreatResponse(
@@ -1350,6 +1374,7 @@ RESPONSES: list[ThreatResponse] = [
             "author who selects and pins each dependency; verifying upstream governance "
             "controls is outside dfetch's own security posture."
         ),
+        target="DF-04a: VCS content inbound - HTTPS/SSH",
     ),
     ThreatResponse(
         "DFT-32",
@@ -1379,6 +1404,7 @@ RESPONSES: list[ThreatResponse] = [
             "dfetch has no mechanism to verify that a pinned SHA remains reachable after "
             "a history rewrite."
         ),
+        target="DF-04a: VCS content inbound - HTTPS/SSH",
     ),
 ]
 


### PR DESCRIPTION
pytm emits a finding for every element a threat's condition matches,
so the rendered threat tables repeated each threat verbatim against many
targets (e.g. the transport threats appeared 7x across fetch dataflows)
and surfaced artifact attributions such as path traversal against the
code-review gate. Add a canonical target to ThreatResponse, dedupe
findings to one row per threat in the renderer, and set sensible targets
in both generators. CIA ratings still derive from the full pytm matches.

https://claude.ai/code/session_013SHhxxFjotxQkSj2uC7QLr