### PR TITLE
Update dfetch environment to show newer version inline

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+Release 0.14.3 (unreleased)
+====================================
+
+* Update ``dfetch environment`` to show newer version inline (#0)
+
 Release 0.14.2 (released 2026-06-21)
 ====================================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 Release 0.14.3 (unreleased)
 ====================================
 
-* Update ``dfetch environment`` to show newer version inline (#0)
+* Update ``dfetch environment`` to show newer version inline (`#1310`)
 
 Release 0.14.2 (released 2026-06-21)
 ====================================

--- a/dfetch/commands/environment.py
+++ b/dfetch/commands/environment.py
@@ -36,11 +36,16 @@ class Environment(dfetch.commands.command.Command):
 
     def __call__(self, _: argparse.Namespace) -> None:
         """Perform listing the environment."""
-        logger.print_report_line("dfetch", __version__)
         logger.debug("Checking for a newer dfetch version")
         newer = newer_version_available()
         if newer:
-            logger.print_newer_version_notice(newer)
+            dfetch_info = (
+                f"{__version__} ({newer} available"
+                " see https://github.com/dfetch-org/dfetch/releases)"
+            )
+        else:
+            dfetch_info = __version__
+        logger.print_report_line("dfetch", dfetch_info)
         logger.print_report_line(
             "platform", f"{platform.system()} {platform.release()}"
         )

--- a/features/environment.feature
+++ b/features/environment.feature
@@ -19,6 +19,5 @@ Feature: Display environment information
         Then the output starts with:
             """
             Dfetch (0.14.2)
-              dfetch              : 0.13.0
-              dfetch 1.99.0 available — https://github.com/dfetch-org/dfetch/releases
+              dfetch              : 0.13.0 (1.99.0 available see https://github.com/dfetch-org/dfetch/releases)
             """


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * `dfetch environment` now shows the installed version and (when applicable) the newer available version inline on the same line, including a direct link to the release page.
* **Documentation**
  * Updated `CHANGELOG.rst` with an unreleased “Release 0.14.3” entry describing the updated version output.
* **Tests**
  * Adjusted the environment information feature expectations to match the new inline “newer version + link” formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->