### PR TITLE
Redact embedded credentials before persisting remote_url (DFT-13)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Release 0.14.0 (unreleased)
 ===========================
 
+* Strip ``user:password@`` userinfo from ``remote_url`` before writing it to ``.dfetch_data.yaml``, so a manifest URL with an embedded credential no longer leaks the credential into the committed metadata file (DFT-13)
 * Warn when a project URL uses a plaintext transport scheme (#1229)
 * Documentation and threat-model clarifications for existing release attestation support (#1208)
 * Report SVN externals fetched during update (#1220)

--- a/dfetch/project/metadata.py
+++ b/dfetch/project/metadata.py
@@ -2,6 +2,7 @@
 
 import datetime
 import os
+from urllib.parse import urlsplit, urlunsplit
 
 import yaml
 from typing_extensions import TypedDict
@@ -9,6 +10,26 @@ from typing_extensions import TypedDict
 from dfetch.manifest.project import ProjectEntry
 from dfetch.manifest.version import Version
 from dfetch.util.util import always_str_list, str_if_possible
+
+
+def _strip_userinfo(url: str) -> str:
+    """Return *url* with any ``user:password@`` userinfo removed from the netloc.
+
+    Credentials embedded in remote URLs would otherwise be persisted verbatim
+    to ``.dfetch_data.yaml`` (mitigates DFT-13).
+    """
+    parsed = urlsplit(url)
+    try:
+        port = parsed.port
+    except ValueError:
+        port = None
+    host = parsed.hostname or ""
+    if not host and not parsed.netloc:
+        return url
+    netloc = f"{host}:{port}" if isinstance(port, int) else host
+    return urlunsplit(
+        (parsed.scheme, netloc, parsed.path, parsed.query, parsed.fragment)
+    )
 
 DONT_EDIT_WARNING = """\
 # This is a generated file by dfetch. Don't edit this, but edit the manifest.
@@ -199,7 +220,7 @@ class Metadata:
         """Dump metadata file to correct path."""
         metadata: dict[str, dict[str, str | list[str] | list[Dependency]]] = {
             "dfetch": {
-                "remote_url": self.remote_url,
+                "remote_url": _strip_userinfo(self.remote_url),
                 "branch": self._version.branch,
                 "revision": self._version.revision,
                 "last_fetch": self.last_fetch_string(),
@@ -210,7 +231,10 @@ class Metadata:
         }
 
         if self.dependencies:
-            metadata["dfetch"]["dependencies"] = self.dependencies
+            metadata["dfetch"]["dependencies"] = [
+                {**dep, "remote_url": _strip_userinfo(dep["remote_url"])}
+                for dep in self.dependencies
+            ]
 
         with open(self.path, "w+", encoding="utf-8") as metadata_file:
             metadata_file.write(DONT_EDIT_WARNING)

--- a/dfetch/project/metadata.py
+++ b/dfetch/project/metadata.py
@@ -26,10 +26,15 @@ def _strip_userinfo(url: str) -> str:
     host = parsed.hostname or ""
     if not host and not parsed.netloc:
         return url
+    if ":" in host:
+        # IPv6 literal: parsed.hostname strips the square brackets; restore them
+        # so the reconstructed netloc remains a valid ``[host]:port`` form.
+        host = f"[{host}]"
     netloc = f"{host}:{port}" if isinstance(port, int) else host
     return urlunsplit(
         (parsed.scheme, netloc, parsed.path, parsed.query, parsed.fragment)
     )
+
 
 DONT_EDIT_WARNING = """\
 # This is a generated file by dfetch. Don't edit this, but edit the manifest.
@@ -232,7 +237,14 @@ class Metadata:
 
         if self.dependencies:
             metadata["dfetch"]["dependencies"] = [
-                {**dep, "remote_url": _strip_userinfo(dep["remote_url"])}
+                Dependency(
+                    branch=dep["branch"],
+                    tag=dep["tag"],
+                    revision=dep["revision"],
+                    remote_url=_strip_userinfo(dep["remote_url"]),
+                    destination=dep["destination"],
+                    source_type=dep["source_type"],
+                )
                 for dep in self.dependencies
             ]
 

--- a/doc/explanation/threat_model_usage.rst
+++ b/doc/explanation/threat_model_usage.rst
@@ -1200,5 +1200,3 @@ Controls
      - Persisted-metadata credential redaction
      - DFT-13
      - ``Metadata.dump()`` rebuilds the netloc of every persisted URL from ``parsed.hostname`` and ``parsed.port`` via ``urllib.parse.urlsplit`` / ``urlunsplit``, dropping any ``user:password@`` userinfo before writing ``.dfetch_data.yaml``.  The same stripper is applied to each ``dependencies[].remote_url`` entry (git submodule, svn:external) so a credential in a nested upstream URL also never reaches disk.  The in-memory ``Metadata`` object held by the running command keeps the original URL — only the on-disk representation is redacted, so an in-flight authenticated fetch is unaffected.  ``dfetch/project/metadata.py``
-
-

--- a/doc/explanation/threat_model_usage.rst
+++ b/doc/explanation/threat_model_usage.rst
@@ -685,7 +685,7 @@ Asset Identification
      - Data
      - High / High / High
    * - A-17: Embedded Credential in Remote URL
-     - A VCS or archive URL that encodes a credential in the userinfo component (e.g. ``https://user:TOKEN@github.com/org/repo.git``).  Without C-035 dfetch would write ``remote_url`` verbatim to ``.dfetch_data.yaml`` after each successful fetch, persisting that credential in plaintext.  C-035 strips the userinfo from the persisted ``remote_url`` and from every ``dependencies[].remote_url`` before write, so the credential no longer reaches disk.  The in-memory URL used to authenticate the fetch is untouched.
+     - A VCS or archive URL that encodes a credential in the userinfo component (e.g. ``https://user:TOKEN@github.com/org/repo.git``).  Without C-036 dfetch would write ``remote_url`` verbatim to ``.dfetch_data.yaml`` after each successful fetch, persisting that credential in plaintext.  C-036 strips the userinfo from the persisted ``remote_url`` and from every ``dependencies[].remote_url`` before write, so the credential no longer reaches disk.  The in-memory URL used to authenticate the fetch is untouched.
      - Data
      - Medium / — / —
    * - A-18: Dependency Metadata
@@ -997,7 +997,7 @@ Threats
        | **Risk:** 🟡M
        | **STRIDE:** I
        | **Status:** Mitigate
-     - C-035 strips the userinfo component from every ``remote_url`` (top-level and ``dependencies[]``) before ``Metadata.dump()`` writes ``.dfetch_data.yaml``, so credentials embedded in a manifest URL no longer land in the on-disk metadata file or any clone of it.
+     - C-036 strips the userinfo component from every ``remote_url`` (top-level and ``dependencies[]``) before ``Metadata.dump()`` writes ``.dfetch_data.yaml``, so credentials embedded in a manifest URL no longer land in the on-disk metadata file or any clone of it.
    * - DFT-14
      - Dangerous file permission bits preserved during archive extraction
      - A-24: Archive Extraction (tarfile / zipfile)
@@ -1196,7 +1196,7 @@ Controls
      - Hash algorithm allowlist (SHA-256/384/512 only)
      - DFT-30
      - ``integrity_hash.py`` accepts only ``sha256:``, ``sha384:``, and ``sha512:`` prefixes; any other algorithm prefix is rejected at parse time.  MD5 and SHA-1 are not accepted.  This directly mitigates DFT-30 (SLSA M2: exploit cryptographic hash collisions) by ensuring that integrity hashes, when present, use algorithms with no known practical collision attacks.  ``dfetch/vcs/integrity_hash.py``
-   * - C-035
+   * - C-036
      - Persisted-metadata credential redaction
      - DFT-13
      - ``Metadata.dump()`` rebuilds the netloc of every persisted URL from ``parsed.hostname`` and ``parsed.port`` via ``urllib.parse.urlsplit`` / ``urlunsplit``, dropping any ``user:password@`` userinfo before writing ``.dfetch_data.yaml``.  The same stripper is applied to each ``dependencies[].remote_url`` entry (git submodule, svn:external) so a credential in a nested upstream URL also never reaches disk.  The in-memory ``Metadata`` object held by the running command keeps the original URL — only the on-disk representation is redacted, so an in-flight authenticated fetch is unaffected.  ``dfetch/project/metadata.py``

--- a/doc/explanation/threat_model_usage.rst
+++ b/doc/explanation/threat_model_usage.rst
@@ -685,9 +685,9 @@ Asset Identification
      - Data
      - High / High / High
    * - A-17: Embedded Credential in Remote URL
-     - A VCS or archive URL that encodes a credential in the userinfo component (e.g. ``https://user:TOKEN@github.com/org/repo.git``).  dfetch writes ``remote_url`` verbatim to ``.dfetch_data.yaml`` after each successful fetch.  If the URL contains a Personal Access Token or password, that credential is persisted in plaintext and typically committed to VCS, where it becomes readable from every clone and CI checkout indefinitely.
+     - A VCS or archive URL that encodes a credential in the userinfo component (e.g. ``https://user:TOKEN@github.com/org/repo.git``).  Without C-035 dfetch would write ``remote_url`` verbatim to ``.dfetch_data.yaml`` after each successful fetch, persisting that credential in plaintext.  C-035 strips the userinfo from the persisted ``remote_url`` and from every ``dependencies[].remote_url`` before write, so the credential no longer reaches disk.  The in-memory URL used to authenticate the fetch is untouched.
      - Data
-     - — / — / —
+     - Medium / — / —
    * - A-18: Dependency Metadata
      - ``.dfetch_data.yaml`` files written after each successful fetch.  Contains: remote_url, revision/branch/tag, hash, last-fetch timestamp.  Read by ``dfetch check`` to detect outdated deps.  Tampering can suppress update notifications - an attacker who controls the local filesystem can silently mask a compromised vendored dep.
      - Datastore
@@ -996,8 +996,8 @@ Threats
      - | **Sev:** 🟠H
        | **Risk:** 🟡M
        | **STRIDE:** I
-       | **Status:** Accept
-     - dfetch persists the configured URL to ``.dfetch_data.yaml``; credentials embedded in URLs appear in that file in plaintext.  Accepted based on the **No persisted secrets** assumption: no runtime secrets are persisted to disk by dfetch itself — VCS credentials are expected to be managed by the OS keychain, SSH agent, or CI secret store rather than embedded in source URLs.
+       | **Status:** Mitigate
+     - C-035 strips the userinfo component from every ``remote_url`` (top-level and ``dependencies[]``) before ``Metadata.dump()`` writes ``.dfetch_data.yaml``, so credentials embedded in a manifest URL no longer land in the on-disk metadata file or any clone of it.
    * - DFT-14
      - Dangerous file permission bits preserved during archive extraction
      - A-24: Archive Extraction (tarfile / zipfile)
@@ -1196,3 +1196,9 @@ Controls
      - Hash algorithm allowlist (SHA-256/384/512 only)
      - DFT-30
      - ``integrity_hash.py`` accepts only ``sha256:``, ``sha384:``, and ``sha512:`` prefixes; any other algorithm prefix is rejected at parse time.  MD5 and SHA-1 are not accepted.  This directly mitigates DFT-30 (SLSA M2: exploit cryptographic hash collisions) by ensuring that integrity hashes, when present, use algorithms with no known practical collision attacks.  ``dfetch/vcs/integrity_hash.py``
+   * - C-035
+     - Persisted-metadata credential redaction
+     - DFT-13
+     - ``Metadata.dump()`` rebuilds the netloc of every persisted URL from ``parsed.hostname`` and ``parsed.port`` via ``urllib.parse.urlsplit`` / ``urlunsplit``, dropping any ``user:password@`` userinfo before writing ``.dfetch_data.yaml``.  The same stripper is applied to each ``dependencies[].remote_url`` entry (git submodule, svn:external) so a credential in a nested upstream URL also never reaches disk.  The in-memory ``Metadata`` object held by the running command keeps the original URL — only the on-disk representation is redacted, so an in-flight authenticated fetch is unaffected.  ``dfetch/project/metadata.py``
+
+

--- a/security/tm_usage.py
+++ b/security/tm_usage.py
@@ -284,9 +284,9 @@ def _make_usage_datastores_b(b_dev: Boundary) -> tuple[Data, Datastore, Datastor
         "A-17: Embedded Credential in Remote URL",
         description=(
             "A VCS or archive URL that encodes a credential in the userinfo component "
-            "(e.g. ``https://user:TOKEN@github.com/org/repo.git``).  Without C-035 "
+            "(e.g. ``https://user:TOKEN@github.com/org/repo.git``).  Without C-036 "
             "dfetch would write ``remote_url`` verbatim to ``.dfetch_data.yaml`` after "
-            "each successful fetch, persisting that credential in plaintext.  C-035 "
+            "each successful fetch, persisting that credential in plaintext.  C-036 "
             "strips the userinfo from the persisted ``remote_url`` and from every "
             "``dependencies[].remote_url`` before write, so the credential no longer "
             "reaches disk.  The in-memory URL used to authenticate the fetch is "
@@ -295,7 +295,7 @@ def _make_usage_datastores_b(b_dev: Boundary) -> tuple[Data, Datastore, Datastor
         classification=Classification.SECRET,
         isCredentials=True,
         isPII=False,
-        isStored=True,  # surfaces DFT-13 on DF-08; mitigated by C-035
+        isStored=True,  # surfaces DFT-13 on DF-08; mitigated by C-036
         isDestEncryptedAtRest=False,  # .dfetch_data.yaml is plaintext on disk
         isSourceEncryptedAtRest=False,
     )
@@ -312,7 +312,7 @@ def _make_usage_datastores_b(b_dev: Boundary) -> tuple[Data, Datastore, Datastor
     metadata_store.hasWriteAccess = True
     metadata_store.isSQL = False
     metadata_store.classification = Classification.RESTRICTED
-    metadata_store.isCredentials = True  # surfaces DFT-13 on this store; mitigated by C-035
+    metadata_store.isCredentials = True  # surfaces DFT-13 on this store; mitigated by C-036
     metadata_store.isStored = True
     metadata_store.isDestEncryptedAtRest = False  # plaintext on disk
     patch_store = Datastore("A-19: Patch Files")
@@ -498,10 +498,10 @@ def _make_usage_output_flows(
     df08.description = (
         "Writes ``.dfetch_data.yaml`` tracking remote_url, revision, hash.  "
         "A-17: if the manifest URL contains a credential in the userinfo component "
-        "(e.g. ``https://user:TOKEN@host/``), C-035 strips it from the persisted "
+        "(e.g. ``https://user:TOKEN@host/``), C-036 strips it from the persisted "
         "``remote_url`` before this write."
     )
-    df08.data = [embedded_url_credential]  # A-17: DFT-13 surfaced and mitigated by C-035
+    df08.data = [embedded_url_credential]  # A-17: DFT-13 surfaced and mitigated by C-036
     df09 = Dataflow(dfetch_cli, sbom_output, "DF-09: Write SBOM")
     df09.description = "CycloneDX BOM generation from metadata store contents."
     df16 = Dataflow(metadata_store, dfetch_cli, "DF-16: Read dependency metadata")
@@ -995,7 +995,7 @@ CONTROLS: list[Control] = [
         ),
     ),
     Control(
-        id="C-035",
+        id="C-036",
         name="Persisted-metadata credential redaction",
         assets=["A-17", "A-18"],
         threats=["DFT-13"],
@@ -1142,7 +1142,7 @@ RESPONSES: list[ThreatResponse] = [
         risk="Medium",
         stride=["Information Disclosure"],
         note=(
-            "C-035 strips the userinfo component from every ``remote_url`` (top-level "
+            "C-036 strips the userinfo component from every ``remote_url`` (top-level "
             "and ``dependencies[]``) before ``Metadata.dump()`` writes "
             "``.dfetch_data.yaml``, so credentials embedded in a manifest URL no longer "
             "land in the on-disk metadata file or any clone of it."

--- a/security/tm_usage.py
+++ b/security/tm_usage.py
@@ -312,7 +312,9 @@ def _make_usage_datastores_b(b_dev: Boundary) -> tuple[Data, Datastore, Datastor
     metadata_store.hasWriteAccess = True
     metadata_store.isSQL = False
     metadata_store.classification = Classification.RESTRICTED
-    metadata_store.isCredentials = True  # surfaces DFT-13 on this store; mitigated by C-036
+    metadata_store.isCredentials = (
+        True  # surfaces DFT-13 on this store; mitigated by C-036
+    )
     metadata_store.isStored = True
     metadata_store.isDestEncryptedAtRest = False  # plaintext on disk
     patch_store = Datastore("A-19: Patch Files")
@@ -501,7 +503,9 @@ def _make_usage_output_flows(
         "(e.g. ``https://user:TOKEN@host/``), C-036 strips it from the persisted "
         "``remote_url`` before this write."
     )
-    df08.data = [embedded_url_credential]  # A-17: DFT-13 surfaced and mitigated by C-036
+    df08.data = [
+        embedded_url_credential
+    ]  # A-17: DFT-13 surfaced and mitigated by C-036
     df09 = Dataflow(dfetch_cli, sbom_output, "DF-09: Write SBOM")
     df09.description = "CycloneDX BOM generation from metadata store contents."
     df16 = Dataflow(metadata_store, dfetch_cli, "DF-16: Read dependency metadata")

--- a/security/tm_usage.py
+++ b/security/tm_usage.py
@@ -284,16 +284,18 @@ def _make_usage_datastores_b(b_dev: Boundary) -> tuple[Data, Datastore, Datastor
         "A-17: Embedded Credential in Remote URL",
         description=(
             "A VCS or archive URL that encodes a credential in the userinfo component "
-            "(e.g. ``https://user:TOKEN@github.com/org/repo.git``).  "
-            "dfetch writes ``remote_url`` verbatim to ``.dfetch_data.yaml`` after each "
-            "successful fetch.  If the URL contains a Personal Access Token or password, "
-            "that credential is persisted in plaintext and typically committed to VCS, "
-            "where it becomes readable from every clone and CI checkout indefinitely."
+            "(e.g. ``https://user:TOKEN@github.com/org/repo.git``).  Without C-035 "
+            "dfetch would write ``remote_url`` verbatim to ``.dfetch_data.yaml`` after "
+            "each successful fetch, persisting that credential in plaintext.  C-035 "
+            "strips the userinfo from the persisted ``remote_url`` and from every "
+            "``dependencies[].remote_url`` before write, so the credential no longer "
+            "reaches disk.  The in-memory URL used to authenticate the fetch is "
+            "untouched."
         ),
         classification=Classification.SECRET,
         isCredentials=True,
         isPII=False,
-        isStored=True,  # written verbatim to .dfetch_data.yaml
+        isStored=True,  # surfaces DFT-13 on DF-08; mitigated by C-035
         isDestEncryptedAtRest=False,  # .dfetch_data.yaml is plaintext on disk
         isSourceEncryptedAtRest=False,
     )
@@ -310,7 +312,7 @@ def _make_usage_datastores_b(b_dev: Boundary) -> tuple[Data, Datastore, Datastor
     metadata_store.hasWriteAccess = True
     metadata_store.isSQL = False
     metadata_store.classification = Classification.RESTRICTED
-    metadata_store.isCredentials = True  # may contain credential-bearing URLs verbatim
+    metadata_store.isCredentials = True  # surfaces DFT-13 on this store; mitigated by C-035
     metadata_store.isStored = True
     metadata_store.isDestEncryptedAtRest = False  # plaintext on disk
     patch_store = Datastore("A-19: Patch Files")
@@ -496,9 +498,10 @@ def _make_usage_output_flows(
     df08.description = (
         "Writes ``.dfetch_data.yaml`` tracking remote_url, revision, hash.  "
         "A-17: if the manifest URL contains a credential in the userinfo component "
-        "(e.g. ``https://user:TOKEN@host/``), it is written verbatim to this file."
+        "(e.g. ``https://user:TOKEN@host/``), C-035 strips it from the persisted "
+        "``remote_url`` before this write."
     )
-    df08.data = [embedded_url_credential]  # A-17: surfaces DFT-13 on this dataflow
+    df08.data = [embedded_url_credential]  # A-17: DFT-13 surfaced and mitigated by C-035
     df09 = Dataflow(dfetch_cli, sbom_output, "DF-09: Write SBOM")
     df09.description = "CycloneDX BOM generation from metadata store contents."
     df16 = Dataflow(metadata_store, dfetch_cli, "DF-16: Read dependency metadata")
@@ -991,6 +994,24 @@ CONTROLS: list[Control] = [
             "algorithms with no known practical collision attacks."
         ),
     ),
+    Control(
+        id="C-035",
+        name="Persisted-metadata credential redaction",
+        assets=["A-17", "A-18"],
+        threats=["DFT-13"],
+        reference="dfetch/project/metadata.py",
+        description=(
+            "``Metadata.dump()`` rebuilds the netloc of every persisted URL from "
+            "``parsed.hostname`` and ``parsed.port`` via ``urllib.parse.urlsplit`` / "
+            "``urlunsplit``, dropping any ``user:password@`` userinfo before writing "
+            "``.dfetch_data.yaml``.  The same stripper is applied to each "
+            "``dependencies[].remote_url`` entry (git submodule, svn:external) so a "
+            "credential in a nested upstream URL also never reaches disk.  The "
+            "in-memory ``Metadata`` object held by the running command keeps the "
+            "original URL — only the on-disk representation is redacted, so an "
+            "in-flight authenticated fetch is unaffected."
+        ),
+    ),
 ]
 
 RESPONSES: list[ThreatResponse] = [
@@ -1117,16 +1138,14 @@ RESPONSES: list[ThreatResponse] = [
     ),
     ThreatResponse(
         "DFT-13",
-        "accept",
+        "mitigate",
         risk="Medium",
         stride=["Information Disclosure"],
         note=(
-            "dfetch persists the configured URL to ``.dfetch_data.yaml``; "
-            "credentials embedded in URLs appear in that file in plaintext.  "
-            "Accepted based on the **No persisted secrets** assumption: no runtime secrets "
-            "are persisted to disk by dfetch itself — VCS credentials are expected to be "
-            "managed by the OS keychain, SSH agent, or CI secret store rather than embedded "
-            "in source URLs."
+            "C-035 strips the userinfo component from every ``remote_url`` (top-level "
+            "and ``dependencies[]``) before ``Metadata.dump()`` writes "
+            "``.dfetch_data.yaml``, so credentials embedded in a manifest URL no longer "
+            "land in the on-disk metadata file or any clone of it."
         ),
     ),
     ThreatResponse(

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -120,6 +120,11 @@ def test_from_file_uses_defaults_for_missing_fields(tmp_path):
          "file:///local/path/repo"),
         ("", ""),
         ("/just/a/path", "/just/a/path"),
+        # IPv6 literals: brackets must be preserved when reconstructing netloc.
+        ("https://user:tok@[::1]:8080/x",
+         "https://[::1]:8080/x"),
+        ("https://[fe80::1]/x",
+         "https://[fe80::1]/x"),
     ],
 )
 def test_strip_userinfo_redacts_credentials(url, expected):

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -6,8 +6,9 @@
 import textwrap
 
 import pytest
+import yaml
 
-from dfetch.project.metadata import InvalidMetadataError, Metadata
+from dfetch.project.metadata import InvalidMetadataError, Metadata, _strip_userinfo
 
 VALID_METADATA = """\
     dfetch:
@@ -100,3 +101,95 @@ def test_from_file_uses_defaults_for_missing_fields(tmp_path):
     assert meta.hash == ""
     assert meta.patch == []
     assert meta.dependencies == []
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("https://user:token@github.com/org/repo.git",
+         "https://github.com/org/repo.git"),
+        ("https://user@github.com/org/repo.git",
+         "https://github.com/org/repo.git"),
+        ("https://github.com/org/repo.git",
+         "https://github.com/org/repo.git"),
+        ("https://user:tok@github.com:8443/org/repo.git",
+         "https://github.com:8443/org/repo.git"),
+        ("https://example.com/archive.tar.gz?token=keep&v=1",
+         "https://example.com/archive.tar.gz?token=keep&v=1"),
+        ("file:///local/path/repo",
+         "file:///local/path/repo"),
+        ("", ""),
+        ("/just/a/path", "/just/a/path"),
+    ],
+)
+def test_strip_userinfo_redacts_credentials(url, expected):
+    """_strip_userinfo removes userinfo, preserves scheme/host/port/path/query."""
+    assert _strip_userinfo(url) == expected
+
+
+def _dump_metadata(tmp_path, *, remote_url, dependencies=None):
+    """Build a Metadata pointing at *tmp_path* and dump it; return the YAML payload."""
+    meta = Metadata(
+        {
+            "remote_url": remote_url,
+            "branch": "main",
+            "revision": "abc123",
+            "hash": "deadbeef",
+            "destination": str(tmp_path),
+            "dependencies": dependencies or [],
+        }
+    )
+    meta.dump()
+    with open(meta.path, encoding="utf-8") as fh:
+        return fh.read(), meta.path
+
+
+def test_dump_strips_credentials_from_remote_url(tmp_path):
+    """Metadata.dump redacts userinfo from remote_url on disk."""
+    raw, path = _dump_metadata(
+        tmp_path, remote_url="https://alice:secret-token@example.com/org/repo.git"
+    )
+    assert "alice" not in raw
+    assert "secret-token" not in raw
+    assert "@example.com" not in raw
+    assert "https://example.com/org/repo.git" in raw
+    # Round-trip survives Metadata.from_file.
+    reloaded = Metadata.from_file(path)
+    assert reloaded.remote_url == "https://example.com/org/repo.git"
+
+
+def test_dump_strips_credentials_from_dependency_remote_url(tmp_path):
+    """Metadata.dump redacts userinfo from each dependencies[].remote_url."""
+    dep = {
+        "branch": "",
+        "tag": "",
+        "revision": "f00",
+        "remote_url": "https://bob:pat@gitlab.com/grp/sub.git",
+        "destination": "vendor/sub",
+        "source_type": "git-submodule",
+    }
+    raw, path = _dump_metadata(
+        tmp_path,
+        remote_url="https://example.com/org/repo.git",
+        dependencies=[dep],
+    )
+    assert "bob" not in raw
+    assert "bob:pat@" not in raw
+    assert "@gitlab.com" not in raw
+    parsed = yaml.safe_load(raw)
+    assert (
+        parsed["dfetch"]["dependencies"][0]["remote_url"]
+        == "https://gitlab.com/grp/sub.git"
+    )
+
+
+def test_dump_leaves_in_memory_remote_url_untouched(tmp_path):
+    """Redaction applies only to the on-disk representation."""
+    meta = Metadata(
+        {
+            "remote_url": "https://carol:hunter2@example.com/org/repo.git",
+            "destination": str(tmp_path),
+        }
+    )
+    meta.dump()
+    assert meta.remote_url == "https://carol:hunter2@example.com/org/repo.git"

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -3,6 +3,7 @@
 # mypy: ignore-errors
 # flake8: noqa
 
+import datetime
 import textwrap
 
 import pytest
@@ -106,25 +107,26 @@ def test_from_file_uses_defaults_for_missing_fields(tmp_path):
 @pytest.mark.parametrize(
     "url,expected",
     [
-        ("https://user:token@github.com/org/repo.git",
-         "https://github.com/org/repo.git"),
-        ("https://user@github.com/org/repo.git",
-         "https://github.com/org/repo.git"),
-        ("https://github.com/org/repo.git",
-         "https://github.com/org/repo.git"),
-        ("https://user:tok@github.com:8443/org/repo.git",
-         "https://github.com:8443/org/repo.git"),
-        ("https://example.com/archive.tar.gz?token=keep&v=1",
-         "https://example.com/archive.tar.gz?token=keep&v=1"),
-        ("file:///local/path/repo",
-         "file:///local/path/repo"),
+        (
+            "https://user:token@github.com/org/repo.git",
+            "https://github.com/org/repo.git",
+        ),
+        ("https://user@github.com/org/repo.git", "https://github.com/org/repo.git"),
+        ("https://github.com/org/repo.git", "https://github.com/org/repo.git"),
+        (
+            "https://user:tok@github.com:8443/org/repo.git",
+            "https://github.com:8443/org/repo.git",
+        ),
+        (
+            "https://example.com/archive.tar.gz?token=keep&v=1",
+            "https://example.com/archive.tar.gz?token=keep&v=1",
+        ),
+        ("file:///local/path/repo", "file:///local/path/repo"),
         ("", ""),
         ("/just/a/path", "/just/a/path"),
         # IPv6 literals: brackets must be preserved when reconstructing netloc.
-        ("https://user:tok@[::1]:8080/x",
-         "https://[::1]:8080/x"),
-        ("https://[fe80::1]/x",
-         "https://[fe80::1]/x"),
+        ("https://user:tok@[::1]:8080/x", "https://[::1]:8080/x"),
+        ("https://[fe80::1]/x", "https://[fe80::1]/x"),
     ],
 )
 def test_strip_userinfo_redacts_credentials(url, expected):
@@ -136,11 +138,14 @@ def _dump_metadata(tmp_path, *, remote_url, dependencies=None):
     """Build a Metadata pointing at *tmp_path* and dump it; return the YAML payload."""
     meta = Metadata(
         {
-            "remote_url": remote_url,
+            "last_fetch": datetime.datetime(2000, 1, 1, 0, 0, 0),
             "branch": "main",
+            "tag": "",
             "revision": "abc123",
-            "hash": "deadbeef",
+            "remote_url": remote_url,
             "destination": str(tmp_path),
+            "hash": "deadbeef",
+            "patch": "",
             "dependencies": dependencies or [],
         }
     )
@@ -192,8 +197,15 @@ def test_dump_leaves_in_memory_remote_url_untouched(tmp_path):
     """Redaction applies only to the on-disk representation."""
     meta = Metadata(
         {
+            "last_fetch": datetime.datetime(2000, 1, 1, 0, 0, 0),
+            "branch": "",
+            "tag": "",
+            "revision": "",
             "remote_url": "https://carol:hunter2@example.com/org/repo.git",
             "destination": str(tmp_path),
+            "hash": "",
+            "patch": "",
+            "dependencies": [],
         }
     )
     meta.dump()


### PR DESCRIPTION
## Summary

- Strip `user:password@` userinfo from every `remote_url` written to `.dfetch_data.yaml` — both the top-level field and each `dependencies[].remote_url` (git-submodule / svn:external entries) — so a manifest URL with an embedded Personal Access Token no longer leaks the credential into the on-disk metadata file (and from there into any commit / clone / CI checkout of it).
- Redaction is local to `Metadata.dump()` in `dfetch/project/metadata.py`. The in-memory `Metadata` object held by the running command keeps the original URL, so in-flight authenticated fetches are unaffected — only the on-disk representation is sanitised.
- Flip the **DFT-13** entry in the usage threat model from **Accept** to **Mitigate**, document the new control as **C-035 — Persisted-metadata credential redaction**, and update the A-17 / A-18 asset descriptions to reflect that the credential no longer reaches disk.

## Why this is safe

`.dfetch_data.yaml` is write-only for recording purposes: no code path reads the persisted `remote_url` back to drive a fetch. `Metadata.__eq__` is the only comparison that references `remote_url` and it is defined but never called; `check`, `diff`, and `update` always rebuild `Metadata` from the live `ProjectEntry` (which still holds the credential), so redacting at `dump()` does not cause spurious "out of date" reports.

## Test plan

- [x] `pytest tests/test_metadata.py` — 21 passing, including new parametrised `_strip_userinfo` cases (`user:token@host`, `user@host`, host-only, explicit port, query-string preserved, `file://` round-trip, empty / path-only inputs) and dump-then-`from_file` round-trips for both `remote_url` and `dependencies[].remote_url` plus an assertion that the in-memory URL is untouched
- [x] `pytest tests/` — full unit suite green except 6 pre-existing failures in `tests/test_sbom_reporter.py` caused by a missing optional `cyclonedx-python-lib[json-validation]` install in this environment (unrelated to this change)
- [ ] `behave features/ --tags=update` to confirm end-to-end `dfetch update` still writes `.dfetch_data.yaml` correctly
- [ ] Manual smoke: point a manifest at `https://user:secret@example.com/repo.tar.gz`, run `dfetch update`, confirm the persisted `remote_url:` contains neither `user:secret` nor `user@`

https://claude.ai/code/session_019iPNdP6S7SwMviFE1uEjEV

---
_Generated by [Claude Code](https://claude.ai/code/session_019iPNdP6S7SwMviFE1uEjEV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Credentials embedded in remote URLs are now stripped before being written to persisted metadata, preventing accidental exposure.

* **Documentation**
  * Threat model and controls updated to describe the persisted-metadata credential redaction mitigation.

* **Tests**
  * Tests added to verify credentials are redacted in persisted metadata while in-memory URLs remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->