### PR TITLE
fix(rtfd): install LaTeX toolchain via apt_packages for PDF generation

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,6 +17,12 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.13"
+  apt_packages:
+    - texlive-latex-recommended
+    - texlive-fonts-recommended
+    - texlive-latex-extra
+    - texlive-xetex
+    - latexmk
 
 # Optionally set the version of Python and requirements required to build your docs
 python:


### PR DESCRIPTION
RTFD's Ubuntu 22.04 build image no longer pre-installs the LaTeX
packages needed to compile XeLaTeX output.  Add an apt_packages section
mirroring the packages already installed by the GitHub Actions pdf job
(docs.yml), so that xelatex and latexmk are available when RTFD runs
the latex builder and compiles the PDF.

https://claude.ai/code/session_01XgdzuNbeqTqWBDXXKrYcoY