### PR TITLE
Fix SSH shorthand URLs joined with '/' instead of ':' (#1247)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Release 0.14.0 (unreleased)
 * Prevent SSH command injection (#1152)
 * Allow manifests with no ``projects`` key so ``dfetch add`` can bootstrap empty manifest (#1197)
 * Fix ``ValueError`` when generating a PackageURL (e.g. for an SBOM) from an empty or path-only remote URL
+* Fix SSH shorthand URLs (``git@host:path``) being incorrectly joined with ``/`` when used as ``url-base`` with ``repo-path`` (#1247)
 
 Release 0.13.0 (released 2026-03-30)
 ====================================

--- a/dfetch/manifest/project.py
+++ b/dfetch/manifest/project.py
@@ -355,8 +355,8 @@ def plaintext_warning(url: str) -> str:
 
 
 def _is_ssh_shorthand(url: str) -> bool:
-    """Return True if *url* is an SSH SCP-style shorthand (``git@host``, no scheme)."""
-    return "@" in url and "://" not in url
+    """Return True if *url* is an SSH SCP-style host-only shorthand (``git@host``, no scheme, no path separator)."""
+    return "@" in url and "://" not in url and ":" not in url
 
 
 @dataclass

--- a/dfetch/manifest/project.py
+++ b/dfetch/manifest/project.py
@@ -493,6 +493,8 @@ class ProjectEntry:  # pylint: disable=too-many-instance-attributes
             return self._url
         if self._remote_obj:
             base = self._remote_obj.url.strip("/")
+            if not self._repo_path:
+                return base
             separator = ":" if _is_ssh_shorthand(base) else "/"
             return (base + separator + self._repo_path).strip("/")
         return ""

--- a/dfetch/manifest/project.py
+++ b/dfetch/manifest/project.py
@@ -354,6 +354,11 @@ def plaintext_warning(url: str) -> str:
     )
 
 
+def _is_ssh_shorthand(url: str) -> bool:
+    """Return True if *url* is an SSH SCP-style shorthand (``git@host``, no scheme)."""
+    return "@" in url and "://" not in url
+
+
 @dataclass
 class Integrity:
     """Integrity verification data for an archive dependency.
@@ -461,7 +466,7 @@ class ProjectEntry:  # pylint: disable=too-many-instance-attributes
         self._remote_obj = remote
         self._remote = remote.name
         if self._url.startswith(remote.url):
-            self._repo_path = self._url.replace(remote.url, "").strip("/")
+            self._repo_path = self._url[len(remote.url) :].lstrip("/:")
             self._url = ""
 
     @property
@@ -487,8 +492,9 @@ class ProjectEntry:  # pylint: disable=too-many-instance-attributes
         if self._url:
             return self._url
         if self._remote_obj:
-            urls = [self._remote_obj.url.strip("/"), self._repo_path]
-            return "/".join(urls).strip("/")
+            base = self._remote_obj.url.strip("/")
+            separator = ":" if _is_ssh_shorthand(base) else "/"
+            return (base + separator + self._repo_path).strip("/")
         return ""
 
     @property

--- a/tests/test_project_entry.py
+++ b/tests/test_project_entry.py
@@ -6,6 +6,7 @@
 import pytest
 
 from dfetch.manifest.project import ProjectEntry
+from dfetch.manifest.remote import Remote
 
 
 def test_projectentry_name():
@@ -49,3 +50,27 @@ def test_projectentry_as_str():
         str(ProjectEntry({"name": "SomeProject"}))
         == "SomeProject          latest  SomeProject"
     )
+
+
+def test_remote_url_ssh_shorthand_uses_colon_separator():
+    entry = ProjectEntry({"name": "myrepo", "repo-path": "myorg/myrepo.git"})
+    entry.set_remote(Remote({"name": "corp", "url-base": "git@git.mycompany.com"}))
+    assert entry.remote_url == "git@git.mycompany.com:myorg/myrepo.git"
+
+
+def test_remote_url_https_base_uses_slash_separator():
+    entry = ProjectEntry({"name": "myrepo", "repo-path": "myorg/myrepo"})
+    entry.set_remote(Remote({"name": "corp", "url-base": "https://github.com"}))
+    assert entry.remote_url == "https://github.com/myorg/myrepo"
+
+
+def test_set_remote_strips_colon_prefix_from_ssh_url():
+    entry = ProjectEntry({"name": "myrepo", "url": "git@git.mycompany.com:my-repo.git"})
+    entry.set_remote(Remote({"name": "corp", "url-base": "git@git.mycompany.com"}))
+    assert entry.remote_url == "git@git.mycompany.com:my-repo.git"
+
+
+def test_set_remote_strips_slash_prefix_from_https_url():
+    entry = ProjectEntry({"name": "myrepo", "url": "https://github.com/org/repo"})
+    entry.set_remote(Remote({"name": "gh", "url-base": "https://github.com"}))
+    assert entry.remote_url == "https://github.com/org/repo"

--- a/tests/test_project_entry.py
+++ b/tests/test_project_entry.py
@@ -86,3 +86,9 @@ def test_remote_url_with_empty_repo_path():
     entry = ProjectEntry({"name": "myrepo"})
     entry.set_remote(Remote({"name": "corp", "url-base": "git@git.mycompany.com"}))
     assert entry.remote_url == "git@git.mycompany.com"
+
+
+def test_remote_url_ssh_base_with_path_prefix_uses_slash_separator():
+    entry = ProjectEntry({"name": "myrepo", "repo-path": "repo.git"})
+    entry.set_remote(Remote({"name": "corp", "url-base": "git@host:org"}))
+    assert entry.remote_url == "git@host:org/repo.git"

--- a/tests/test_project_entry.py
+++ b/tests/test_project_entry.py
@@ -74,3 +74,15 @@ def test_set_remote_strips_slash_prefix_from_https_url():
     entry = ProjectEntry({"name": "myrepo", "url": "https://github.com/org/repo"})
     entry.set_remote(Remote({"name": "gh", "url-base": "https://github.com"}))
     assert entry.remote_url == "https://github.com/org/repo"
+
+
+def test_remote_url_with_trailing_slash_in_base():
+    entry = ProjectEntry({"name": "myrepo", "repo-path": "myorg/myrepo"})
+    entry.set_remote(Remote({"name": "corp", "url-base": "https://github.com/"}))
+    assert entry.remote_url == "https://github.com/myorg/myrepo"
+
+
+def test_remote_url_with_empty_repo_path():
+    entry = ProjectEntry({"name": "myrepo"})
+    entry.set_remote(Remote({"name": "corp", "url-base": "git@git.mycompany.com"}))
+    assert entry.remote_url == "git@git.mycompany.com"


### PR DESCRIPTION
When `url-base` is an SSH SCP-style shorthand like `git@git.mycompany.com`,
dfetch was joining it with `repo-path` using '/' (producing the invalid
`git@git.mycompany.com/my-repo.git`) instead of ':' (the correct
`git@git.mycompany.com:my-repo.git`).

Add `_is_ssh_shorthand` helper to detect these URLs (has '@', no '://'),
use ':' as separator in `remote_url`, and fix `set_remote` to strip both
'/' and ':' separators when decomposing a full SSH URL against a remote base.

https://claude.ai/code/session_01MhZACpoBQKKtSFVwjZcuo7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SSH shorthand URLs (e.g., git@host:path) being joined with "/" when combining URL base and repository path, ensuring correct separator and normalization.
* **Tests**
  * Added unit tests covering remote URL construction and normalization for SSH vs HTTPS bases and related edge cases.
* **Documentation**
  * Updated changelog entry for the unreleased 0.14.0 release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->