### PR TITLE
Add ziglang.org to build.yml harden-runner allowlist

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,7 @@ jobs:
             rekor.sigstore.dev:443
             tuf-repo-cdn.sigstore.dev:443
             *.blob.core.windows.net:443
+            ziglang.org:443
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:


### PR DESCRIPTION
The Windows build job runs `choco install zig` but its harden-runner
allowed-endpoints list was missing ziglang.org, which the choco
package downloads from. run.yml already allows it for the same step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to allow required network access for Zig tooling during automated builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->