### PR TITLE
fix(pdf): break long tables across pages automatically

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -287,9 +287,23 @@ def _set_latex_pygments_style(app):
         app.config.pygments_style = "dfetch"
 
 
+def _force_longtable(app, doctree, docname):
+    # tabulary does not support page breaks; longtable does.
+    # Mark every table as longtable so Sphinx's LaTeX writer uses the
+    # longtable environment, which splits automatically across pages.
+    if not app.builder.name.startswith("latex"):
+        return
+    from docutils import nodes
+
+    for tbl in doctree.traverse(nodes.table):
+        if "longtable" not in tbl["classes"]:
+            tbl["classes"].append("longtable")
+
+
 def setup(app):
     """Apply custom Pygments style only for LaTeX builds."""
     app.connect("builder-inited", _set_latex_pygments_style)
+    app.connect("doctree-resolved", _force_longtable)
 
 
 # -- Options for manual page output ---------------------------------------

--- a/doc/dfetch_preamble.inc
+++ b/doc/dfetch_preamble.inc
@@ -90,6 +90,9 @@
 \setlength{\tabcolsep}{8pt}            % horizontal cell padding (website 0.875rem)
 \AtBeginEnvironment{tabulary}{\small\renewcommand{\vline}{}}
 \AtBeginEnvironment{longtable}{\small\renewcommand{\vline}{}}
+% longtable: flush to text margins (Sphinx default centers with \fill padding)
+\setlength{\LTleft}{0pt}
+\setlength{\LTright}{0pt}
 \providecommand{\sphinxstyletheadfamily}{\sffamily}
 \renewcommand{\sphinxstyletheadfamily}{\cellcolor{dfbgtint}\small\bfseries}
 


### PR DESCRIPTION
Sphinx defaults to the tabulary environment, which cannot split across
pages, so wide multi-row tables overflow the page bottom.

Add a doctree-resolved hook that marks every table node as longtable
(LaTeX builds only), causing Sphinx to emit the longtable environment
instead. longtable handles page breaks natively, and the existing
preamble styling already covers it.

Also pin LTleft/LTright to 0 pt so longtables are flush to the text
margins rather than centred with the Sphinx default \fill padding.

https://claude.ai/code/session_018x2naGb8NGwqyJkpc2u7jS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced table formatting in LaTeX-generated documentation with improved margin alignment and visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->