### PR TITLE
Fix winget publish

### DIFF
--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -31,6 +31,7 @@ jobs:
             api.github.com:443
             release-assets.githubusercontent.com:443
             uploads.github.com:443
+            index.crates.io:443
 
       - name: Publish to WinGet
         # Requires WINGET_TOKEN secret in the 'winget' environment.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated the GitHub Actions workflow runner hardening settings to permit required outbound connections for the publishing process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->