### PR TITLE
build: modernize build-system requires

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm==10.1.2", "wheel"]
+requires = ["setuptools>=80", "setuptools-scm==10.1.2"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
## Summary

- Drop `wheel` from `[build-system].requires` — pip has handled wheel building automatically since pip 21.3, so declaring it is redundant
- Add `setuptools>=80` floor — recommended by setuptools-scm 10.x docs; support for older setuptools is deprecated and will be removed in a future release

## Test plan

- [ ] CI builds (wheel, nuitka) pass without `wheel` in build-system requires
- [ ] No functional change to the built package

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build system configuration with minimum version constraints to improve build reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->